### PR TITLE
make the json object ordered

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -34,7 +34,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Enumeration;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
@@ -43,7 +43,7 @@ import java.util.ResourceBundle;
 import java.util.Set;
 
 /**
- * A JSONObject is an unordered collection of name/value pairs. Its external
+ * A JSONObject is an collection of name/value pairs. Its external
  * form is a string wrapped in curly braces with colons between the names and
  * values, and commas between the values and names. The internal form is an
  * object having <code>get</code> and <code>opt</code> methods for accessing
@@ -154,7 +154,7 @@ public class JSONObject {
      * Construct an empty JSONObject.
      */
     public JSONObject() {
-        this.map = new HashMap<String, Object>();
+        this.map = new LinkedHashMap<String, Object>();
     }
 
     /**
@@ -240,7 +240,7 @@ public class JSONObject {
      *            the JSONObject.
      */
     public JSONObject(Map<?, ?> map) {
-        this.map = new HashMap<String, Object>();
+        this.map = new LinkedHashMap<String, Object>();
         if (map != null) {
         	for (final Entry<?, ?> e : map.entrySet()) {
                 final Object value = e.getValue();


### PR DESCRIPTION
If you use a linkedHashMap instead of just hashMap you can easily make it ordered. I work on https://github.com/LibraryOfCongress/bagger which needs the JSONObject to preserve the ordering of the fields.