### PR TITLE
leave numeric text with . as a string if it cannot be faithfully convert...

### DIFF
--- a/XML.java
+++ b/XML.java
@@ -332,7 +332,12 @@ public class XML {
             }
             if ((initial >= '0' && initial <= '9')) {
                 if (string.indexOf('.') >= 0) {
-                    return Double.valueOf(string);
+                    Double value = Double.valueOf(string);
+                    if (string.equals(value.toString())) {
+                        return value;
+                    } else {
+                        return string;
+                    }
                 } else if (string.indexOf('e') < 0 && string.indexOf('E') < 0) {
                     Long myLong = new Long(string);
                     if (myLong.longValue() == myLong.intValue()) {


### PR DESCRIPTION
...ed to double

If seemingly numeric text gets changed/rounded when interpreted as a double then leave it as a string. More often than not the original text is intended to remain as is and is not a number.
