### PR TITLE
IndexOutOfBoundsException, JSONArray#remove(int)

### DIFF
--- a/JSONArray.java
+++ b/JSONArray.java
@@ -813,9 +813,8 @@ public class JSONArray {
      *         was no value.
      */
     public Object remove(int index) {
-        Object o = this.opt(index);
-        this.myArrayList.remove(index);
-        return o;
+        return (index < 0 || index >= this.length()) ? null : this.myArrayList
+                .remove(index);
     }
 
     /**


### PR DESCRIPTION
`List#remove(int)` throws an `IndexOutOfBoundsException` when index < 0 or index >= list size. The `JSONArray#remove(int)` method was not making the proper check on the index value. Method now behaves as documented.
