### PR TITLE
Re-throw Runtime exceptions from JavaBean getter methods

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -1429,7 +1429,15 @@ public class JSONObject {
                         }
                     }
                 }
-            } catch (Exception ignore) {
+            } catch (IllegalAccessException ignore) {
+            } catch (InvocationTargetException ex) {
+                // An exception happened during the construction of one of the sub-beans.
+                // If the underlying target exception is a runtime exception, re-throw it...
+                Throwable targetEx = ex.getTargetException();
+                if (targetEx instanceof RuntimeException) {
+                    throw (RuntimeException)targetEx;
+                }
+                // ...otherwise ignore the (checked) exception
             }
         }
     }
@@ -2164,7 +2172,7 @@ public class JSONObject {
                 return object.toString();
             }
             return new JSONObject(object);
-        } catch (Exception exception) {
+        } catch (JSONException exception) {
             return null;
         }
     }


### PR DESCRIPTION
**Summary:** When creating a JSONObject, Runtime exceptions thrown by JavaBean getters are being squelched by populateMap() and wrap().  This version re-throws Runtime exceptions while continuing to squelch checked exceptions (to remain consistent with the current API).

**Scenario:**  Need to create a JSONObject from a simple Java object (POJO/bean) that contains other simple Java objects with getter methods that might throw Runtime exceptions.

**Issue:**  When creating a JSONObject via the "bean" constructor, if the getter methods throw a Runtime exception (e.g., IllegalStateException) those exceptions are squelched by the generic exception handlers in populateMap() and wrap().

**Clarification:**  I agree that traditional getter methods rarely throw exceptions.  Our POJOs are created using a builder pattern with fluid setters - a pattern that has become popular recently.  If the POJOs are still "under construction" (because the final build() method hasn't been called), then the getter methods will throw an IllegalStateException which should be passed back up the chain.  Currently, all getter exceptions are being squelched by two general exception handlers - one in populateMap() and one in wrap().

**Change Details:** The change in populateMap() will pass all underlying Runtime exceptions back up the chain however it will still squelch any _checked_ exceptions that occur since throwing those exceptions would require the API to change (i.e., you'd need to explicitly catch them or declare them to be thrown).

The change in wrap() is to simply squelch JSONExceptions instead of all exceptions.

Clearly, this is a low-priority issue however with the increasing popularity of fluid-style constructors, I thought that this might be worth fixing.

