### PR TITLE
JSONWriter uses Appendable (v2)

### DIFF
--- a/JSONWriter.java
+++ b/JSONWriter.java
@@ -1,7 +1,6 @@
 package org.json;
 
 import java.io.IOException;
-import java.io.Writer;
 
 /*
 Copyright (c) 2006 JSON.org
@@ -50,11 +49,11 @@ SOFTWARE.
  * <p>
  * The first method called must be <code>array</code> or <code>object</code>.
  * There are no methods for adding commas or colons. JSONWriter adds them for
- * you. Objects and arrays can be nested up to 20 levels deep.
+ * you. Objects and arrays can be nested up to 200 levels deep.
  * <p>
  * This can sometimes be easier than using a JSONObject to build a string.
  * @author JSON.org
- * @version 2015-12-09
+ * @version 2016-08-08
  */
 public class JSONWriter {
     private static final int maxdepth = 200;
@@ -88,12 +87,12 @@ public class JSONWriter {
     /**
      * The writer that will receive the output.
      */
-    protected Writer writer;
+    protected Appendable writer;
 
     /**
      * Make a fresh JSONWriter. It can be used to build one JSON text.
      */
-    public JSONWriter(Writer w) {
+    public JSONWriter(Appendable w) {
         this.comma = false;
         this.mode = 'i';
         this.stack = new JSONObject[maxdepth];
@@ -114,9 +113,9 @@ public class JSONWriter {
         if (this.mode == 'o' || this.mode == 'a') {
             try {
                 if (this.comma && this.mode == 'a') {
-                    this.writer.write(',');
+                    this.writer.append(',');
                 }
-                this.writer.write(string);
+                this.writer.append(string);
             } catch (IOException e) {
                 throw new JSONException(e);
             }
@@ -163,7 +162,7 @@ public class JSONWriter {
         }
         this.pop(mode);
         try {
-            this.writer.write(c);
+            this.writer.append(c);
         } catch (IOException e) {
             throw new JSONException(e);
         }
@@ -207,10 +206,10 @@ public class JSONWriter {
             try {
                 this.stack[this.top - 1].putOnce(string, Boolean.TRUE);
                 if (this.comma) {
-                    this.writer.write(',');
+                    this.writer.append(',');
                 }
-                this.writer.write(JSONObject.quote(string));
-                this.writer.write(':');
+                this.writer.append(JSONObject.quote(string));
+                this.writer.append(':');
                 this.comma = false;
                 this.mode = 'o';
                 return this;


### PR DESCRIPTION
**What problem does this code solve?**
* Changes methods that take a `java.io.Writer` to use a
  `java.lang.Appendable` instead. Situations where `Appendable`
  can be used where `Writer` cannot include the `StringBuffer`,
  `StringBuilder`, and `CharBuffer` classes.

**Risks**
Low risk. This is modifying an API method to take an interface instead of a base class, which is generally a good practice. The positive unit test coverage is good. But JSONWriter is lacking coverage for most of the thrown exceptions, including in modified methods. OK to commit, but better unit test code coverage will be required before this code can be included in a release.  See https://github.com/stleary/JSON-Java-unit-test/issues/56. 

**Changes to the API?**
The constructor for JSONWriter has changed from `Writer` to `Appendable`.

**Will this require a new release?**
Can be rolled into the next release, pending completion of the unit tests.

**Should the documentation be updated?**
Not required.

**Does it break the unit tests?**
No, the current tests run successfully. However, new unit tests have been added. See 
https://github.com/stleary/JSON-Java-unit-test/pull/53
