### PR TITLE
Simplify Number comparison during wrap

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -1732,12 +1732,8 @@ public class JSONObject {
             }
             if (object instanceof JSONObject || object instanceof JSONArray
                     || NULL.equals(object) || object instanceof JSONString
-                    || object instanceof Byte || object instanceof Character
-                    || object instanceof Short || object instanceof Integer
-                    || object instanceof Long || object instanceof Boolean
-                    || object instanceof Float || object instanceof Double
-                    || object instanceof String || object instanceof BigInteger
-                    || object instanceof BigDecimal) {
+                    || object instanceof Number || object instanceof Character
+                    || object instanceof Boolean || object instanceof String) {
                 return object;
             }
 


### PR DESCRIPTION
**What problem does this code solve?**
Simplifies the comparison in the wrap method to only compare against the Parent Class `Number` instead of individual Number sub types. This should speed up code as well as allow for other number types to remain unwrapped like `AtomicInteger`.  Classes like `AtomicInteger` used to be wrapped into a JSONObject and treated like a Bean instead of a number.

**Risks**
Low risk. Possibly a bug fix. One caveat is that if the `AtomicInteger` is updated after insert into a JSONObject or JSONArray, but before the JSON is serialized, then the updated value is written, not the original.

``` java
AtomicInteger ai = new AtomicInteger(1);
JSONObject jo = new JSONObject();
jo.put("value", ai); // value is 1
ai.getAndIncrement();

assert (new JSONObject(jo.toString())).optInt("value") == 2
    : "Value should have been 2!";
```

This may lead to unexpected results, however, users of `AtomicInteger` should already be aware of this and know the risks.

Currently types like `java.util.concurrent.atomic.AtomicInteger` will be converted to either string or a number inconsistently depending on how it's inserted into a JSONObject or JSONArray.

**Changes to the API?**
No, but there are functional changes

**Will this require a new release?**
Can be rolled into the next release, pending comments.

**Should the documentation be updated?**
Possibly. Maybe just updated javadocs. Will wait on comments before updating.

**Does it break the unit tests?**
No, new unit tests could possibly be added though.
