### PR TITLE
JSONObject.NULL now outputs an empty tag when converting to xml with …

### DIFF
--- a/XML.java
+++ b/XML.java
@@ -378,7 +378,7 @@ public class XML {
                     if (jsonobject.length() > 0) {
                         context.accumulate(tagName, jsonobject);
                     } else {
-                        context.accumulate(tagName, "");
+                        context.accumulate(tagName, JSONObject.NULL);
                     }
                     return false;
 
@@ -533,8 +533,8 @@ public class XML {
             while (keys.hasNext()) {
                 key = keys.next();
                 value = jo.opt(key);
-                if (value == null) {
-                    value = "";
+                if (JSONObject.NULL.equals(value)) {
+                    value = null;
                 } else if (value.getClass().isArray()) {
                     value = new JSONArray(value);
                 }
@@ -553,7 +553,7 @@ public class XML {
                             i++;
                         }
                     } else {
-                        sb.append(escape(value.toString()));
+                        sb.append(escape(String.valueOf(value)));
                     }
 
                     // Emit an array of similar keys
@@ -576,9 +576,19 @@ public class XML {
                 } else if ("".equals(value)) {
                     sb.append('<');
                     sb.append(key);
-                    sb.append("/>");
+                    sb.append('>');
+                    sb.append("</");
+                    sb.append(key);
+                    sb.append('>');
 
                     // Emit a new tag <k>
+
+                } else if (value == null) {
+                    sb.append('<');
+                    sb.append(key);
+                    sb.append("/>");
+
+                    // Emit a new empty tag <k/>
 
                 } else {
                     sb.append(toString(value, key));


### PR DESCRIPTION
This is to address issue #319 

To address @stleary's concerns I will be making a pull request to JSON-Java-unit-test as well with modifications to both XMLTest.shouldHandleNullNodeValue() and JSONObjectTest.jsonObjectNullOperations(). XMLTest.shouldHandleNullNodeValue already had code commented out to test the JSONObject.NULL -> empty xml tag, because this case isn't covered by any other tests I think it's important to modify the test rather than remove it. For the same reason I think modifying JSONObjectTest.jsonObjectNullOperations is the correct move, not to mention that test handles multiple other cases and removing it remove all JSONObject.NULL coverage.

Unfortunately there is some potential to break existing code, though anyone using XML.toString should be able to handle the new empty tags because it's a valid scenario (when the input json has a value that is an empty string) it's possible that some code expects a string of "null" in the instance of null in the json. I suspect that most code that's expecting a string of "null" is to treat it as a null value, but the potential for breakage is still there and should be considered.