### PR TITLE
Make test run on german locale.

### DIFF
--- a/tests/TestJSONObject.java
+++ b/tests/TestJSONObject.java
@@ -801,7 +801,7 @@ public class TestJSONObject extends TestCase
     {
         try
         {
-            Locale currentLocale = new Locale("en");
+            Locale currentLocale = new Locale("en", "US");
             assertEquals(
                     "{\"ASCII\":\"American Standard Code for Information Interchange\",\"JSON\":\"JavaScript Object Notation\",\"JAVA\":{\"desc\":\"Just Another Vague Acronym\",\"data\":\"Sweet language\"}}",
                     new JSONObject("org.json.tests.SampleResourceBundle",


### PR DESCRIPTION
Hi Douglas,

Out of the box the test failed with the exception below. We think it may be because of my German locale. Our change makes the test green.

Thanks for providing the code!

Cheers,
Bernhard & Görge

java.util.MissingResourceException: Can't find bundle for base name org.json.tests.SampleResourceBundle, locale en
    at java.util.ResourceBundle.throwMissingResourceException(ResourceBundle.java:1427)
    at java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:1250)
    at java.util.ResourceBundle.getBundle(ResourceBundle.java:952)
    at org.json.JSONObject.<init>(JSONObject.java:321)
    at org.json.tests.TestJSONObject.testConstructor_UsResourceBundle(TestJSONObject.java:690)
