### PR TITLE
Fixed `unchecked` warnings, more robust XML to JSON conversion

### DIFF
--- a/JSONArray.java
+++ b/JSONArray.java
@@ -82,13 +82,13 @@ public class JSONArray {
     /**
      * The arrayList where the JSONArray's properties are kept.
      */
-    private final ArrayList myArrayList;
+    private final ArrayList<Object> myArrayList;
 
     /**
      * Construct an empty JSONArray.
      */
     public JSONArray() {
-        this.myArrayList = new ArrayList();
+        this.myArrayList = new ArrayList<>();
     }
 
     /**
@@ -151,7 +151,7 @@ public class JSONArray {
      *            A Collection.
      */
     public JSONArray(Collection collection) {
-        this.myArrayList = new ArrayList();
+        this.myArrayList = new ArrayList<>();
         if (collection != null) {
             Iterator iter = collection.iterator();
             while (iter.hasNext()) {

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -135,7 +135,7 @@ public class JSONObject {
     /**
      * The map where the JSONObject's properties are kept.
      */
-    private final Map map;
+    private final Map<Object, Object> map;
 
     /**
      * It is sometimes more convenient and less ambiguous to have a
@@ -149,7 +149,7 @@ public class JSONObject {
      * Construct an empty JSONObject.
      */
     public JSONObject() {
-        this.map = new HashMap();
+        this.map = new HashMap<>();
     }
 
     /**
@@ -240,7 +240,7 @@ public class JSONObject {
      * @throws JSONException
      */
     public JSONObject(Map map) {
-        this.map = new HashMap();
+        this.map = new HashMap<>();
         if (map != null) {
             Iterator i = map.entrySet().iterator();
             while (i.hasNext()) {

--- a/XML.java
+++ b/XML.java
@@ -164,7 +164,7 @@ public class XML {
                     if (x.next() == '[') {
                         string = x.nextCDATA();
                         if (string.length() > 0) {
-                            context.accumulate("content", string);
+                            context.accumulate("#text", string);
                         }
                         return false;
                     }
@@ -229,11 +229,11 @@ public class XML {
                         if (!(token instanceof String)) {
                             throw x.syntaxError("Missing value");
                         }
-                        jsonobject.accumulate(string,
+                        jsonobject.accumulate("@" + string,
                                 XML.stringToValue((String)token));
                         token = null;
                     } else {
-                        jsonobject.accumulate(string, "");
+                        jsonobject.accumulate("@" + string, "");
                     }
 
 // Empty tag <.../>
@@ -245,7 +245,7 @@ public class XML {
                     if (jsonobject.length() > 0) {
                         context.accumulate(tagName, jsonobject);
                     } else {
-                        context.accumulate(tagName, "");
+                        context.accumulate(tagName, JSONObject.NULL);
                     }
                     return false;
 
@@ -262,7 +262,7 @@ public class XML {
                         } else if (token instanceof String) {
                             string = (String)token;
                             if (string.length() > 0) {
-                                jsonobject.accumulate("content",
+                                jsonobject.accumulate("#text",
                                         XML.stringToValue(string));
                             }
 
@@ -271,11 +271,11 @@ public class XML {
                         } else if (token == LT) {
                             if (parse(x, jsonobject, tagName)) {
                                 if (jsonobject.length() == 0) {
-                                    context.accumulate(tagName, "");
+                                    context.accumulate(tagName, JSONObject.NULL);
                                 } else if (jsonobject.length() == 1 &&
-                                       jsonobject.opt("content") != null) {
+                                       jsonobject.opt("#text") != null) {
                                     context.accumulate(tagName,
-                                            jsonobject.opt("content"));
+                                            jsonobject.opt("#text"));
                                 } else {
                                     context.accumulate(tagName, jsonobject);
                                 }
@@ -356,7 +356,7 @@ public class XML {
      * collections of name/value pairs and arrays of values. JSON does not
      * does not like to distinguish between elements and attributes.
      * Sequences of similar elements are represented as JSONArrays. Content
-     * text may be placed in a "content" member. Comments, prologs, DTDs, and
+     * text may be placed in a "#text" member. Comments, prologs, DTDs, and
      * <code>&lt;[ [ ]]></code> are ignored.
      * @param string The source string.
      * @return A JSONObject containing the structured data from the XML string.
@@ -429,7 +429,7 @@ public class XML {
 
 // Emit content in body
 
-                if ("content".equals(key)) {
+                if ("#text".equals(key)) {
                     if (value instanceof JSONArray) {
                         ja = (JSONArray)value;
                         length = ja.length();

--- a/XMLTokener.java
+++ b/XMLTokener.java
@@ -36,10 +36,10 @@ public class XMLTokener extends JSONTokener {
    /** The table of entity values. It initially contains Character values for
     * amp, apos, gt, lt, quot.
     */
-   public static final java.util.HashMap entity;
+   public static final java.util.HashMap<String, Character> entity;
 
    static {
-       entity = new java.util.HashMap(8);
+       entity = new java.util.HashMap<>(8);
        entity.put("amp",  XML.AMP);
        entity.put("apos", XML.APOS);
        entity.put("gt",   XML.GT);


### PR DESCRIPTION
Two changes were made in this revision:
- Java unchecked warnings were fixed (this is a minor change)
- XML to JSON conversion was made more robust
  - This convention was followed http://www.xml.com/pub/a/2006/05/31/converting-between-xml-and-json.html
  - What changed is
    - Attributes are prefixed with an `@` (which cannot be the start of a valid XML tag, so there can't be a name collision)
    - Content is prefixed with a `#` and called "#text" (which cannot be the start of a valid XML tag, so there can't be a name collision)
    - Empty tags `<tag></tag>` or `<tag/>` are given null values instead of empty string values
  - This approach is more robust because it avoids name collisions which result in loss of data (examples below)

All three examples below are valid XML (according to the W3C XML validator). Processing any of the examples below would result in data loss.

Here is one example where name collision in an attribute results in data loss.

``` xml
<a tag="text"><tag>different text</tag></a>
```

Here is another example where name collision in the content section results in data loss.

``` xml
<a content="text">different text</a>
```

Here is another example where name collision in the content section results in data loss.

``` xml
<a><content>text</content>different text</a>
```

All these cases are fixed in this code.
