### PR TITLE
JSONObject render fields in sorted order with -Dorg.json.fields.sort=true

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -1129,14 +1129,16 @@ public class JSONObject {
         }
         if (value != null) {
             testValidity(value);
-            pooled = (String)keyPool.get(key);
-            if (pooled == null) {
-                if (keyPool.size() >= keyPoolSize) {
-                    keyPool = new HashMap(keyPoolSize);
+            synchronized (JSONObject.class) {
+                pooled = (String)keyPool.get(key);
+                if (pooled == null) {
+                    if (keyPool.size() >= keyPoolSize) {
+                      keyPool = new HashMap(keyPoolSize);
+                    }
+                    keyPool.put(key, key);
+                } else {
+                    key = pooled;
                 }
-                keyPool.put(key, key);
-            } else {
-                key = pooled;
             }
             this.map.put(key, value);
         } else {


### PR DESCRIPTION
The new Java versions(*) randomize the plain HashMap order making the current JSONObject.toString unusable in unit tests or other situations where the output could needs to be in same order on each run.

*) Java8 or Java7 with CVE fix enabling system property (http://docs.oracle.com/javase/7/docs/technotes/guides/collections/changes7.html)
