### PR TITLE
Update enum support to be more fully featured.

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -1708,6 +1708,9 @@ public class JSONObject {
         if (value.getClass().isArray()) {
             return new JSONArray(value).toString();
         }
+        if(value instanceof Enum<?>){
+            return quote(((Enum<?>)value).name());
+        }
         return quote(value.toString());
     }
 
@@ -1730,12 +1733,9 @@ public class JSONObject {
             }
             if (object instanceof JSONObject || object instanceof JSONArray
                     || NULL.equals(object) || object instanceof JSONString
-                    || object instanceof Byte || object instanceof Character
-                    || object instanceof Short || object instanceof Integer
-                    || object instanceof Long || object instanceof Boolean
-                    || object instanceof Float || object instanceof Double
-                    || object instanceof String || object instanceof BigInteger
-                    || object instanceof BigDecimal) {
+                    || object instanceof Number || object instanceof Character
+                    || object instanceof Boolean || object instanceof String
+                    || object instanceof Enum) {
                 return object;
             }
 
@@ -1797,6 +1797,8 @@ public class JSONObject {
             writer.write(numberToString((Number) value));
         } else if (value instanceof Boolean) {
             writer.write(value.toString());
+        } else if (value instanceof Enum<?>) {
+            writer.write(quote(((Enum<?>)value).name()));
         } else if (value instanceof JSONString) {
             Object o;
             try {

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -1733,9 +1733,12 @@ public class JSONObject {
             }
             if (object instanceof JSONObject || object instanceof JSONArray
                     || NULL.equals(object) || object instanceof JSONString
-                    || object instanceof Number || object instanceof Character
-                    || object instanceof Boolean || object instanceof String
-                    || object instanceof Enum) {
+                    || object instanceof Byte || object instanceof Character
+                    || object instanceof Short || object instanceof Integer
+                    || object instanceof Long || object instanceof Boolean
+                    || object instanceof Float || object instanceof Double
+                    || object instanceof String || object instanceof BigInteger
+                    || object instanceof BigDecimal || object instanceof Enum) {
                 return object;
             }
 


### PR DESCRIPTION
Adds support to JSONObject wrap and write methods to explicitly handle Enums.

**What problem does this code solve?**
Enums were handled inconsistently as noted in the original improvement (#140 and #127) and brought up again in #145 and #255 

The new way enums are handled is to always place the actual enum in the JSONObject/JSONArray (not wrapped, similar to other value types). When writing, we always write the actual "name" of the enum, so even with a toString override on the enum class, the value remains consistent and compatible with the optEnum/getEnum methods.

The constructor JSONObject(Object) functions the same way as before when passing an enum and is consistent with other "value" types. For example, when creating a JSONObject with Long, Boolean, BigDecimal as the constructor parameter, the value will be treated as a "bean".

**Risks**
Low risk. Currently inserting enums into JSONObject and JSONArray are not consistent. Anyone depending on the existing handling of enums probably does so with if blocks to ensure they have the correct data. Additionally, some cases of inserting an enum would produce results that could not be read back using get|optEnum methods.
```java
Set<MyEnumField> set = new EnumSet.of(MyEnumField.VAL1);
JSONObject jo = new JSONObject();
jo.put("value", set);

assert (new JSONObject(jo.toString()).optEnum(MyEnumField.class, "value") != null
    : "Oops, couldn't read back the enum value.";
```

Given that the data is not always reversible, it's unlikely that people are depending on this behaviour.

**Changes to the API?**
No, but there are functional changes

**Will this require a new release?**
Can be rolled into the next release, pending comments.

**Should the documentation be updated?**
Not required.

**Does it break the unit tests?**
Yes, new unit tests have been added.

**Review status**
ACCEPTED. Starting 3-day comment window 15 Aug 2016