### PR TITLE
Error message position fixes

### DIFF
--- a/CDL.java
+++ b/CDL.java
@@ -22,7 +22,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-*/
+ */
 
 /**
  * This provides static methods to convert comma delimited text into a
@@ -70,9 +70,12 @@ public class CDL {
                 c = x.next();
                 if (c == q) {
                     //Handle escaped double-quote
-                    if(x.next() != '\"')
-                    {
-                        x.back();
+                    char nextC = x.next();
+                    if(nextC != '\"') {
+                        // if our quote was the end of the file, don't step
+                        if(nextC > 0) {
+                            x.back();
+                        }
                         break;
                     }
                 }

--- a/JSONTokener.java
+++ b/JSONTokener.java
@@ -144,6 +144,8 @@ public class JSONTokener {
     }
 
     /**
+     * Checks if the end of the input has been reached.
+     *  
      * @return true if at the end of the file and we didn't step back
      */
     public boolean end() {
@@ -168,7 +170,8 @@ public class JSONTokener {
             throw new JSONException("Unable to preserve stream position", e);
         }
         try {
-            if(this.reader.read()<0) {
+            // -1 is EOF, but next() can not consume the null character '\0'
+            if(this.reader.read() <= 0) {
                 this.eof = true;
                 return false;
             }

--- a/XMLTokener.java
+++ b/XMLTokener.java
@@ -64,11 +64,8 @@ public class XMLTokener extends JSONTokener {
         char         c;
         int          i;
         StringBuilder sb = new StringBuilder();
-        for (;;) {
+        while (more()) {
             c = next();
-            if (end()) {
-                throw syntaxError("Unclosed CDATA");
-            }
             sb.append(c);
             i = sb.length() - 3;
             if (i >= 0 && sb.charAt(i) == ']' &&
@@ -77,6 +74,7 @@ public class XMLTokener extends JSONTokener {
                 return sb.toString();
             }
         }
+        throw syntaxError("Unclosed CDATA");
     }
 
 
@@ -103,7 +101,10 @@ public class XMLTokener extends JSONTokener {
         }
         sb = new StringBuilder();
         for (;;) {
-            if (c == '<' || c == 0) {
+            if (c == 0) {
+                return sb.toString().trim();
+            }
+            if (c == '<') {
                 back();
                 return sb.toString().trim();
             }


### PR DESCRIPTION
**Key Changes:**
* Fix error message position information to be accurate

**What problem does this code solve?**
Corrects incorrect position information when generating syntax errors in tokeners.

**Risks**
None. The current position information is wildly off in some cases. It's not helpful to anyone trying to debug a failing document.

**Changes to the API?**
none.

**Will this require a new release?**
Yes, this is a bug fix that should probably be corrected as soon as possible

**Should the documentation be updated?**
No

**Does it break the unit tests?**
Yes. The current position information in the XML error messages is wrong/inaccurate. The changes here in regards to the `JSONTokener.more` function have fixed many of the position problems in the old code. Some other pieces of code needed to be updated as well.

See the corrected tests here: https://github.com/stleary/JSON-Java-unit-test/pull/74

**Was any code refactored in this commit?**
Yes. The `JSONToken.more` function was changed to use the mark/reset support in the stream reader instead of stepping forward and backward. This gives us faster checking on `more()` as well as more accurate position information as we aren't moving our index around every time we want to see if there is more information in the stream.

Also, a new field `characterPreviousLine` was added to track the previous line's character count in order to preserve character information when stepping back at a new line mark.

**Review status**
ACCEPTED, starting 3 day comment window.