### PR TITLE
Either log or rethrow otherwise invisible Exceptions.

### DIFF
--- a/JSONArray.java
+++ b/JSONArray.java
@@ -35,6 +35,8 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A JSONArray is an ordered sequence of values. Its external text form is a
@@ -82,6 +84,11 @@ import java.util.Map;
  */
 public class JSONArray implements Iterable<Object> {
 
+    /**
+     * Logger for retrieving otherwise invisible Exceptions.
+     */
+    private static final Logger LOGGER = Logger.getLogger(JSONArray.class.getName());
+    
     /**
      * The arrayList where the JSONArray's properties are kept.
      */
@@ -244,7 +251,7 @@ public class JSONArray implements Iterable<Object> {
             return object instanceof Number ? ((Number) object).doubleValue()
                     : Double.parseDouble((String) object);
         } catch (Exception e) {
-            throw new JSONException("JSONArray[" + index + "] is not a number.");
+            throw new JSONException("JSONArray[" + index + "] is not a number.", e);
         }
     }
 
@@ -289,7 +296,7 @@ public class JSONArray implements Iterable<Object> {
             return new BigDecimal(object.toString());
         } catch (Exception e) {
             throw new JSONException("JSONArray[" + index +
-                    "] could not convert to BigDecimal.");
+                    "] could not convert to BigDecimal.", e);
         }
     }
 
@@ -309,7 +316,7 @@ public class JSONArray implements Iterable<Object> {
             return new BigInteger(object.toString());
         } catch (Exception e) {
             throw new JSONException("JSONArray[" + index +
-                    "] could not convert to BigInteger.");
+                    "] could not convert to BigInteger.", e);
         }
     }
 
@@ -328,7 +335,7 @@ public class JSONArray implements Iterable<Object> {
             return object instanceof Number ? ((Number) object).intValue()
                     : Integer.parseInt((String) object);
         } catch (Exception e) {
-            throw new JSONException("JSONArray[" + index + "] is not a number.");
+            throw new JSONException("JSONArray[" + index + "] is not a number.", e);
         }
     }
 
@@ -384,7 +391,7 @@ public class JSONArray implements Iterable<Object> {
             return object instanceof Number ? ((Number) object).longValue()
                     : Long.parseLong((String) object);
         } catch (Exception e) {
-            throw new JSONException("JSONArray[" + index + "] is not a number.");
+            throw new JSONException("JSONArray[" + index + "] is not a number.", e);
         }
     }
 
@@ -489,6 +496,7 @@ public class JSONArray implements Iterable<Object> {
         try {
             return this.getBoolean(index);
         } catch (Exception e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return defaultValue;
         }
     }
@@ -521,6 +529,7 @@ public class JSONArray implements Iterable<Object> {
         try {
             return this.getDouble(index);
         } catch (Exception e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return defaultValue;
         }
     }
@@ -553,6 +562,7 @@ public class JSONArray implements Iterable<Object> {
         try {
             return this.getInt(index);
         } catch (Exception e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return defaultValue;
         }
     }
@@ -596,8 +606,10 @@ public class JSONArray implements Iterable<Object> {
             }
             return Enum.valueOf(clazz, val.toString());
         } catch (IllegalArgumentException e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return defaultValue;
         } catch (NullPointerException e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return defaultValue;
         }
     }
@@ -618,6 +630,7 @@ public class JSONArray implements Iterable<Object> {
         try {
             return this.getBigInteger(index);
         } catch (Exception e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return defaultValue;
         }
     }
@@ -637,6 +650,7 @@ public class JSONArray implements Iterable<Object> {
         try {
             return this.getBigDecimal(index);
         } catch (Exception e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return defaultValue;
         }
     }
@@ -696,6 +710,7 @@ public class JSONArray implements Iterable<Object> {
         try {
             return this.getLong(index);
         } catch (Exception e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return defaultValue;
         }
     }
@@ -996,6 +1011,7 @@ public class JSONArray implements Iterable<Object> {
         try {
             return pointer.queryFrom(this);
         } catch (JSONPointerException e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return null;
         }
     }
@@ -1085,6 +1101,7 @@ public class JSONArray implements Iterable<Object> {
         try {
             return this.toString(0);
         } catch (Exception e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return null;
         }
     }

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -41,6 +41,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A JSONObject is an unordered collection of name/value pairs. Its external
@@ -150,6 +152,11 @@ public class JSONObject {
      * <code>JSONObject.NULL.toString()</code> returns <code>"null"</code>.
      */
     public static final Object NULL = new Null();
+    
+    /**
+     * Logger for retrieving otherwise invisible Exceptions.
+     */
+    private static final Logger LOGGER = Logger.getLogger(JSONObject.class.getName());
 
     /**
      * Construct an empty JSONObject.
@@ -174,6 +181,7 @@ public class JSONObject {
             try {
                 this.putOnce(names[i], jo.opt(names[i]));
             } catch (Exception ignore) {
+                LOGGER.log(Level.FINE, ignore.getMessage(), ignore);
             }
         }
     }
@@ -300,6 +308,7 @@ public class JSONObject {
             try {
                 this.putOpt(name, c.getField(name).get(object));
             } catch (Exception ignore) {
+                LOGGER.log(Level.FINE, ignore.getMessage(), ignore);
             }
         }
     }
@@ -540,7 +549,7 @@ public class JSONObject {
             return new BigInteger(object.toString());
         } catch (Exception e) {
             throw new JSONException("JSONObject[" + quote(key)
-                    + "] could not be converted to BigInteger.");
+                    + "] could not be converted to BigInteger.", e);
         }
     }
 
@@ -560,7 +569,7 @@ public class JSONObject {
             return new BigDecimal(object.toString());
         } catch (Exception e) {
             throw new JSONException("JSONObject[" + quote(key)
-                    + "] could not be converted to BigDecimal.");
+                    + "] could not be converted to BigDecimal.", e);
         }
     }
 
@@ -581,7 +590,7 @@ public class JSONObject {
                     : Double.parseDouble((String) object);
         } catch (Exception e) {
             throw new JSONException("JSONObject[" + quote(key)
-                    + "] is not a number.");
+                    + "] is not a number.", e);
         }
     }
 
@@ -602,7 +611,7 @@ public class JSONObject {
                     : Integer.parseInt((String) object);
         } catch (Exception e) {
             throw new JSONException("JSONObject[" + quote(key)
-                    + "] is not an int.");
+                    + "] is not an int.", e);
         }
     }
 
@@ -659,7 +668,7 @@ public class JSONObject {
                     : Long.parseLong((String) object);
         } catch (Exception e) {
             throw new JSONException("JSONObject[" + quote(key)
-                    + "] is not a long.");
+                    + "] is not a long.", e);
         }
     }
 
@@ -903,8 +912,10 @@ public class JSONObject {
             }
             return Enum.valueOf(clazz, val.toString());
         } catch (IllegalArgumentException e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return defaultValue;
         } catch (NullPointerException e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return defaultValue;
         }
     }
@@ -936,6 +947,7 @@ public class JSONObject {
         try {
             return this.getBoolean(key);
         } catch (Exception e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return defaultValue;
         }
     }
@@ -968,6 +980,7 @@ public class JSONObject {
         try {
             return this.getBigInteger(key);
         } catch (Exception e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return defaultValue;
         }
     }
@@ -987,6 +1000,7 @@ public class JSONObject {
         try {
             return this.getBigDecimal(key);
         } catch (Exception e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return defaultValue;
         }
     }
@@ -1006,6 +1020,7 @@ public class JSONObject {
         try {
             return this.getDouble(key);
         } catch (Exception e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return defaultValue;
         }
     }
@@ -1038,6 +1053,7 @@ public class JSONObject {
         try {
             return this.getInt(key);
         } catch (Exception e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return defaultValue;
         }
     }
@@ -1096,6 +1112,7 @@ public class JSONObject {
         try {
             return this.getLong(key);
         } catch (Exception e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return defaultValue;
         }
     }
@@ -1170,6 +1187,7 @@ public class JSONObject {
                     }
                 }
             } catch (Exception ignore) {
+                LOGGER.log(Level.FINE, ignore.getMessage(), ignore);
             }
         }
     }
@@ -1375,6 +1393,7 @@ public class JSONObject {
         try {
             return pointer.queryFrom(this);
         } catch (JSONPointerException e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return null;
         }
     }
@@ -1396,6 +1415,7 @@ public class JSONObject {
                 return quote(string, sw).toString();
             } catch (IOException ignored) {
                 // will never happen - we are writing to a string writer
+                LOGGER.log(Level.FINE, ignored.getMessage(), ignored);
                 return "";
             }
         }
@@ -1507,7 +1527,8 @@ public class JSONObject {
                 }
             }
             return true;
-        } catch (Throwable exception) {
+        } catch (Exception exception) {
+            LOGGER.log(Level.FINE, exception.getMessage(), exception);
             return false;
         }
     }
@@ -1559,6 +1580,7 @@ public class JSONObject {
                     }
                 }
             } catch (Exception ignore) {
+                LOGGER.log(Level.FINE, ignore.getMessage(), ignore);
             }
         }
         return string;
@@ -1627,6 +1649,7 @@ public class JSONObject {
         try {
             return this.toString(0);
         } catch (Exception e) {
+            LOGGER.log(Level.FINE, e.getMessage(), e);
             return null;
         }
     }
@@ -1703,6 +1726,7 @@ public class JSONObject {
             } catch (NumberFormatException ex){
                 // The Number value is not a valid JSON number.
                 // Instead we will quote it as a string
+                LOGGER.log(Level.FINE, ex.getMessage(), ex);
                 return quote(numberAsString);
             }
         }
@@ -1776,6 +1800,7 @@ public class JSONObject {
             }
             return new JSONObject(object);
         } catch (Exception exception) {
+            LOGGER.log(Level.FINE, exception.getMessage(), exception);
             return null;
         }
     }
@@ -1817,6 +1842,7 @@ public class JSONObject {
             } catch (NumberFormatException ex){
                 // The Number value is not a valid JSON number.
                 // Instead we will quote it as a string
+                LOGGER.log(Level.FINE, ex.getMessage(), ex);
                 quote(numberAsString, writer);
             }
         } else if (value instanceof Boolean) {


### PR DESCRIPTION
When possible, just put the original Exception as the cause of thrown
JSONException.
Using log to give possibility to trace other exceptions, with FINE level
so they don't show up in a default configuration (default ConsoleHandler
log from INFO to SEVERE).
Linked to #237 issue.