### PR TITLE
Make nextString throw a JSONException instead of a NumberFormatExcept…

### DIFF
--- a/JSONTokener.java
+++ b/JSONTokener.java
@@ -281,7 +281,7 @@ public class JSONTokener {
                     try {
                         sb.append((char)Integer.parseInt(this.next(4), 16));
                     } catch (NumberFormatException e) {
-                        throw this.syntaxError("Illegal escape.");
+                        throw this.syntaxError("Illegal escape.", e);
                     }
                     break;
                 case '"':
@@ -437,6 +437,16 @@ public class JSONTokener {
         return new JSONException(message + this.toString());
     }
 
+    /**
+     * Make a JSONException to signal a syntax error.
+     *
+     * @param message The error message.
+     * @param causedBy The throwable that caused the error.
+     * @return  A JSONException object, suitable for throwing
+     */
+    public JSONException syntaxError(String message, Throwable causedBy) {
+        return new JSONException(message + this.toString(), causedBy);
+    }
 
     /**
      * Make a printable string of this JSONTokener.

--- a/JSONTokener.java
+++ b/JSONTokener.java
@@ -278,7 +278,11 @@ public class JSONTokener {
                     sb.append('\r');
                     break;
                 case 'u':
-                    sb.append((char)Integer.parseInt(this.next(4), 16));
+                    try {
+                        sb.append((char)Integer.parseInt(this.next(4), 16));
+                    } catch (NumberFormatException e) {
+                        throw this.syntaxError("Illegal escape.");
+                    }
                     break;
                 case '"':
                 case '\'':


### PR DESCRIPTION
…ion for malformed input.

The documentation for the JSONObject(String) constructor says that JSONExceptions are thrown for invalid input. However, the implementation can throw a NumberFormatException as well. This fixes that.