### PR TITLE
Allow JSONTokener to tolerate comments

### DIFF
--- a/JSONTokener.java
+++ b/JSONTokener.java
@@ -229,8 +229,60 @@ public class JSONTokener {
     public char nextClean() throws JSONException {
         for (;;) {
             char c = next();
+            if (c == '/') {
+                c = next();
+                if (c == '/') {
+                    nextToEndOfLine();
+                    back();
+                    continue;
+                }
+                if (c == '*') {
+                    nextToEndOfCommentBlock();
+                    back();
+                    continue;
+                }
+            }
             if (c == 0 || c > ' ') {
                 return c;
+            }
+        }
+    }
+
+
+    /**
+     * Scan to the next end of line char.
+     * @throws JSONException
+     * @return  A character, or 0 if there are no more characters.
+     */
+    public char nextToEndOfLine() throws JSONException {
+        for (;;) {
+            char c = next();
+
+            if (c == 0 || c == '\r' || c == '\n') {
+                return next();
+            }
+        }
+    }
+
+
+    /**
+     * Get the next char in the string, skipping comments.
+     * @throws JSONException
+     * @return  A character, or 0 if there are no more characters.
+     */
+    public char nextToEndOfCommentBlock() throws JSONException {
+        for (;;) {
+            char c = next();
+
+            if (c == 0) {
+                return c;
+            }
+
+            if (c == '*') {
+                c = next();
+                if (c == '/') {
+                    return next();
+                }
             }
         }
     }


### PR DESCRIPTION
JSONTokener no longer fails on comments, both `//` and `/* */`.
