### PR TITLE
Provide info about duplicate keys when parsing

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -231,8 +231,12 @@ public class JSONObject {
             if (c != ':') {
                 throw x.syntaxError("Expected a ':' after a key");
             }
-            this.putOnce(key, x.nextValue());
-
+            // Catch exception but re-throw using tokenizer syntaxError(...) - provides info about where the error is located
+            try {
+                this.putOnce(key, x.nextValue());
+            } catch (JSONException _e) {
+                throw x.syntaxError(_e.getMessage());
+            }
             // Pairs are separated by ','.
 
             switch (x.nextClean()) {


### PR DESCRIPTION
Wrap `this.putOnce(...)` to catch `JSONException` when creating `JSONObject` from a `JSONTokener`.
The new exception message will contain the duplicate key name, plus the location of the error.