### PR TITLE
Optimizes opt* functions

### DIFF
--- a/JSONArray.java
+++ b/JSONArray.java
@@ -816,8 +816,6 @@ public class JSONArray implements Iterable<Object> {
      *
      * @param index
      *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default.
      * @return An object which is the value.
      */
     public Number optNumber(int index) {
@@ -858,7 +856,7 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the optional string value associated with an index. It returns an
      * empty string if there is no value at that index. If the value is not a
-     * string and is not null, then it is coverted to a string.
+     * string and is not null, then it is converted to a string.
      *
      * @param index
      *            The index must be between 0 and length() - 1.

--- a/JSONArray.java
+++ b/JSONArray.java
@@ -536,7 +536,7 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional double value associated with an index. NaN is returned
+     * Get the optional float value associated with an index. NaN is returned
      * if there is no value for the index, or if the value is not a number and
      * cannot be converted to a number.
      *
@@ -549,7 +549,7 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional double value associated with an index. The defaultValue
+     * Get the optional float value associated with an index. The defaultValue
      * is returned if there is no value for the index, or if the value is not a
      * number and cannot be converted to a number.
      *
@@ -806,6 +806,22 @@ public class JSONArray implements Iterable<Object> {
             }
         }
         return defaultValue;
+    }
+
+    /**
+     * Get an optional {@link Number} value associated with a key, or <code>null</code>
+     * if there is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number ({@link BigDecimal}). This method
+     * would be used in cases where type coercion of the number value is unwanted.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default.
+     * @return An object which is the value.
+     */
+    public Number optNumber(int index) {
+        return this.optNumber(index, null);
     }
 
     /**

--- a/JSONArray.java
+++ b/JSONArray.java
@@ -518,11 +518,63 @@ public class JSONArray implements Iterable<Object> {
      * @return The value.
      */
     public double optDouble(int index, double defaultValue) {
-        try {
-            return this.getDouble(index);
-        } catch (Exception e) {
+        Object val = this.opt(index);
+        if (JSONObject.NULL.equals(val)) {
             return defaultValue;
         }
+        if (val instanceof Number){
+            return ((Number) val).doubleValue();
+        }
+        if (val instanceof String) {
+            try {
+                return new BigDecimal((String) val).doubleValue();
+            } catch (Exception e) {
+                return defaultValue;
+            }
+        }
+        return defaultValue;
+    }
+
+    /**
+     * Get the optional double value associated with an index. NaN is returned
+     * if there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The value.
+     */
+    public float optFloat(int index) {
+        return this.optFloat(index, Float.NaN);
+    }
+
+    /**
+     * Get the optional double value associated with an index. The defaultValue
+     * is returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
+     *
+     * @param index
+     *            subscript
+     * @param defaultValue
+     *            The default value.
+     * @return The value.
+     */
+    public float optFloat(int index, float defaultValue) {
+        Object val = this.opt(index);
+        if (JSONObject.NULL.equals(val)) {
+            return defaultValue;
+        }
+        if (val instanceof Number){
+            return ((Number) val).floatValue();
+        }
+        if (val instanceof String) {
+            try {
+                return new BigDecimal((String) val).floatValue();
+            } catch (Exception e) {
+                return defaultValue;
+            }
+        }
+        return defaultValue;
     }
 
     /**
@@ -550,11 +602,22 @@ public class JSONArray implements Iterable<Object> {
      * @return The value.
      */
     public int optInt(int index, int defaultValue) {
-        try {
-            return this.getInt(index);
-        } catch (Exception e) {
+        Object val = this.opt(index);
+        if (JSONObject.NULL.equals(val)) {
             return defaultValue;
         }
+        if (val instanceof Number){
+            return ((Number) val).intValue();
+        }
+        
+        if (val instanceof String) {
+            try {
+                return new BigDecimal(val.toString()).intValue();
+            } catch (Exception e) {
+                return defaultValue;
+            }
+        }
+        return defaultValue;
     }
 
     /**
@@ -615,8 +678,25 @@ public class JSONArray implements Iterable<Object> {
      * @return The value.
      */
     public BigInteger optBigInteger(int index, BigInteger defaultValue) {
+        Object val = this.opt(index);
+        if (JSONObject.NULL.equals(val)) {
+            return defaultValue;
+        }
+        if (val instanceof BigInteger){
+            return (BigInteger) val;
+        }
+        if (val instanceof BigDecimal){
+            return ((BigDecimal) val).toBigInteger();
+        }
+        if (val instanceof Double || val instanceof Float){
+            return new BigDecimal(((Number) val).doubleValue()).toBigInteger();
+        }
+        if (val instanceof Long || val instanceof Integer
+                || val instanceof Short || val instanceof Byte){
+            return BigInteger.valueOf(((Number) val).longValue());
+        }
         try {
-            return this.getBigInteger(index);
+            return new BigDecimal(val.toString()).toBigInteger();
         } catch (Exception e) {
             return defaultValue;
         }
@@ -634,8 +714,25 @@ public class JSONArray implements Iterable<Object> {
      * @return The value.
      */
     public BigDecimal optBigDecimal(int index, BigDecimal defaultValue) {
+        Object val = this.opt(index);
+        if (JSONObject.NULL.equals(val)) {
+            return defaultValue;
+        }
+        if (val instanceof BigDecimal){
+            return (BigDecimal) val;
+        }
+        if (val instanceof BigInteger){
+            return new BigDecimal((BigInteger) val);
+        }
+        if (val instanceof Double || val instanceof Float){
+            return new BigDecimal(((Number) val).doubleValue());
+        }
+        if (val instanceof Long || val instanceof Integer
+                || val instanceof Short || val instanceof Byte){
+            return new BigDecimal(((Number) val).longValue());
+        }
         try {
-            return this.getBigDecimal(index);
+            return new BigDecimal(val.toString());
         } catch (Exception e) {
             return defaultValue;
         }
@@ -693,11 +790,53 @@ public class JSONArray implements Iterable<Object> {
      * @return The value.
      */
     public long optLong(int index, long defaultValue) {
-        try {
-            return this.getLong(index);
-        } catch (Exception e) {
+        Object val = this.opt(index);
+        if (JSONObject.NULL.equals(val)) {
             return defaultValue;
         }
+        if (val instanceof Number){
+            return ((Number) val).longValue();
+        }
+        
+        if (val instanceof String) {
+            try {
+                return new BigDecimal(val.toString()).longValue();
+            } catch (Exception e) {
+                return defaultValue;
+            }
+        }
+        return defaultValue;
+    }
+
+    /**
+     * Get an optional {@link Number} value associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number ({@link BigDecimal}). This method
+     * would be used in cases where type coercion of the number value is unwanted.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default.
+     * @return An object which is the value.
+     */
+    public Number optNumber(int index, Number defaultValue) {
+        Object val = this.opt(index);
+        if (JSONObject.NULL.equals(val)) {
+            return defaultValue;
+        }
+        if (val instanceof Number){
+            return (Number) val;
+        }
+        
+        if (val instanceof String) {
+            try {
+                return new BigDecimal(val.toString());
+            } catch (Exception e) {
+                return defaultValue;
+            }
+        }
+        return defaultValue;
     }
 
     /**

--- a/JSONArray.java
+++ b/JSONArray.java
@@ -249,6 +249,49 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
+     * Get the float value associated with a key.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The numeric value.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a Number
+     *             object and cannot be converted to a number.
+     */
+    public float getFloat(int index) throws JSONException {
+        Object object = this.get(index);
+        try {
+            return object instanceof Number ? ((Number) object).floatValue()
+                    : Float.parseFloat(object.toString());
+        } catch (Exception e) {
+            throw new JSONException("JSONArray[" + index
+                    + "] is not a number.", e);
+        }
+    }
+
+    /**
+     * Get the Number value associated with a key.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The numeric value.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a Number
+     *             object and cannot be converted to a number.
+     */
+    public Number getNumber(int index) throws JSONException {
+        Object object = this.get(index);
+        try {
+            if (object instanceof Number) {
+                return (Number)object;
+            }
+            return JSONObject.stringToNumber(object.toString());
+        } catch (Exception e) {
+            throw new JSONException("JSONArray[" + index + "] is not a number.");
+        }
+    }
+
+    /**
     * Get the enum value associated with an index.
     * 
     * @param clazz
@@ -266,9 +309,8 @@ public class JSONArray implements Iterable<Object> {
             // JSONException should really take a throwable argument.
             // If it did, I would re-implement this with the Enum.valueOf
             // method and place any thrown exception in the JSONException
-            throw new JSONException("JSONObject[" + JSONObject.quote(Integer.toString(index))
-                    + "] is not an enum of type " + JSONObject.quote(clazz.getSimpleName())
-                    + ".");
+            throw new JSONException("JSONArray[" + index + "] is not an enum of type "
+                    + JSONObject.quote(clazz.getSimpleName()) + ".");
         }
         return val;
     }
@@ -845,7 +887,7 @@ public class JSONArray implements Iterable<Object> {
         
         if (val instanceof String) {
             try {
-                return new BigDecimal(val.toString());
+                return JSONObject.stringToNumber((String) val);
             } catch (Exception e) {
                 return defaultValue;
             }

--- a/JSONArray.java
+++ b/JSONArray.java
@@ -244,7 +244,7 @@ public class JSONArray implements Iterable<Object> {
             return object instanceof Number ? ((Number) object).doubleValue()
                     : Double.parseDouble((String) object);
         } catch (Exception e) {
-            throw new JSONException("JSONArray[" + index + "] is not a number.");
+            throw new JSONException("JSONArray[" + index + "] is not a number.", e);
         }
     }
 
@@ -287,7 +287,7 @@ public class JSONArray implements Iterable<Object> {
             }
             return JSONObject.stringToNumber(object.toString());
         } catch (Exception e) {
-            throw new JSONException("JSONArray[" + index + "] is not a number.");
+            throw new JSONException("JSONArray[" + index + "] is not a number.", e);
         }
     }
 
@@ -331,7 +331,7 @@ public class JSONArray implements Iterable<Object> {
             return new BigDecimal(object.toString());
         } catch (Exception e) {
             throw new JSONException("JSONArray[" + index +
-                    "] could not convert to BigDecimal.");
+                    "] could not convert to BigDecimal.", e);
         }
     }
 
@@ -351,7 +351,7 @@ public class JSONArray implements Iterable<Object> {
             return new BigInteger(object.toString());
         } catch (Exception e) {
             throw new JSONException("JSONArray[" + index +
-                    "] could not convert to BigInteger.");
+                    "] could not convert to BigInteger.", e);
         }
     }
 
@@ -370,7 +370,7 @@ public class JSONArray implements Iterable<Object> {
             return object instanceof Number ? ((Number) object).intValue()
                     : Integer.parseInt((String) object);
         } catch (Exception e) {
-            throw new JSONException("JSONArray[" + index + "] is not a number.");
+            throw new JSONException("JSONArray[" + index + "] is not a number.", e);
         }
     }
 
@@ -426,7 +426,7 @@ public class JSONArray implements Iterable<Object> {
             return object instanceof Number ? ((Number) object).longValue()
                     : Long.parseLong((String) object);
         } catch (Exception e) {
-            throw new JSONException("JSONArray[" + index + "] is not a number.");
+            throw new JSONException("JSONArray[" + index + "] is not a number.", e);
         }
     }
 
@@ -569,7 +569,7 @@ public class JSONArray implements Iterable<Object> {
         }
         if (val instanceof String) {
             try {
-                return new BigDecimal((String) val).doubleValue();
+                return Double.parseDouble((String) val);
             } catch (Exception e) {
                 return defaultValue;
             }
@@ -611,7 +611,7 @@ public class JSONArray implements Iterable<Object> {
         }
         if (val instanceof String) {
             try {
-                return new BigDecimal((String) val).floatValue();
+                return Float.parseFloat((String) val);
             } catch (Exception e) {
                 return defaultValue;
             }

--- a/JSONArray.java
+++ b/JSONArray.java
@@ -738,7 +738,11 @@ public class JSONArray implements Iterable<Object> {
             return BigInteger.valueOf(((Number) val).longValue());
         }
         try {
-            return new BigDecimal(val.toString()).toBigInteger();
+            final String valStr = val.toString();
+            if(JSONObject.isDecimalNotation(valStr)) {
+                return new BigDecimal(valStr).toBigInteger();
+            }
+            return new BigInteger(valStr);
         } catch (Exception e) {
             return defaultValue;
         }

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -1075,8 +1075,8 @@ public class JSONObject {
      * if there is no value for the index, or if the value is not a number and
      * cannot be converted to a number.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param key
+     *            A key string.
      * @return The value.
      */
     public float optFloat(String key) {
@@ -1088,8 +1088,8 @@ public class JSONObject {
      * is returned if there is no value for the index, or if the value is not a
      * number and cannot be converted to a number.
      *
-     * @param index
-     *            subscript
+     * @param key
+     *            A key string.
      * @param defaultValue
      *            The default value.
      * @return The value.

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -1024,14 +1024,12 @@ public class JSONObject {
                 || val instanceof Short || val instanceof Byte){
             return new BigDecimal(((Number) val).longValue());
         }
-        if (val instanceof String) {
-            try {
-                return new BigDecimal((String) val);
-            } catch (Exception e) {
-                return defaultValue;
-            }
+        // don't check if it's a string in case of unchecked Number subclasses
+        try {
+            return new BigDecimal(val.toString());
+        } catch (Exception e) {
+            return defaultValue;
         }
-        return defaultValue;
     }
 
     /**
@@ -1063,19 +1061,17 @@ public class JSONObject {
                 || val instanceof Short || val instanceof Byte){
             return BigInteger.valueOf(((Number) val).longValue());
         }
-        if (val instanceof String) {
-            try {
-                // the other opt functions handle implicit conversions, i.e. 
-                // jo.put("double",1.1d);
-                // jo.optInt("double"); -- will return 1, not an error
-                // this conversion to BigDecimal then to BigInteger is to maintain
-                // that type cast support that may truncate the decimal.
-                return new BigDecimal((String) val).toBigInteger();
-            } catch (Exception e) {
-                return defaultValue;
-            }
+        // don't check if it's a string in case of unchecked Number subclasses
+        try {
+            // the other opt functions handle implicit conversions, i.e. 
+            // jo.put("double",1.1d);
+            // jo.optInt("double"); -- will return 1, not an error
+            // this conversion to BigDecimal then to BigInteger is to maintain
+            // that type cast support that may truncate the decimal.
+            return new BigDecimal(val.toString()).toBigInteger();
+        } catch (Exception e) {
+            return defaultValue;
         }
-        return defaultValue;
     }
 
     /**

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -952,53 +952,6 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional double associated with a key, or NaN if there is no such
-     * key or if its value is not a number. If the value is a string, an attempt
-     * will be made to evaluate it as a number.
-     *
-     * @param key
-     *            A string which is the key.
-     * @return An object which is the value.
-     */
-    public double optDouble(String key) {
-        return this.optDouble(key, Double.NaN);
-    }
-
-    /**
-     * Get an optional BigInteger associated with a key, or the defaultValue if
-     * there is no such key or if its value is not a number. If the value is a
-     * string, an attempt will be made to evaluate it as a number.
-     *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
-     * @return An object which is the value.
-     */
-    public BigInteger optBigInteger(String key, BigInteger defaultValue) {
-        Object val = this.opt(key);
-        if (NULL.equals(val)) {
-            return defaultValue;
-        }
-        if (val instanceof BigInteger){
-            return (BigInteger) val;
-        }
-        if (val instanceof BigDecimal){
-            return ((BigDecimal) val).toBigInteger();
-        }
-        try {
-            // the other opt functions handle implicit conversions, i.e. 
-            // jo.put("double",1.1d);
-            // jo.optInt("double"); -- will return 1, not an error
-            // this conversion to BigDecimal then to BigInteger is to maintain
-            // that type cast support that may truncate the decimal.
-            return new BigDecimal(val.toString()).toBigInteger();
-        } catch (Exception e) {
-            return defaultValue;
-        }
-    }
-
-    /**
      * Get an optional BigDecimal associated with a key, or the defaultValue if
      * there is no such key or if its value is not a number. If the value is a
      * string, an attempt will be made to evaluate it as a number.
@@ -1035,6 +988,60 @@ public class JSONObject {
     }
 
     /**
+     * Get an optional BigInteger associated with a key, or the defaultValue if
+     * there is no such key or if its value is not a number. If the value is a
+     * string, an attempt will be made to evaluate it as a number.
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
+     * @return An object which is the value.
+     */
+    public BigInteger optBigInteger(String key, BigInteger defaultValue) {
+        Object val = this.opt(key);
+        if (NULL.equals(val)) {
+            return defaultValue;
+        }
+        if (val instanceof BigInteger){
+            return (BigInteger) val;
+        }
+        if (val instanceof BigDecimal){
+            return ((BigDecimal) val).toBigInteger();
+        }
+        if (val instanceof Double || val instanceof Float){
+            return new BigDecimal(((Number) val).doubleValue()).toBigInteger();
+        }
+        if (val instanceof Long || val instanceof Integer
+                || val instanceof Short || val instanceof Byte){
+            return BigInteger.valueOf(((Number) val).longValue());
+        }
+        try {
+            // the other opt functions handle implicit conversions, i.e. 
+            // jo.put("double",1.1d);
+            // jo.optInt("double"); -- will return 1, not an error
+            // this conversion to BigDecimal then to BigInteger is to maintain
+            // that type cast support that may truncate the decimal.
+            return new BigDecimal(val.toString()).toBigInteger();
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Get an optional double associated with a key, or NaN if there is no such
+     * key or if its value is not a number. If the value is a string, an attempt
+     * will be made to evaluate it as a number.
+     *
+     * @param key
+     *            A string which is the key.
+     * @return An object which is the value.
+     */
+    public double optDouble(String key) {
+        return this.optDouble(key, Double.NaN);
+    }
+
+    /**
      * Get an optional double associated with a key, or the defaultValue if
      * there is no such key or if its value is not a number. If the value is a
      * string, an attempt will be made to evaluate it as a number.
@@ -1056,6 +1063,48 @@ public class JSONObject {
         if (val instanceof String) {
             try {
                 return new BigDecimal((String) val).doubleValue();
+            } catch (Exception e) {
+                return defaultValue;
+            }
+        }
+        return defaultValue;
+    }
+
+    /**
+     * Get the optional double value associated with an index. NaN is returned
+     * if there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The value.
+     */
+    public float optFloat(String key) {
+        return this.optFloat(key, Float.NaN);
+    }
+
+    /**
+     * Get the optional double value associated with an index. The defaultValue
+     * is returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
+     *
+     * @param index
+     *            subscript
+     * @param defaultValue
+     *            The default value.
+     * @return The value.
+     */
+    public float optFloat(String key, float defaultValue) {
+        Object val = this.opt(key);
+        if (JSONObject.NULL.equals(val)) {
+            return defaultValue;
+        }
+        if (val instanceof Number){
+            return ((Number) val).floatValue();
+        }
+        if (val instanceof String) {
+            try {
+                return new BigDecimal((String) val).floatValue();
             } catch (Exception e) {
                 return defaultValue;
             }
@@ -1168,6 +1217,53 @@ public class JSONObject {
         if (val instanceof String) {
             try {
                 return new BigDecimal(val.toString()).longValue();
+            } catch (Exception e) {
+                return defaultValue;
+            }
+        }
+        return defaultValue;
+    }
+    
+    /**
+     * Get an optional {@link Number} value associated with a key, or <code>null</code>
+     * if there is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number ({@link BigDecimal}). This method
+     * would be used in cases where type coercion of the number value is unwanted.
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
+     * @return An object which is the value.
+     */
+    public Number optNumber(String key) {
+        return this.optNumber(key, null);
+    }
+
+    /**
+     * Get an optional {@link Number} value associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number ({@link BigDecimal}). This method
+     * would be used in cases where type coercion of the number value is unwanted.
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
+     * @return An object which is the value.
+     */
+    public Number optNumber(String key, Number defaultValue) {
+        Object val = this.opt(key);
+        if (NULL.equals(val)) {
+            return defaultValue;
+        }
+        if (val instanceof Number){
+            return (Number) val;
+        }
+        
+        if (val instanceof String) {
+            try {
+                return new BigDecimal(val.toString());
             } catch (Exception e) {
                 return defaultValue;
             }

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -980,11 +980,14 @@ public class JSONObject {
                 || val instanceof Short || val instanceof Byte){
             return new BigDecimal(((Number) val).longValue());
         }
-        try {
-            return new BigDecimal(val.toString());
-        } catch (Exception e) {
-            return defaultValue;
+        if (val instanceof String) {
+            try {
+                return new BigDecimal((String) val);
+            } catch (Exception e) {
+                return defaultValue;
+            }
         }
+        return defaultValue;
     }
 
     /**
@@ -1016,16 +1019,19 @@ public class JSONObject {
                 || val instanceof Short || val instanceof Byte){
             return BigInteger.valueOf(((Number) val).longValue());
         }
-        try {
-            // the other opt functions handle implicit conversions, i.e. 
-            // jo.put("double",1.1d);
-            // jo.optInt("double"); -- will return 1, not an error
-            // this conversion to BigDecimal then to BigInteger is to maintain
-            // that type cast support that may truncate the decimal.
-            return new BigDecimal(val.toString()).toBigInteger();
-        } catch (Exception e) {
-            return defaultValue;
+        if (val instanceof String) {
+            try {
+                // the other opt functions handle implicit conversions, i.e. 
+                // jo.put("double",1.1d);
+                // jo.optInt("double"); -- will return 1, not an error
+                // this conversion to BigDecimal then to BigInteger is to maintain
+                // that type cast support that may truncate the decimal.
+                return new BigDecimal((String) val).toBigInteger();
+            } catch (Exception e) {
+                return defaultValue;
+            }
         }
+        return defaultValue;
     }
 
     /**
@@ -1147,7 +1153,7 @@ public class JSONObject {
         
         if (val instanceof String) {
             try {
-                return new BigDecimal(val.toString()).intValue();
+                return new BigDecimal((String) val).intValue();
             } catch (Exception e) {
                 return defaultValue;
             }
@@ -1216,7 +1222,7 @@ public class JSONObject {
         
         if (val instanceof String) {
             try {
-                return new BigDecimal(val.toString()).longValue();
+                return new BigDecimal((String) val).longValue();
             } catch (Exception e) {
                 return defaultValue;
             }
@@ -1261,7 +1267,7 @@ public class JSONObject {
         
         if (val instanceof String) {
             try {
-                return new BigDecimal(val.toString());
+                return new BigDecimal((String) val);
             } catch (Exception e) {
                 return defaultValue;
             }

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -1020,8 +1020,8 @@ public class JSONObject {
         if (val instanceof BigInteger){
             return new BigDecimal((BigInteger) val);
         }
-        if (val instanceof Double){
-            return new BigDecimal(((Double) val).doubleValue());
+        if (val instanceof Double || val instanceof Float){
+            return new BigDecimal(((Number) val).doubleValue());
         }
         if (val instanceof Long || val instanceof Integer
                 || val instanceof Short || val instanceof Byte){

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -1232,8 +1232,6 @@ public class JSONObject {
      *
      * @param key
      *            A key string.
-     * @param defaultValue
-     *            The default.
      * @return An object which is the value.
      */
     public Number optNumber(String key) {


### PR DESCRIPTION
Adjustments to the opt* functions in reference to #334

Notable changes:
* New API functions for `optFloat(key, default)` and `optFloat(key)`
* New API functions for `optNumber(key, default)` and `optNumber(key)`
* New API functions for `getNumber` and `getFloat`
* Update all opt* functions that relied on the get* function throwing an exception to no longer rely on that.

Test speedup over the old implementation is 870s -> 120s for a 2.1 GB file (about 14% of the time; or 86% time saved). See https://github.com/stleary/JSON-java/pull/337#issuecomment-302104179 and https://github.com/stleary/JSON-java/pull/337#issuecomment-302125122

**What problem does this code solve?**
This is a performance enhancement, not a bug fix. Some code is refactored to prevent exceptions from being thrown. Type coercion is also standardized between all the opt* number functions.

**Risks**
low

**Changes to the API?**
New methods added for `optFloat` and `optNumber`. 

**Will this require a new release?**
No, can be rolled into the next release

**Should the documentation be updated?**
No

**Does it break the unit tests?**
Broke one unit tests for BigDecimal->BigInteger conversion due to updated coercion rules. Tests has been updated and new tests added for new methods `optFloat` and `optNumber`. See https://github.com/stleary/JSON-Java-unit-test/pull/71 for full changes.

**Was any code refactored in this commit?**
Yes

**Review status**
ACCEPTED, Starting 3 day timer for comments