### PR TITLE
Support reversible JsonML mapping by avoiding implicit type conversion

### DIFF
--- a/JSONML.java
+++ b/JSONML.java
@@ -36,7 +36,7 @@ import java.util.Iterator;
  * @version 2012-03-28
  */
 public class JSONML {
-
+	
     /**
      * Parse XML values and store them in a JSONArray.
      * @param x       The XMLTokener containing the source string.
@@ -46,10 +46,29 @@ public class JSONML {
      * @return A JSONArray if the value is the outermost tag, otherwise null.
      * @throws JSONException
      */
+	private static Object parse(
+			XMLTokener x,
+			boolean arrayForm,
+			JSONArray ja
+	) throws JSONException {
+		return parse(x, arrayForm, ja, false);
+	}
+
+    /**
+     * Parse XML values and store them in a JSONArray.
+     * @param x       The XMLTokener containing the source string.
+     * @param arrayForm true if array form, false if object form.
+     * @param ja      The JSONArray that is containing the current tag or null
+     *     if we are at the outermost level.
+     * @param keepStrings	Don't type-convert text nodes and attibute values
+     * @return A JSONArray if the value is the outermost tag, otherwise null.
+     * @throws JSONException
+     */
     private static Object parse(
         XMLTokener x,
         boolean    arrayForm,
-        JSONArray  ja
+        JSONArray  ja,
+        boolean keepStrings
     ) throws JSONException {
         String     attribute;
         char       c;
@@ -174,7 +193,7 @@ public class JSONML {
                             if (!(token instanceof String)) {
                                 throw x.syntaxError("Missing value");
                             }
-                            newjo.accumulate(attribute, XML.stringToValue((String)token));
+                            newjo.accumulate(attribute, keepStrings ? token : XML.stringToValue((String)token));
                             token = null;
                         } else {
                             newjo.accumulate(attribute, "");
@@ -204,7 +223,7 @@ public class JSONML {
                         if (token != XML.GT) {
                             throw x.syntaxError("Misshaped tag");
                         }
-                        closeTag = (String)parse(x, arrayForm, newja);
+                        closeTag = (String)parse(x, arrayForm, newja, keepStrings);
                         if (closeTag != null) {
                             if (!closeTag.equals(tagName)) {
                                 throw x.syntaxError("Mismatched '" + tagName +
@@ -227,7 +246,7 @@ public class JSONML {
             } else {
                 if (ja != null) {
                     ja.put(token instanceof String
-                        ? XML.stringToValue((String)token)
+                        ? keepStrings ? token : XML.stringToValue((String)token)
                         : token);
                 }
             }
@@ -249,6 +268,46 @@ public class JSONML {
      */
     public static JSONArray toJSONArray(String string) throws JSONException {
         return toJSONArray(new XMLTokener(string));
+    }
+
+
+    /**
+     * Convert a well-formed (but not necessarily valid) XML string into a
+     * JSONArray using the JsonML transform. Each XML tag is represented as
+     * a JSONArray in which the first element is the tag name. If the tag has
+     * attributes, then the second element will be JSONObject containing the
+     * name/value pairs. If the tag contains children, then strings and
+     * JSONArrays will represent the child tags.
+     * As opposed to toJSONArray this method does not attempt to convert 
+     * any text node or attribute value to any type 
+     * but just leaves it as a string.
+     * Comments, prologs, DTDs, and <code>&lt;[ [ ]]></code> are ignored.
+     * @param string The source string.
+     * @return A JSONArray containing the structured data from the XML string.
+     * @throws JSONException
+     */
+    public static JSONArray toJsonML(String string) throws JSONException {
+        return toJsonML(new XMLTokener(string));
+    }
+
+
+    /**
+     * Convert a well-formed (but not necessarily valid) XML string into a
+     * JSONArray using the JsonML transform. Each XML tag is represented as
+     * a JSONArray in which the first element is the tag name. If the tag has
+     * attributes, then the second element will be JSONObject containing the
+     * name/value pairs. If the tag contains children, then strings and
+     * JSONArrays will represent the child content and tags.
+     * As opposed to toJSONArray this method does not attempt to convert 
+     * any text node or attribute value to any type 
+     * but just leaves it as a string.
+     * Comments, prologs, DTDs, and <code>&lt;[ [ ]]></code> are ignored.
+     * @param x An XMLTokener.
+     * @return A JSONArray containing the structured data from the XML string.
+     * @throws JSONException
+     */
+    public static JSONArray toJsonML(XMLTokener x) throws JSONException {
+        return (JSONArray)parse(x, true, null, true);
     }
 
 


### PR DESCRIPTION
To introduce the opportunity to avoid implicit type conversion I have overloaded the parse method and added a new toJsonML(String) and a new toJsonML(XMLTokener) method using the overloaded parse method.
The changes have no impact on previously existing public methods - those should behave exactly as before.

One of the problems with the implicit type conversion is that xml data converted to json cannot be reverted to the original xml. Actually all non-string Json values are completely lost. This may be considered to be a separate problem of JSON.toString(JSONArray) which I did not try to solve directly, because for xml data converted using the new JsonML operations it is not relevant.

The following test case (groovy) illustrates the problems (testToJSONArray_*) and the solution (testToJsonML):

``` groovy
import org.json.JSONML
import org.junit.Test

class JsonMLTestCase {
    def originalXml = '<root><id>01</id><id>1</id><id>00</id><id>0</id><item id="01"/><title>True</title></root>'
    def expectedJsonString = '["root",["id","01"],["id","1"],["id","00"],["id","0"],["item",{"id":"01"}],["title","True"]]'

    @Test // test fails - JSON string lost leading zero and converted "True" to true. See test result in comment below
    void testToJSONArray_jsonOutput() {
        def actualJsonOutput = JSONML.toJSONArray(originalXml)
        assert actualJsonOutput == expectedJsonString
    }

    @Test // test fails - JSON string cannot be reverted to original xml. See test result in comment below
    void testToJSONArray_reversibility() {
        def revertedXml = JSONML.toString(org.json.JSONML.toJSONArray(originalXml))
        assert revertedXml == originalXml
    }

    @Test // test passes when using the new method toJsonML
    void testToJsonML() {
        def json = JSONML.toJsonML(originalXml)
        def reverseXml = org.json.JSONML.toString(json)
        assert originalXml == reverseXml
        assert json.toString() == expectedJsonString
    }
}


/****************** Test result:
testToJSONArray_jsonOutput(JsonMLTestCase)
expexted: ["root",["id","01"],["id","1"],["id","00"],["id","0"],["item",{"id":"01"}],["title","True"]]
actual:   ["root",["id",1],["id",1],["id","00"],["id",0],["item",{"id":1}],["title",true]]

testToJSONArray_reversibility(JsonMLTestCase)
expexted: <root><id>01</id><id>1</id><id>00</id><id>0</id><item id="01"/><title>True</title></root>
actual:   <root><id></id><id></id><id>00</id><id></id><item id="1"/><title></title></root>
********************/
```
