### PR TITLE
Enabled serialization to JSONObject and JSONArray

### DIFF
--- a/JSONArray.java
+++ b/JSONArray.java
@@ -77,7 +77,7 @@ import java.util.Map;
  * @author JSON.org
  * @version 2013-04-18
  */
-public class JSONArray {
+public class JSONArray implements java.io.Serializable {
 
     /**
      * The arrayList where the JSONArray's properties are kept.

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -92,7 +92,7 @@ import java.util.Set;
  * @author JSON.org
  * @version 2013-06-17
  */
-public class JSONObject {
+public class JSONObject implements java.io.Serializable {
     /**
      * JSONObject.NULL is equivalent to the value that JavaScript calls null,
      * whilst Java's null is equivalent to the value that JavaScript calls


### PR DESCRIPTION
Why do not add Serializaion option to the main JSON objects? Developers are complaining about this missing feature. I have created Unit tests and tested it working. If you have a place for unit tests I could sent it to you.
