### PR TITLE
Changed Exception wrap test to more common exception

### DIFF
--- a/tests/TestJSONObject.java
+++ b/tests/TestJSONObject.java
@@ -1401,8 +1401,8 @@ public class TestJSONObject extends TestCase
             Map<String, Object> map = new HashMap<String, Object>();
             map.put("abc", "123");
             assertEquals("{\"abc\":\"123\"}", JSONObject.wrap(map).toString());
-            assertEquals("javax.print.PrintException",
-                    JSONObject.wrap(new javax.print.PrintException()));
+            assertEquals("java.io.IOException",
+                    JSONObject.wrap(new java.io.IOException()));
             Class<?> d = this.getClass();
             assertEquals("class org.json.tests.TestJSONObject",
                     JSONObject.wrap(d));


### PR DESCRIPTION
Just a minor change.

I changed the javax.print.PrintException to java.io.IOException.
Because javax isn't always available, as with Android development.
