### PR TITLE
possible tweaks from intervision

### DIFF
--- a/JSONArray.java
+++ b/JSONArray.java
@@ -170,7 +170,11 @@ public class JSONArray implements Iterable<Object> {
      */
     public JSONArray(Object array) throws JSONException {
         this();
-        if (array.getClass().isArray()) {
+        if (array instanceof Collection) {
+            for (Object o: (Collection)array)){
+                this.put(JSONObject.wrap(o));
+            }
+        } else if (array.getClass().isArray()) {
             int length = Array.getLength(array);
             for (int i = 0; i < length; i += 1) {
                 this.put(JSONObject.wrap(Array.get(array, i)));

--- a/JSONArray.java
+++ b/JSONArray.java
@@ -171,7 +171,7 @@ public class JSONArray implements Iterable<Object> {
     public JSONArray(Object array) throws JSONException {
         this();
         if (array instanceof Collection) {
-            for (Object o: (Collection)array)){
+            for (Object o: ((Collection)array)){
                 this.put(JSONObject.wrap(o));
             }
         } else if (array.getClass().isArray()) {

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -34,6 +34,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Enumeration;
+import java.util.LinkedHashMap;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Locale;
@@ -140,7 +141,7 @@ public class JSONObject {
     /**
      * The map where the JSONObject's properties are kept.
      */
-    private final Map<String, Object> map;
+    private final LinkedHashMap<String, Object> map;
 
     /**
      * It is sometimes more convenient and less ambiguous to have a
@@ -154,7 +155,7 @@ public class JSONObject {
      * Construct an empty JSONObject.
      */
     public JSONObject() {
-        this.map = new HashMap<String, Object>();
+        this.map = new LinkedHashMap<String, Object>();
     }
 
     /**
@@ -240,7 +241,7 @@ public class JSONObject {
      *            the JSONObject.
      */
     public JSONObject(Map<?, ?> map) {
-        this.map = new HashMap<String, Object>();
+        this.map = new LinkedHashMap<String, Object>();
         if (map != null) {
         	for (final Entry<?, ?> e : map.entrySet()) {
                 final Object value = e.getValue();
@@ -1889,7 +1890,7 @@ public class JSONObject {
      * @return a java.util.Map containing the entrys of this object
      */
     public Map<String, Object> toMap() {
-        Map<String, Object> results = new HashMap<String, Object>();
+        Map<String, Object> results = new LinkedHashMap<String, Object>();
         for (Entry<String, Object> entry : this.map.entrySet()) {
             Object value;
             if (entry.getValue() == null || NULL.equals(entry.getValue())) {

--- a/JSONSerializable.java
+++ b/JSONSerializable.java
@@ -1,6 +1,31 @@
 package org.json;
+
+/*
+ Copyright (c) 2002 JSON.org
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ The Software shall be used for Good, not Evil.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
 /**
- * The <code>JSONString</code> interface allows a <code>toJSON()</code>
+ * The <code>JSONSerializable</code> interface allows a <code>toJSON()</code>
  * method. 
  */
 public interface JSONSerializable {
@@ -8,7 +33,7 @@ public interface JSONSerializable {
      * The <code>toJSON</code> method allows a class to produce its own JSON
      * object creation.
      *
-     * @return A strictly syntactically correct JSON text.
+     * @return An Object that is either a JSONObject or JSONArray.
      */
     public Object toJSON();
 }

--- a/JSONSerializable.java
+++ b/JSONSerializable.java
@@ -1,0 +1,14 @@
+package org.json;
+/**
+ * The <code>JSONString</code> interface allows a <code>toJSON()</code>
+ * method. 
+ */
+public interface JSONSerializable {
+    /**
+     * The <code>toJSON</code> method allows a class to produce its own JSON
+     * object creation.
+     *
+     * @return A strictly syntactically correct JSON text.
+     */
+    public Object toJSON();
+}

--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+javac -d . -cp . *.java zip/*.java
+jar cvf json.jar org

--- a/compile.sh
+++ b/compile.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-javac -d . -cp . *.java zip/*.java
+javac -d . -cp . *.java
 jar cvf json.jar org


### PR DESCRIPTION
Here are some possible tweaks I came up with to this library while writing java code for my organization.

1. Make the map implementation of the JSONObject a LinkedHashMap instead of HashMap, this allows me to enforce that the order I put the properties into the JSONObject is the order I will pull them out when writing the JSONObject to string (this was required due to organizational coding standards, and because of some really bad front end jquery code I had to work arround).
2. Allow JSONArrays to be be built from generic Collections (this was required when I needed to build a JSONArray for serialization from a dynamically build array, or possibly when I was trying to import an array of json objects containing json arrays).
3. Adding a JSONSerializable interface, this commit is optional (I put it here because it made sense to me to put it with the other json functions), but it made sense to include an interface that can be used to define a class that can be exported to a JSONObject to go with the JSONString class.
