### PR TITLE
Use LinkedHashMap instead of HashMap

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -32,8 +32,8 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
@@ -149,7 +149,7 @@ public class JSONObject {
      * Construct an empty JSONObject.
      */
     public JSONObject() {
-        this.map = new HashMap();
+        this.map = new LinkedHashMap();
     }
 
     /**
@@ -240,7 +240,7 @@ public class JSONObject {
      * @throws JSONException
      */
     public JSONObject(Map map) {
-        this.map = new HashMap();
+        this.map = new LinkedHashMap();
         if (map != null) {
             Iterator i = map.entrySet().iterator();
             while (i.hasNext()) {


### PR DESCRIPTION
Using HashMap leads to loss of keys order when converting json to xml or xml to json
