### PR TITLE
There are use cases that require a canonical form of the JSON string …

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * A JSONObject is an unordered collection of name/value pairs. Its external
@@ -140,8 +141,9 @@ public class JSONObject {
 
     /**
      * The map where the JSONObject's properties are kept.
+     * See {@link JSONObject#createMap()}.
      */
-    private final Map<String, Object> map;
+    protected final Map<String, Object> map;
 
     /**
      * It is sometimes more convenient and less ambiguous to have a
@@ -155,7 +157,7 @@ public class JSONObject {
      * Construct an empty JSONObject.
      */
     public JSONObject() {
-        this.map = new HashMap<String, Object>();
+        this.map = createMap();
     }
 
     /**
@@ -241,7 +243,7 @@ public class JSONObject {
      *            the JSONObject.
      */
     public JSONObject(Map<?, ?> map) {
-        this.map = new HashMap<String, Object>();
+        this.map = createMap();
         if (map != null) {
         	for (final Entry<?, ?> e : map.entrySet()) {
                 final Object value = e.getValue();
@@ -251,6 +253,22 @@ public class JSONObject {
             }
         }
     }
+
+   /**
+    * Allows successors to override the type of {@link Map} being used by this
+    * implementation.<br>
+    * This allows for a JSON {@link String} whose attributes are sorted (by
+    * using {@link TreeMap} instead of {@link HashMap}), thus allowing
+    * implementation of a JSON that:
+    * <ul>
+    * <li> Has a {@link String} representation in a canonical form.
+    * <li> Is easier to implement {@link #hashCode()}.
+    * <li> Is easier to implement {@link #equals(Object)}.
+    * </ul>
+    */
+   protected Map<String, Object> createMap() {
+      return new HashMap<String, Object>();
+   }
 
     /**
      * Construct a JSONObject from an Object using bean getters. It reflects on
@@ -476,7 +494,7 @@ public class JSONObject {
 
     /**
     * Get the enum value associated with a key.
-    * 
+    *
     * @param clazz
     *           The type of enum to retrieve.
     * @param key
@@ -531,7 +549,7 @@ public class JSONObject {
      *            A key string.
      * @return The numeric value.
      * @throws JSONException
-     *             if the key is not found or if the value cannot 
+     *             if the key is not found or if the value cannot
      *             be converted to BigInteger.
      */
     public BigInteger getBigInteger(String key) throws JSONException {
@@ -866,7 +884,7 @@ public class JSONObject {
 
     /**
      * Get the enum value associated with a key.
-     * 
+     *
      * @param clazz
      *            The type of enum to retrieve.
      * @param key
@@ -879,7 +897,7 @@ public class JSONObject {
 
     /**
      * Get the enum value associated with a key.
-     * 
+     *
      * @param clazz
      *            The type of enum to retrieve.
      * @param key
@@ -1340,7 +1358,7 @@ public class JSONObject {
     }
 
     /**
-     * Creates a JSONPointer using an intialization string and tries to 
+     * Creates a JSONPointer using an intialization string and tries to
      * match it to an item within this JSONObject. For example, given a
      * JSONObject initialized with this document:
      * <pre>
@@ -1348,24 +1366,24 @@ public class JSONObject {
      *     "a":{"b":"c"}
      * }
      * </pre>
-     * and this JSONPointer string: 
+     * and this JSONPointer string:
      * <pre>
      * "/a/b"
      * </pre>
      * Then this method will return the String "c".
      * A JSONPointerException may be thrown from code called by this method.
-     *   
+     *
      * @param jsonPointer string that can be used to create a JSONPointer
      * @return the item matched by the JSONPointer, otherwise null
      */
     public Object query(String jsonPointer) {
         return new JSONPointer(jsonPointer).queryFrom(this);
     }
-    
+
     /**
      * Queries and returns a value from this object using {@code jsonPointer}, or
      * returns null if the query fails due to a missing key.
-     * 
+     *
      * @param jsonPointer the string representation of the JSON pointer
      * @return the queried value or {@code null}
      * @throws IllegalArgumentException if {@code jsonPointer} has invalid syntax
@@ -1919,7 +1937,7 @@ public class JSONObject {
      * @return a java.util.Map containing the entries of this object
      */
     public Map<String, Object> toMap() {
-        Map<String, Object> results = new HashMap<String, Object>();
+        Map<String, Object> results = createMap();
         for (Entry<String, Object> entry : this.map.entrySet()) {
             Object value;
             if (entry.getValue() == null || NULL.equals(entry.getValue())) {


### PR DESCRIPTION
…(or at least a form where JSON attributes appear in a sorted order)

E.g. security applications where client and server need to construct a JSON structure and sign it, and the other party need to validate the signature.
With this change JSONObject allows its children to override the type of java.util.Map being used, thus allowing for TreeMap, thus allowing sorted JSON, thus allowing two clients to generate the same JSON string, given they provide the same attributes.