### PR TITLE
Added checks for extra non-whitespace characters after a closing '}'.

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -202,6 +202,9 @@ public class JSONObject {
             case 0:
                 throw x.syntaxError("A JSONObject text must end with '}'");
             case '}':
+                if (x.nextClean() != 0) {
+                    throw x.syntaxError("Extra characters after closing '}'");
+                }
                 return;
             default:
                 x.back();
@@ -222,11 +225,17 @@ public class JSONObject {
             case ';':
             case ',':
                 if (x.nextClean() == '}') {
+                    if (x.nextClean() != 0) {
+                        throw x.syntaxError("Extra characters after closing '}'");
+                    }
                     return;
                 }
                 x.back();
                 break;
             case '}':
+                if (x.nextClean() != 0) {
+                    throw x.syntaxError("Extra characters after closing '}'");
+                }
                 return;
             default:
                 throw x.syntaxError("Expected a ',' or '}'");


### PR DESCRIPTION
Since the JSON Standard doesn't specify that extra characters may be present after the closing brace of a JSON string, I have added checks and appropriate syntax error JSONException throws into the JSONObject(JSONTokener x) constructor.

Although the additions are repeated x3, I felt that the constructor was so simple creating an additional private method would over complicate the parsing logic. Let me know if you'd prefer a separate checkEOF method.
