### PR TITLE
Force an array using accumulate (even if there is only one item)

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -389,6 +389,7 @@ public class JSONObject {
         if (object == null) {
             //this is the modified line  The old version would put the raw value
             //this forces an array when the accumulate version is used
+            
             this.put(key, new JSONArray().put(value));
         } else if (object instanceof JSONArray) {
             ((JSONArray) object).put(value);


### PR DESCRIPTION
I don't know if anyone wants this (or whether it violates JSON standards) but I've found that when I use JSONObject.accumulate I want to force an array object.  This saves from having to write checking code on the client side to see if the item is an object or an array.  You can just iterate over it the same way (because sometimes collections only have one item).  

If there is a better way to handle this, please let me know.

In any case, this mod does it, but I suspect this function may have been written this way on purpose.  Anyway, I love and depend on this library so thanks for keeping it maintained.
