### PR TITLE
Creating a JSONObject from a string that contains a duplicate key (any level) throws a JSONException that includes location

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -231,7 +231,21 @@ public class JSONObject {
             if (c != ':') {
                 throw x.syntaxError("Expected a ':' after a key");
             }
-            this.putOnce(key, x.nextValue());
+            
+            // Replace: this.putOnce(key, x.nextValue());
+            // Use syntaxError(..) to include error location
+            
+            if (key != null) {
+                // Check if key exists
+            	if (this.opt(key) != null) {
+                    throw x.syntaxError("Duplicate key \"" + key + "\"");
+            	}
+                // Only add value if non-null
+                Object value = x.nextValue();
+                if (value!=null) {
+                	this.put(key, value);
+                }
+            }
 
             // Pairs are separated by ','.
 

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -236,15 +236,15 @@ public class JSONObject {
             
             if (key != null) {
                 // Check if key exists
-            	if (this.opt(key) != null) {
-            		// back one token to point to the last key character
-            		x.back();
+                if (this.opt(key) != null) {
+                    // back one token to point to the last key character
+                    x.back();
                     throw x.syntaxError("Duplicate key \"" + key + "\"");
-            	}
+                }
                 // Only add value if non-null
                 Object value = x.nextValue();
                 if (value!=null) {
-                	this.put(key, value);
+                    this.put(key, value);
                 }
             }
 

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -232,12 +232,13 @@ public class JSONObject {
                 throw x.syntaxError("Expected a ':' after a key");
             }
             
-            // Replace: this.putOnce(key, x.nextValue());
             // Use syntaxError(..) to include error location
             
             if (key != null) {
                 // Check if key exists
             	if (this.opt(key) != null) {
+            		// back one token to point to the last key character
+            		x.back();
                     throw x.syntaxError("Duplicate key \"" + key + "\"");
             	}
                 // Only add value if non-null

--- a/JSONObject.java
+++ b/JSONObject.java
@@ -237,8 +237,7 @@ public class JSONObject {
             if (key != null) {
                 // Check if key exists
                 if (this.opt(key) != null) {
-                    // back one token to point to the last key character
-                    x.back();
+                    // key already exists
                     throw x.syntaxError("Duplicate key \"" + key + "\"");
                 }
                 // Only add value if non-null


### PR DESCRIPTION
Constructor `JSONObject(JSONTokener)` has been updated to provide an error message that includes error location within the source string using local method `syntaxError(String)`.
JUnit test cases has been updated as well (see [`org.json.unit.JSONObjectTest#jsonObjectParsingErrors()`](https://github.com/stleary/JSON-Java-unit-test/pull/78))