### PR TITLE
Numeric enhancements, Refactoring, Fix spelling

### DIFF
--- a/CookieList.java
+++ b/CookieList.java
@@ -39,7 +39,7 @@ public class CookieList {
      * The pairs are separated by ';'. The names and the values
      * will be unescaped, possibly converting '+' and '%' sequences.
      *
-     * To add a cookie to a cooklist,
+     * To add a cookie to a cookie list,
      * cookielistJSONObject.put(cookieJSONObject.getString("name"),
      *     cookieJSONObject.getString("value"));
      * @param string  A cookie list string

--- a/JSONArray.java
+++ b/JSONArray.java
@@ -183,7 +183,7 @@ public class JSONArray implements Iterable<Object> {
 
     @Override
     public Iterator<Object> iterator() {
-        return myArrayList.iterator();
+        return this.myArrayList.iterator();
     }
 
     /**
@@ -1115,6 +1115,7 @@ public class JSONArray implements Iterable<Object> {
      * @return a printable, displayable, transmittable representation of the
      *         array.
      */
+    @Override
     public String toString() {
         try {
             return this.toString(0);
@@ -1124,7 +1125,7 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Make a prettyprinted JSON text of this JSONArray. Warning: This method
+     * Make a pretty-printed JSON text of this JSONArray. Warning: This method
      * assumes that the data structure is acyclical.
      *
      * @param indentFactor
@@ -1166,7 +1167,7 @@ public class JSONArray implements Iterable<Object> {
      * @param indentFactor
      *            The number of spaces to add to each level of indentation.
      * @param indent
-     *            The indention of the top level.
+     *            The indentation of the top level.
      * @return The writer.
      * @throws JSONException
      */

--- a/JSONML.java
+++ b/JSONML.java
@@ -42,7 +42,7 @@ public class JSONML {
      * @param arrayForm true if array form, false if object form.
      * @param ja      The JSONArray that is containing the current tag or null
      *     if we are at the outermost level.
-     * @param keepStrings	Don't type-convert text nodes and attibute values
+     * @param keepStrings	Don't type-convert text nodes and attribute values
      * @return A JSONArray if the value is the outermost tag, otherwise null.
      * @throws JSONException
      */

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -767,9 +767,9 @@ public class JSONObject {
         } else if (value instanceof Long) {
             this.put(key, ((Long) value).longValue() + 1L);
         } else if (value instanceof Double) {
-            this.put(key, ((Double) value).doubleValue() + 1D);
+            this.put(key, ((Double) value).doubleValue() + 1.0d);
         } else if (value instanceof Float) {
-            this.put(key, ((Float) value).floatValue() + 1F);
+            this.put(key, ((Float) value).floatValue() + 1.0f);
         } else {
             throw new JSONException("Unable to increment [" + quote(key) + "].");
         }

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -126,6 +126,15 @@ public class JSONObject {
         public boolean equals(Object object) {
             return object == null || object == this;
         }
+        /**
+         * A Null object is equal to the null value and to itself.
+         *
+         * @return always returns 0.
+         */
+        @Override
+        public int hashCode() {
+            return 0;
+        }
 
         /**
          * Get the "null" string value.
@@ -754,13 +763,13 @@ public class JSONObject {
         } else if (value instanceof BigDecimal) {
             this.put(key, ((BigDecimal)value).add(BigDecimal.ONE));
         } else if (value instanceof Integer) {
-            this.put(key, (Integer) value + 1);
+            this.put(key, ((Integer) value).intValue() + 1);
         } else if (value instanceof Long) {
-            this.put(key, (Long) value + 1);
+            this.put(key, ((Long) value).longValue() + 1L);
         } else if (value instanceof Double) {
-            this.put(key, (Double) value + 1);
+            this.put(key, ((Double) value).doubleValue() + 1D);
         } else if (value instanceof Float) {
-            this.put(key, (Float) value + 1);
+            this.put(key, ((Float) value).floatValue() + 1F);
         } else {
             throw new JSONException("Unable to increment [" + quote(key) + "].");
         }
@@ -887,7 +896,7 @@ public class JSONObject {
      * @param defaultValue
      *            The default in case the value is not found
      * @return The enum value associated with the key or defaultValue
-     *            if the value is not found or cannot be assigned to clazz
+     *            if the value is not found or cannot be assigned to <code>clazz</code>
      */
     public <E extends Enum<E>> E optEnum(Class<E> clazz, String key, E defaultValue) {
         try {
@@ -1218,7 +1227,23 @@ public class JSONObject {
      *             If the key is null or if the number is invalid.
      */
     public JSONObject put(String key, double value) throws JSONException {
-        this.put(key, new Double(value));
+        this.put(key, Double.valueOf(value));
+        return this;
+    }
+    
+    /**
+     * Put a key/float pair in the JSONObject.
+     *
+     * @param key
+     *            A key string.
+     * @param value
+     *            A float which is the value.
+     * @return this.
+     * @throws JSONException
+     *             If the key is null or if the number is invalid.
+     */
+    public JSONObject put(String key, float value) throws JSONException {
+        this.put(key, Float.valueOf(value));
         return this;
     }
 
@@ -1234,7 +1259,7 @@ public class JSONObject {
      *             If the key is null.
      */
     public JSONObject put(String key, int value) throws JSONException {
-        this.put(key, new Integer(value));
+        this.put(key, Integer.valueOf(value));
         return this;
     }
 
@@ -1250,7 +1275,7 @@ public class JSONObject {
      *             If the key is null.
      */
     public JSONObject put(String key, long value) throws JSONException {
-        this.put(key, new Long(value));
+        this.put(key, Long.valueOf(value));
         return this;
     }
 
@@ -1340,7 +1365,7 @@ public class JSONObject {
     }
 
     /**
-     * Creates a JSONPointer using an intialization string and tries to 
+     * Creates a JSONPointer using an initialization string and tries to 
      * match it to an item within this JSONObject. For example, given a
      * JSONObject initialized with this document:
      * <pre>
@@ -1362,7 +1387,7 @@ public class JSONObject {
         return query(new JSONPointer(jsonPointer));
     }
     /**
-     * Uses a uaer initialized JSONPointer  and tries to 
+     * Uses a user initialized JSONPointer  and tries to 
      * match it to an item within this JSONObject. For example, given a
      * JSONObject initialized with this document:
      * <pre>
@@ -1665,7 +1690,7 @@ public class JSONObject {
     }
 
     /**
-     * Make a prettyprinted JSON text of this JSONObject.
+     * Make a pretty-printed JSON text of this JSONObject.
      * <p>
      * Warning: This method assumes that the data structure is acyclical.
      *
@@ -1730,7 +1755,8 @@ public class JSONObject {
             final String numberAsString = numberToString((Number) value);
             try {
                 // Use the BigDecimal constructor for it's parser to validate the format.
-                new BigDecimal(numberAsString);
+                @SuppressWarnings("unused")
+                BigDecimal unused = new BigDecimal(numberAsString);
                 // Close enough to a JSON number that we will return it unquoted
                 return numberAsString;
             } catch (NumberFormatException ex){
@@ -1891,7 +1917,7 @@ public class JSONObject {
      * @param indentFactor
      *            The number of spaces to add to each level of indentation.
      * @param indent
-     *            The indention of the top level.
+     *            The indentation of the top level.
      * @return The writer.
      * @throws JSONException
      */

--- a/JSONPointer.java
+++ b/JSONPointer.java
@@ -68,11 +68,11 @@ public class JSONPointer {
          * {@link #append(String)} method calls.
          */
         public JSONPointer build() {
-            return new JSONPointer(refTokens);
+            return new JSONPointer(this.refTokens);
         }
 
         /**
-         * Adds an arbitary token to the list of reference tokens. It can be any non-null value.
+         * Adds an arbitrary token to the list of reference tokens. It can be any non-null value.
          * 
          * Unlike in the case of JSON string or URI fragment representation of JSON pointers, the
          * argument of this method MUST NOT be escaped. If you want to query the property called
@@ -87,7 +87,7 @@ public class JSONPointer {
             if (token == null) {
                 throw new NullPointerException("token cannot be null");
             }
-            refTokens.add(token);
+            this.refTokens.add(token);
             return this;
         }
 
@@ -99,7 +99,7 @@ public class JSONPointer {
          * @return {@code this}
          */
         public Builder append(int arrayIndex) {
-            refTokens.add(String.valueOf(arrayIndex));
+            this.refTokens.add(String.valueOf(arrayIndex));
             return this;
         }
     }
@@ -134,29 +134,30 @@ public class JSONPointer {
      * @param pointer the JSON String or URI Fragment representation of the JSON pointer.
      * @throws IllegalArgumentException if {@code pointer} is not a valid JSON pointer
      */
-    public JSONPointer(String pointer) {
+    public JSONPointer(final String pointer) {
         if (pointer == null) {
             throw new NullPointerException("pointer cannot be null");
         }
         if (pointer.isEmpty() || pointer.equals("#")) {
-            refTokens = Collections.emptyList();
+            this.refTokens = Collections.emptyList();
             return;
         }
+        String refs;
         if (pointer.startsWith("#/")) {
-            pointer = pointer.substring(2);
+            refs = pointer.substring(2);
             try {
-                pointer = URLDecoder.decode(pointer, ENCODING);
+                refs = URLDecoder.decode(refs, ENCODING);
             } catch (UnsupportedEncodingException e) {
                 throw new RuntimeException(e);
             }
         } else if (pointer.startsWith("/")) {
-            pointer = pointer.substring(1);
+            refs = pointer.substring(1);
         } else {
             throw new IllegalArgumentException("a JSON pointer should start with '/' or '#/'");
         }
-        refTokens = new ArrayList<String>();
-        for (String token : pointer.split("/")) {
-            refTokens.add(unescape(token));
+        this.refTokens = new ArrayList<String>();
+        for (String token : refs.split("/")) {
+            this.refTokens.add(unescape(token));
         }
     }
 
@@ -181,11 +182,11 @@ public class JSONPointer {
      * @throws JSONPointerException if an error occurs during evaluation
      */
     public Object queryFrom(Object document) {
-        if (refTokens.isEmpty()) {
+        if (this.refTokens.isEmpty()) {
             return document;
         }
         Object current = document;
-        for (String token : refTokens) {
+        for (String token : this.refTokens) {
             if (current instanceof JSONObject) {
                 current = ((JSONObject) current).opt(unescape(token));
             } else if (current instanceof JSONArray) {
@@ -206,6 +207,7 @@ public class JSONPointer {
      * @return the matched object. If no matching item is found a
      * JSONPointerException is thrown
      */
+    @SuppressWarnings("boxing")
     private Object readByIndexToken(Object current, String indexToken) {
         try {
             int index = Integer.parseInt(indexToken);
@@ -227,7 +229,7 @@ public class JSONPointer {
     @Override
     public String toString() {
         StringBuilder rval = new StringBuilder("");
-        for (String token: refTokens) {
+        for (String token: this.refTokens) {
             rval.append('/').append(escape(token));
         }
         return rval.toString();
@@ -255,7 +257,7 @@ public class JSONPointer {
     public String toURIFragment() {
         try {
             StringBuilder rval = new StringBuilder("#");
-            for (String token : refTokens) {
+            for (String token : this.refTokens) {
                 rval.append('/').append(URLEncoder.encode(token, ENCODING));
             }
             return rval.toString();

--- a/JSONStringer.java
+++ b/JSONStringer.java
@@ -72,6 +72,7 @@ public class JSONStringer extends JSONWriter {
      * <code>endArray</code>).
      * @return The JSON text.
      */
+    @Override
     public String toString() {
         return this.mode == 'd' ? this.writer.toString() : null;
     }

--- a/JSONWriter.java
+++ b/JSONWriter.java
@@ -149,18 +149,18 @@ public class JSONWriter {
 
     /**
      * End something.
-     * @param mode Mode
+     * @param m Mode
      * @param c Closing character
      * @return this
      * @throws JSONException If unbalanced.
      */
-    private JSONWriter end(char mode, char c) throws JSONException {
-        if (this.mode != mode) {
-            throw new JSONException(mode == 'a'
+    private JSONWriter end(char m, char c) throws JSONException {
+        if (this.mode != m) {
+            throw new JSONException(m == 'a'
                 ? "Misplaced endArray."
                 : "Misplaced endObject.");
         }
-        this.pop(mode);
+        this.pop(m);
         try {
             this.writer.append(c);
         } catch (IOException e) {

--- a/XML.java
+++ b/XML.java
@@ -211,7 +211,7 @@ public class XML {
                             sb.append('<');
                         } else if ("gt".equalsIgnoreCase(entity)) {
                             sb.append('>');
-                        } else {
+                        } else {// unsupported xml entity. leave encoded
                             sb.append('&').append(entity).append(';');
                         }
                     }
@@ -219,7 +219,7 @@ public class XML {
                     i += entity.length() + 1;
                 } else {
                     // this shouldn't happen in most cases since the parser
-                    // errors on unclosed enties.
+                    // errors on unclosed entries.
                     sb.append(c);
                 }
             } else {
@@ -508,7 +508,7 @@ public class XML {
      * @return A string.
      * @throws JSONException Thrown if there is an error parsing the string
      */
-    public static String toString(Object object, String tagName)
+    public static String toString(final Object object, final String tagName)
             throws JSONException {
         StringBuilder sb = new StringBuilder();
         JSONArray ja;
@@ -595,21 +595,19 @@ public class XML {
 
         }
 
-        if (object != null) {
-            if (object.getClass().isArray()) {
-                object = new JSONArray(object);
-            }
-
-            if (object instanceof JSONArray) {
+        if (object != null && (object instanceof JSONArray ||  object.getClass().isArray())) {
+            if(object.getClass().isArray()) {
+                ja = new JSONArray(object);
+            } else {
                 ja = (JSONArray) object;
-                for (Object val : ja) {
-                    // XML does not have good support for arrays. If an array
-                    // appears in a place where XML is lacking, synthesize an
-                    // <array> element.
-                    sb.append(toString(val, tagName == null ? "array" : tagName));
-                }
-                return sb.toString();
             }
+            for (Object val : ja) {
+                // XML does not have good support for arrays. If an array
+                // appears in a place where XML is lacking, synthesize an
+                // <array> element.
+                sb.append(toString(val, tagName == null ? "array" : tagName));
+            }
+            return sb.toString();
         }
 
         string = (object == null) ? "null" : escape(object.toString());


### PR DESCRIPTION
This is mostly cleanup of comments with a few changes to also remove some compile time warnings.

* JSONObject
  * `increment` I replaced the autoboxing calls with explicit accessors and also prevented runtime casting by using the proper long/float/double literals.
  * `Null` I added a hashcode function that explicitly returns 0 everytime, the same as most hash functions when handling null : `return someField == null ? 0 : someField.hashCode();`
  * Added a `put` function for `float`... for some reason we have code that handles floats in multiple places, but no way to directly add them into the JSONObject. Previously these would get converted to `double`
  * Modified the `put(literalNumber)` methods to use the valueOf static instead of always creating new instances.
* JSONPointer
  * Updated class references to be fully qualified with `this.`
  * Updated `constructor` parameters to be final. 
* XML
  * `toString(String, String)` updated parameters to be final

Let me know if I should roll any of the changes back and just keep the comment fixes.