### PR TITLE
added an option to use a LinkedHashMap to keep the original order

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -158,6 +159,16 @@ public class JSONObject {
     }
 
     /**
+     * Construct an empty JSONObject.
+     * 
+     * @param ordered
+     *            if ordered == true, then the JSONObject keeps the original order of properties
+     */
+    public JSONObject(boolean ordered) {
+        this.map = ordered ? new LinkedHashMap<String, Object>() : new HashMap<String, Object>();
+    }
+
+    /**
      * Construct a JSONObject from a subset of another JSONObject. An array of
      * strings is used to identify the keys that should be copied. Missing keys
      * are ignored.
@@ -240,7 +251,7 @@ public class JSONObject {
      *            the JSONObject.
      */
     public JSONObject(Map<?, ?> map) {
-        this.map = new HashMap<String, Object>();
+        this.map = map instanceof LinkedHashMap ? new LinkedHashMap<String, Object>() : new HashMap<String, Object>();
         if (map != null) {
         	for (final Entry<?, ?> e : map.entrySet()) {
                 final Object value = e.getValue();


### PR DESCRIPTION
debugging of data from a json api is much easier if the order of the keys is stable.

I added an option to store the JSONObject's properties in a LinkedHashMap to produce a self-defined order of entities when a JSONObject is serialized with toString()