### PR TITLE
Preserving XML ordem when parse from XML string to Json

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -34,8 +34,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -155,7 +155,7 @@ public class JSONObject {
      * Construct an empty JSONObject.
      */
     public JSONObject() {
-        this.map = new HashMap<String, Object>();
+        this.map = new LinkedHashMap<>();
     }
 
     /**
@@ -241,7 +241,7 @@ public class JSONObject {
      *            the JSONObject.
      */
     public JSONObject(Map<?, ?> map) {
-        this.map = new HashMap<String, Object>();
+        this.map = new LinkedHashMap<String, Object>();
         if (map != null) {
             for (final Entry<?, ?> e : map.entrySet()) {
                 final Object value = e.getValue();
@@ -1944,7 +1944,7 @@ public class JSONObject {
      * @return a java.util.Map containing the entries of this object
      */
     public Map<String, Object> toMap() {
-        Map<String, Object> results = new HashMap<String, Object>();
+        Map<String, Object> results = new LinkedHashMap<String, Object>();
         for (Entry<String, Object> entry : this.map.entrySet()) {
             Object value;
             if (entry.getValue() == null || NULL.equals(entry.getValue())) {

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -155,7 +155,7 @@ public class JSONObject {
      * Construct an empty JSONObject.
      */
     public JSONObject() {
-        this.map = new LinkedHashMap<>();
+        this.map = new LinkedHashMap<String, Object>();
     }
 
     /**


### PR DESCRIPTION
 Currently, if we parse a xml string to a JsonObject, we have no guarantee that the xml order will be preserved (because JSONObject uses a HashMap).
 May be interesting keep this order (although it does not make a difference in the Json's structure).
 This pull request swaps from HashMap to LinkedHashMap.