### PR TITLE
Convert a Property file data/object to JSONObject and vice versa

### DIFF
--- a/Property.java
+++ b/Property.java
@@ -1,0 +1,75 @@
+package org.json;
+
+/*
+Copyright (c) 2002 JSON.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+The Software shall be used for Good, not Evil.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.Properties;
+
+/**
+ * Converts a Property file data into JSONObject and back.
+ * @author JSON.org
+ * @version 2013-05-23
+ */
+public class Property {
+    /**
+     * Converts a property file object into a JSONObject. The property file object is a table of name value pairs.
+     * @param properties java.util.Properties
+     * @return JSONObject
+     * @throws JSONException
+     */
+    public static JSONObject toJSONObject(java.util.Properties properties) throws JSONException {
+        JSONObject jo = new JSONObject();
+        if(properties!=null && !properties.isEmpty()) {
+            Enumeration<?> enumProperties = properties.propertyNames();
+            while(enumProperties.hasMoreElements()) {
+                String name = (String)enumProperties.nextElement();
+                jo.put( name, properties.getProperty( name) );
+            }
+        }
+        return jo;
+
+    }
+
+    /**
+     * Converts the JSONObject into a property file object.
+     * @param jo JSONObject
+     * @return java.util.Properties
+     * @throws JSONException
+     */
+    public static Properties toProperties( JSONObject jo )  throws JSONException {
+        Properties  properties = new Properties();
+        if( jo!=null ) {
+            Iterator    keys = jo.keys();
+
+            while (keys.hasNext()) {
+                String  name    = keys.next().toString();
+                String  value   = jo.getString( name );
+                properties.put(name,value);
+            }
+        }
+        return properties;
+    }
+}


### PR DESCRIPTION
Hello Douglas,
I have a been using your code for a quiet some time now. I wrote a simple Property file converter. Thought I will share it.

Currently there is no way for converting java.util.Properties into a JSONObject. 
        Added two new methods to  
            a) JSONObject toJSONObject(java.util.Properties properties)  // convert java.util.Properties to JSONObject
            b) java.util.Properties toProperties( JSONObject jo )        // convert JSONObject to java.util.Properties
        /\*  
        http://docs.oracle.com/javase/6/docs/api/java/util/Properties.html

```
    /* Example:
    sample property file  : testdata.properties
    weight=10kg
    age=
    height=5'8"
    */
    //Test Code to read property file and convert to JSON and vice versa

    try {
        // load property file
        File fh  = new File("/usr/local/testdata.properties");
        FileInputStream fis = new FileInputStream(fh);
        Properties pConfig = new Properties();
        pConfig.load(fis);

        //Convert to JSON
        JSONObject propJSON = Property.toJSONObject(pConfig);
        log("Property as JSON " + propJSON );  // output : { "weight" : "10kg","height" : "5'8\"", "age":""}

        //Convert JSON to java.util.Properties
        java.util.Properties tmpProperties = Property.toProperties(propJSON);
        log("JSON  as Property" + tmpProperties );  // This will display the name/value pair as per Java's specs.
    } catch (Exception e) {

    }
```
