### PR TITLE
Tweaked JSONObject.getString() to evade exceptions

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -706,20 +706,17 @@ public class JSONObject {
     }
 
     /**
-     * Get the string associated with a key.
+     * Get the string representation of the value associated with a key.
      *
      * @param key
      *            A key string.
-     * @return A string which is the value.
+     * @return The string representation of the value.
      * @throws JSONException
-     *             if there is no string value for the key.
+     *             if there is no value for the key.
      */
     public String getString(String key) throws JSONException {
         Object object = this.get(key);
-        if (object instanceof String) {
-            return (String) object;
-        }
-        throw new JSONException("JSONObject[" + quote(key) + "] not a string.");
+        return object.toString();
     }
 
     /**

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -715,8 +715,7 @@ public class JSONObject {
      *             if there is no value for the key.
      */
     public String getString(String key) throws JSONException {
-        Object object = this.get(key);
-        return object.toString();
+        return this.get(key).toString();
     }
 
     /**


### PR DESCRIPTION
Right now, if the value `JSONObject.getString()` is trying to retrieve happens to be a number (or anything else that's not a `String`), you get a `JSONException`. Looking in from the outside of the API, I would expect `getString()` to return the `String` representation of the value, without being sensitive to the type it _should have_ been.

So this change calls `toString()` on the value `JSONObject.get()` returned and returns that, instead of throwing an exception.