### PR TITLE
Capacity improvements for internal structures

### DIFF
--- a/JSONArray.java
+++ b/JSONArray.java
@@ -154,7 +154,7 @@ public class JSONArray implements Iterable<Object> {
      *            A Collection.
      */
     public JSONArray(Collection<?> collection) {
-        this.myArrayList = new ArrayList<Object>();
+        this.myArrayList = new ArrayList<Object>(collection == null ? 0 : collection.size());
         if (collection != null) {
         	for (Object o: collection){
         		this.myArrayList.add(JSONObject.wrap(o));
@@ -172,6 +172,7 @@ public class JSONArray implements Iterable<Object> {
         this();
         if (array.getClass().isArray()) {
             int length = Array.getLength(array);
+            this.myArrayList.ensureCapacity(length);
             for (int i = 0; i < length; i += 1) {
                 this.put(JSONObject.wrap(Array.get(array, i)));
             }
@@ -495,7 +496,7 @@ public class JSONArray implements Iterable<Object> {
      * Get the optional object value associated with an index.
      *
      * @param index
-     *            The index must be between 0 and length() - 1.
+     *            The index must be between 0 and length() - 1. If not, null is returned.
      * @return An object value, or null if there is no object at that index.
      */
     public Object opt(int index) {
@@ -1150,7 +1151,13 @@ public class JSONArray implements Iterable<Object> {
         }
         if (index < this.length()) {
             this.myArrayList.set(index, value);
+        } else if(index == this.length()){
+            // simple append
+            this.put(value);
         } else {
+            // if we are inserting past the length, we want to grow the array all at once
+            // instead of incrementally.
+            this.myArrayList.ensureCapacity(index + 1);
             while (index != this.length()) {
                 this.put(JSONObject.NULL);
             }
@@ -1302,7 +1309,7 @@ public class JSONArray implements Iterable<Object> {
         if (names == null || names.length() == 0 || this.length() == 0) {
             return null;
         }
-        JSONObject jo = new JSONObject();
+        JSONObject jo = new JSONObject(names.length());
         for (int i = 0; i < names.length(); i += 1) {
             jo.put(names.getString(i), this.opt(i));
         }

--- a/JSONArray.java
+++ b/JSONArray.java
@@ -154,8 +154,10 @@ public class JSONArray implements Iterable<Object> {
      *            A Collection.
      */
     public JSONArray(Collection<?> collection) {
-        this.myArrayList = new ArrayList<Object>(collection == null ? 0 : collection.size());
-        if (collection != null) {
+        if (collection == null) {
+            this.myArrayList = new ArrayList<Object>();
+        } else {
+            this.myArrayList = new ArrayList<Object>(collection.size());
         	for (Object o: collection){
         		this.myArrayList.add(JSONObject.wrap(o));
         	}

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -250,8 +250,10 @@ public class JSONObject {
      *            the JSONObject.
      */
     public JSONObject(Map<?, ?> m) {
-        this.map = new HashMap<String, Object>(m == null ? 0 : m.size());
-        if (m != null) {
+        if (m == null) {
+            this.map = new HashMap<String, Object>();
+        } else {
+            this.map = new HashMap<String, Object>(m.size());
         	for (final Entry<?, ?> e : m.entrySet()) {
                 final Object value = e.getValue();
                 if (value != null) {

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -178,7 +178,7 @@ public class JSONObject {
      *            An array of strings.
      */
     public JSONObject(JSONObject jo, String[] names) {
-        this();
+        this(names.length);
         for (int i = 0; i < names.length; i += 1) {
             try {
                 this.putOnce(names[i], jo.opt(names[i]));
@@ -250,7 +250,7 @@ public class JSONObject {
      *            the JSONObject.
      */
     public JSONObject(Map<?, ?> m) {
-        this.map = new HashMap<String, Object>();
+        this.map = new HashMap<String, Object>(m == null ? 0 : m.size());
         if (m != null) {
         	for (final Entry<?, ?> e : m.entrySet()) {
                 final Object value = e.getValue();
@@ -302,7 +302,7 @@ public class JSONObject {
      *            from the object.
      */
     public JSONObject(Object object, String names[]) {
-        this();
+        this(names.length);
         Class<?> c = object.getClass();
         for (int i = 0; i < names.length; i += 1) {
             String name = names[i];
@@ -370,6 +370,17 @@ public class JSONObject {
                 target.put(path[last], bundle.getString((String) key));
             }
         }
+    }
+    
+    /**
+     * Constructor to specify an initial capacity of the internal map. Useful for library 
+     * internal calls where we know, or at least can best guess, how big this JSONObject
+     * will be.
+     * 
+     * @param initialCapacity initial capacity of the internal map.
+     */
+    protected JSONObject(int initialCapacity){
+        this.map = new HashMap<String, Object>(initialCapacity);
     }
 
     /**

--- a/Property.java
+++ b/Property.java
@@ -41,7 +41,7 @@ public class Property {
      * @throws JSONException
      */
     public static JSONObject toJSONObject(java.util.Properties properties) throws JSONException {
-        JSONObject jo = new JSONObject();
+        JSONObject jo = new JSONObject(properties == null ? 0 : properties.size());
         if (properties != null && !properties.isEmpty()) {
             Enumeration<?> enumProperties = properties.propertyNames();
             while(enumProperties.hasMoreElements()) {


### PR DESCRIPTION
Key Changes:
* Updates array constructor and bulk operations to best guess capacity information
* Update JSONObject to allow best guess for initial capacity for internal operations

**What problem does this code solve?**
For some operations for JSONArray and JSONObject we already know the end-capacity of our internal structures, however, we grow them dynamically instead. This change reduces dynamic growth operations by providing capacity information ahead of time for certain operations.

**Risks**
low. If anything, this should be improvements for both CPU and memory for the cases effected by the change.

**Changes to the API?**
One new protected constructor added to JSONObject to allow specification of the internal hashmap capacity. I didn't feel this was valid as a public constructor as it exposes implementation details of the underlying structure.

**Will this require a new release?**
No, can be rolled into the next release

**Should the documentation be updated?**
No

**Does it break the unit tests?**
No test cases failed on the current master.

**Was any code refactored in this commit?**
Yes

**Review status**
**ACCEPTED** Starting 3 day window