### PR TITLE
fix to compile with 1.6.0_45

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -1842,7 +1842,7 @@ public class JSONObject {
      * @return a java.util.Map containing the entrys of this object
      */
     public Map<String, Object> toMap() {
-        Map<String, Object> results = new HashMap<>();
+        Map<String, Object> results = new HashMap<String, Object>();
         for (Entry<String, Object> entry : this.map.entrySet()) {
             Object value;
             if (entry.getValue() == null || NULL.equals(entry.getValue())) {


### PR DESCRIPTION
**What problem does this code solve?**
Accidentally broke 1.6 compatibility with https://github.com/stleary/JSON-java/pull/203. With this change, the code will compile with Oracle javac 1.6.0_45 and 1.8.0_05.

**Changes to the API?**
No.

**Does it break the unit tests?**
No, and no tests are added for this change.

**Will this require a new release?**
No, this will be rolled into the next release, which is not yet scheduled.

**Should the documentation be updated?**
No, this is an internal bug fix to maintain compiler compatibility.