### PR TITLE
Updates for populateMap based on discussion in #279 and #264

### DIFF
--- a/JSONArray.java
+++ b/JSONArray.java
@@ -1230,7 +1230,7 @@ public class JSONArray implements Iterable<Object> {
      * Queries and returns a value from this object using {@code jsonPointer}, or
      * returns null if the query fails due to a missing key.
      * 
-     * @param The JSON pointer
+     * @param jsonPointer The JSON pointer
      * @return the queried value or {@code null}
      * @throws IllegalArgumentException if {@code jsonPointer} has invalid syntax
      */

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -277,16 +277,19 @@ public class JSONObject {
      * <code>"is"</code> followed by an uppercase letter, the method is invoked,
      * and a key and the value returned from the getter method are put into the
      * new JSONObject.
-     *
+     * <p>
      * The key is formed by removing the <code>"get"</code> or <code>"is"</code>
      * prefix. If the second remaining character is not upper case, then the
      * first character is converted to lower case.
-     *
+     * <p>
      * For example, if an object has a method named <code>"getName"</code>, and
      * if the result of calling <code>object.getName()</code> is
      * <code>"Larry Fine"</code>, then the JSONObject will contain
      * <code>"name": "Larry Fine"</code>.
-     *
+     * <p>
+     * Methods that return <code>void</code> as well as <code>static</code>
+     * methods are ignored.
+     * 
      * @param bean
      *            An object that has getter methods that should be used to make
      *            a JSONObject.
@@ -1389,6 +1392,15 @@ public class JSONObject {
         return NULL.equals(object) ? defaultValue : object.toString();
     }
 
+    /**
+     * Populates the internal map of the JSONObject with the bean properties.
+     * The bean can not be recursive.
+     *
+     * @see JSONObject#JSONObject(Object)
+     *
+     * @param bean
+     *            the bean
+     */
     private void populateMap(Object bean) {
         Class<?> klass = bean.getClass();
 

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -1704,7 +1704,7 @@ public class JSONObject {
      * Queries and returns a value from this object using {@code jsonPointer}, or
      * returns null if the query fails due to a missing key.
      * 
-     * @param The JSON pointer
+     * @param jsonPointer The JSON pointer
      * @return the queried value or {@code null}
      * @throws IllegalArgumentException if {@code jsonPointer} has invalid syntax
      */

--- a/XML.java
+++ b/XML.java
@@ -423,7 +423,7 @@ public class XML {
     }
     
     /**
-     * This method is the same as {@link JSONObject.stringToValue(String)}
+     * This method is the same as {@link JSONObject#stringToValue(String)}
      * except that this also tries to unescape String values.
      * 
      * @param string String to convert


### PR DESCRIPTION
**Key Changes:**

* Updates internal `populateMap` function to be more strict about what methods it calls.

**What problem does this code solve?**
Fixes issues as noted in #279 and #264. Namely, this changes populateMap to now exclude the following:
* Methods that return `void`
* [Bridge methods](https://docs.oracle.com/javase/tutorial/java/generics/bridgeMethods.html)
* Static methods

I also tightened up the exception handling in the private method to only handle the checked exceptions. This should make debugging failed serializations easier as runtime exceptions will be propagated to the caller instead of creating an empty JSONObject.

**Risks**
Low. In general the method types now excluded should generally not be serialized. Even though in #279 it was noted that static should not be included, I did run unto an issue where serializing statics lead to a stack overflow as well.

Also, as noted in multiple places, static properties are considered part of a `class` not an `instance`. References:
* http://javabeginnerstutorial.com/core-java-tutorial/transient-vs-static-variable-java/
* https://stackoverflow.com/questions/11000975/are-static-variables-serialized-in-serialization-process
* https://stackoverflow.com/questions/1008023/how-to-serialize-static-data-members-of-a-java-class

I believe keeping the current implementation of serializing static members would actually lead to unexpected behavior.

The argument @stleary made [here](https://github.com/stleary/JSON-java/issues/279#issuecomment-242755649) for static methods doesn't hold up for me. If a static singleton class needs to be serialized, it should hopefully be easy enough for a developer to handle that as a one off case instead of the norm.

**Changes to the API?**
None

**Will this require a new release?**
No, can be rolled into the next release

**Should the documentation be updated?**
No

**Does it break the unit tests?**
No. All unit tests should pass. New unit tests were created that will fail against the current master, but pass with this PR. See https://github.com/stleary/JSON-Java-unit-test/pull/75

**Was any code refactored in this commit?**
Yes, the private JSONObject.populateMap function

**Review status**
ACCEPTED