### PR TITLE
Bug fixes for XML Encoding and Decoding

### DIFF
--- a/JSONML.java
+++ b/JSONML.java
@@ -175,7 +175,7 @@ public class JSONML {
                             if (!(token instanceof String)) {
                                 throw x.syntaxError("Missing value");
                             }
-                            newjo.accumulate(attribute, keepStrings ? token :JSONObject.stringToValue((String)token));
+                            newjo.accumulate(attribute, keepStrings ? token :XML.stringToValue((String)token));
                             token = null;
                         } else {
                             newjo.accumulate(attribute, "");
@@ -226,7 +226,7 @@ public class JSONML {
             } else {
                 if (ja != null) {
                     ja.put(token instanceof String
-                        ? keepStrings ? token :JSONObject.stringToValue((String)token)
+                        ? keepStrings ? token :XML.stringToValue((String)token)
                         : token);
                 }
             }

--- a/JSONML.java
+++ b/JSONML.java
@@ -175,7 +175,7 @@ public class JSONML {
                             if (!(token instanceof String)) {
                                 throw x.syntaxError("Missing value");
                             }
-                            newjo.accumulate(attribute, keepStrings ? token :XML.stringToValue((String)token));
+                            newjo.accumulate(attribute, keepStrings ? XML.unescape((String)token) :XML.stringToValue((String)token));
                             token = null;
                         } else {
                             newjo.accumulate(attribute, "");
@@ -226,7 +226,7 @@ public class JSONML {
             } else {
                 if (ja != null) {
                     ja.put(token instanceof String
-                        ? keepStrings ? token :XML.stringToValue((String)token)
+                        ? keepStrings ? XML.unescape((String)token) :XML.stringToValue((String)token)
                         : token);
                 }
             }

--- a/XML.java
+++ b/XML.java
@@ -165,15 +165,15 @@ public class XML {
                 if (semic > i) {
                     final String entity = string.substring(i + 1, semic);
                     if (entity.charAt(0) == '#') {
-                        char cc;
+                        int cp;
                         if (entity.charAt(1) == 'x') {
                             // hex encoded unicode
-                            cc = (char) Integer.parseInt(entity.substring(2), 16);
+                            cp = Integer.parseInt(entity.substring(2), 16);
                         } else {
                             // decimal encoded unicode
-                            cc = (char) Integer.parseInt(entity.substring(1));
+                            cp = Integer.parseInt(entity.substring(1));
                         }
-                        sb.append(cc);
+                        sb.append(new String(Character.toChars(cp)));
                     } else {
                         if ("quot".equalsIgnoreCase(entity)) {
                             sb.append('"');

--- a/XML.java
+++ b/XML.java
@@ -64,7 +64,11 @@ public class XML {
     
     /**
      * Creates an iterator for navigating Code Points in a string instead of
-     * characters.
+     * characters. Once Java7 support is dropped, this can be replaced with
+     * <code>
+     * string.codePoints()
+     * </code>
+     * which is available in Java8 and above.
      * 
      * @see <a href=
      *      "http://stackoverflow.com/a/21791059/6030888">http://stackoverflow.com/a/21791059/6030888</a>

--- a/XML.java
+++ b/XML.java
@@ -166,12 +166,12 @@ public class XML {
                 && cp != 0x9
                 && cp != 0xA
                 && cp != 0xD
-                ) || !(
-                    // valid the range of acceptable characters that aren't control
-                    (cp >= 0x20 && cp <= 0xD7FF)
-                    || (cp >= 0xE000 && cp <= 0xFFFD)
-                    || (cp >= 0x10000 && cp <= 0x10FFFF)
-                )
+            ) || !(
+                // valid the range of acceptable characters that aren't control
+                (cp >= 0x20 && cp <= 0xD7FF)
+                || (cp >= 0xE000 && cp <= 0xFFFD)
+                || (cp >= 0x10000 && cp <= 0x10FFFF)
+            )
         ;
     }
 

--- a/XML.java
+++ b/XML.java
@@ -61,6 +61,42 @@ public class XML {
 
     /** The Character '/'. */
     public static final Character SLASH = '/';
+    
+    /**
+     * Creates an iterator for navigating Code Points in a string instead of
+     * characters.
+     * 
+     * @see <a href=
+     *      "http://stackoverflow.com/a/21791059/6030888">http://stackoverflow.com/a/21791059/6030888</a>
+     */
+    private static Iterable<Integer> codePointIterator(final String string) {
+        return new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return new Iterator<Integer>() {
+                    private int nextIndex = 0;
+                    private int length = string.length();
+
+                    @Override
+                    public boolean hasNext() {
+                        return this.nextIndex < this.length;
+                    }
+
+                    @Override
+                    public Integer next() {
+                        int result = string.codePointAt(this.nextIndex);
+                        this.nextIndex += Character.charCount(result);
+                        return result;
+                    }
+
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+        };
+    }
 
     /**
      * Replace special characters with XML escapes:
@@ -79,8 +115,7 @@ public class XML {
      */
     public static String escape(String string) {
         StringBuilder sb = new StringBuilder(string.length());
-        for (int i = 0, length = string.length(); i < length; i++) {
-            char c = string.charAt(i);
+        for (final int c : codePointIterator(string)) {
             switch (c) {
             case '&':
                 sb.append("&amp;");
@@ -98,18 +133,18 @@ public class XML {
                 sb.append("&apos;");
                 break;
             default:
-                if (c < ' ' || (c >= '\u0080' && c < '\u00a0') || (c >= '\u2000' && c < '\u2100')) {
+                if (Character.isISOControl(c)) {
                     sb.append("&#x");
                     sb.append(Integer.toHexString(c));
                     sb.append(";");
                 } else {
-                    sb.append(c);
+                    sb.append(new String(Character.toChars(c)));
                 }
             }
         }
         return sb.toString();
     }
-
+    
     /**
      * Removes XML escapes from the string.
      * 

--- a/XML.java
+++ b/XML.java
@@ -137,7 +137,7 @@ public class XML {
                 sb.append("&apos;");
                 break;
             default:
-                if (Character.isISOControl(cp)) {
+                if (mustEscape(cp)) {
                     sb.append("&#x");
                     sb.append(Integer.toHexString(cp));
                     sb.append(";");
@@ -149,6 +149,32 @@ public class XML {
         return sb.toString();
     }
     
+    /**
+     * @param cp code point to test
+     * @return true if the code point is not valid for an XML
+     */
+    private static boolean mustEscape(int cp) {
+        /* Valid range from https://www.w3.org/TR/REC-xml/#charsets
+         * 
+         * #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF] 
+         * 
+         * any Unicode character, excluding the surrogate blocks, FFFE, and FFFF. 
+         */
+        // isISOControl is true when (cp >= 0 && cp <= 0x1F) || (cp >= 0x7F && cp <= 0x9F)
+        // all ISO control characters are out of range except tabs and new lines
+        return (Character.isISOControl(cp)
+                && cp != 0x9
+                && cp != 0xA
+                && cp != 0xD
+                ) || !(
+                    // valid the range of acceptable characters that aren't control
+                    (cp >= 0x20 && cp <= 0xD7FF)
+                    || (cp >= 0xE000 && cp <= 0xFFFD)
+                    || (cp >= 0x10000 && cp <= 0x10FFFF)
+                )
+        ;
+    }
+
     /**
      * Removes XML escapes from the string.
      * 

--- a/XML.java
+++ b/XML.java
@@ -119,8 +119,8 @@ public class XML {
      */
     public static String escape(String string) {
         StringBuilder sb = new StringBuilder(string.length());
-        for (final int c : codePointIterator(string)) {
-            switch (c) {
+        for (final int cp : codePointIterator(string)) {
+            switch (cp) {
             case '&':
                 sb.append("&amp;");
                 break;
@@ -137,12 +137,12 @@ public class XML {
                 sb.append("&apos;");
                 break;
             default:
-                if (Character.isISOControl(c)) {
+                if (Character.isISOControl(cp)) {
                     sb.append("&#x");
-                    sb.append(Integer.toHexString(c));
+                    sb.append(Integer.toHexString(cp));
                     sb.append(";");
                 } else {
-                    sb.append(new String(Character.toChars(c)));
+                    sb.appendCodePoint(cp);
                 }
             }
         }
@@ -173,7 +173,7 @@ public class XML {
                             // decimal encoded unicode
                             cp = Integer.parseInt(entity.substring(1));
                         }
-                        sb.append(new String(Character.toChars(cp)));
+                        sb.appendCodePoint(cp);
                     } else {
                         if ("quot".equalsIgnoreCase(entity)) {
                             sb.append('"');

--- a/XML.java
+++ b/XML.java
@@ -186,7 +186,7 @@ public class XML {
         StringBuilder sb = new StringBuilder(string.length());
         for (int i = 0, length = string.length(); i < length; i++) {
             char c = string.charAt(i);
-            if (c == AMP) {
+            if (c == '&') {
                 final int semic = string.indexOf(';', i);
                 if (semic > i) {
                     final String entity = string.substring(i + 1, semic);
@@ -204,7 +204,7 @@ public class XML {
                         if ("quot".equalsIgnoreCase(entity)) {
                             sb.append('"');
                         } else if ("amp".equalsIgnoreCase(entity)) {
-                            sb.append(AMP);
+                            sb.append('&');
                         } else if ("apos".equalsIgnoreCase(entity)) {
                             sb.append('\'');
                         } else if ("lt".equalsIgnoreCase(entity)) {
@@ -212,7 +212,7 @@ public class XML {
                         } else if ("gt".equalsIgnoreCase(entity)) {
                             sb.append('>');
                         } else {
-                            sb.append(AMP).append(entity).append(';');
+                            sb.append('&').append(entity).append(';');
                         }
                     }
                     // skip past the entity we just parsed.


### PR DESCRIPTION
This pull request is in reference to issue #285. It modifies how the XML parser handles string values and also updates the `escape` function to properly encode control characters using XML entities. Better reversibility is now available that entities are decoded on read. Previously they were encoded but not decoded.

**What problem does this code solve?**
Fixes bug where control characters were being placed in XML as unescaped values. Also unescapes encoded values when reading XML into a JSONObject to support full reversibility of XML -> JSON -> XML.

**Risks**
_Control Character Changes_
Low risk bug fix. No users should be expecting control characters output as unicode characters. They will now see ISO Control characters encoded using the &#xXXXX; notation as defined by the running JVMs `Character.isISOControl(int)` method.

_Reversibility Changes_
Low risk. Full reversibility is not offered with the XML class but improvements have been made in recent releases for Arrays (#170) and other minor items. Full reversibility is supposed to be offered through there JSONML class as it uses a normalized XML structure.

HTML Entities are still not supported and will still break reversibility in both XML and JSONML classes, however regular XML entities are now fully supported and are properly converted between the two object types. Most XML parsers will fail if they see an HTML specific entity when run in strict mode, so this is not a major concern here.

Example of broken HTML entities (not valid XML and should break most parsers):

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<root><amount>10,00 &#x20ac;</amount><description>A&ccedil;&atilde;o V&aacute;lida</description></root>
```

This would turn into JSON that looks like this:

``` json
{"root":{"amount":"10,00 €","description":"A&ccedil;&atilde;o V&aacute;lida"}}
```

If the JSON is converted back to XML, proper XML would be generated like so:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<root><amount>10,00 €</amount><description>A&amp;ccedil;&amp;atilde;o V&amp;aacute;lida</description></root>
```

The resulting XML does not match the original. This is probably the desired behavior, but should be noted. This has not changed in this pull request. This is current behaviour that is being noted here.

The parsing that has changed is in the case of valid XML entities. Now when valid XML entities are encountered in an XML document, they will be decoded upon conversion to JSON. The JSON -> XML conversion will still encode the entities (< > ' " &) as well as now encoding control characters. The XML -> JSON -> XML -> JSON will have the proper values over multiple iterations.

**Changes to the API?**
Yes, I removed the deprecation that I previously added to `XML.stringToValue`. I also added a new public static method to the XML class called `unescape` to complement the existing public static method `escape`.

**Will this require a new release?**
Can be rolled into the next release, pending comments.

**Should the documentation be updated?**
No documentation updates required.

**Does it break the unit tests?**
No, but new unit tests have been added in a separate pull request.
