### PR TITLE
Fixes XML Unescaping

### DIFF
--- a/JSONML.java
+++ b/JSONML.java
@@ -174,7 +174,7 @@ public class JSONML {
                             if (!(token instanceof String)) {
                                 throw x.syntaxError("Missing value");
                             }
-                            newjo.accumulate(attribute, keepStrings ? XML.unescape((String)token) :XML.stringToValue((String)token));
+                            newjo.accumulate(attribute, keepStrings ? ((String)token) :XML.stringToValue((String)token));
                             token = null;
                         } else {
                             newjo.accumulate(attribute, "");

--- a/XML.java
+++ b/XML.java
@@ -141,7 +141,7 @@ public class XML {
                 if (mustEscape(cp)) {
                     sb.append("&#x");
                     sb.append(Integer.toHexString(cp));
-                    sb.append(";");
+                    sb.append(';');
                 } else {
                     sb.appendCodePoint(cp);
                 }
@@ -191,31 +191,7 @@ public class XML {
                 final int semic = string.indexOf(';', i);
                 if (semic > i) {
                     final String entity = string.substring(i + 1, semic);
-                    if (entity.charAt(0) == '#') {
-                        int cp;
-                        if (entity.charAt(1) == 'x') {
-                            // hex encoded unicode
-                            cp = Integer.parseInt(entity.substring(2), 16);
-                        } else {
-                            // decimal encoded unicode
-                            cp = Integer.parseInt(entity.substring(1));
-                        }
-                        sb.appendCodePoint(cp);
-                    } else {
-                        if ("quot".equalsIgnoreCase(entity)) {
-                            sb.append('"');
-                        } else if ("amp".equalsIgnoreCase(entity)) {
-                            sb.append('&');
-                        } else if ("apos".equalsIgnoreCase(entity)) {
-                            sb.append('\'');
-                        } else if ("lt".equalsIgnoreCase(entity)) {
-                            sb.append('<');
-                        } else if ("gt".equalsIgnoreCase(entity)) {
-                            sb.append('>');
-                        } else {// unsupported xml entity. leave encoded
-                            sb.append('&').append(entity).append(';');
-                        }
-                    }
+                    sb.append(XMLTokener.unescapeEntity(entity));
                     // skip past the entity we just parsed.
                     i += entity.length() + 1;
                 } else {
@@ -364,7 +340,7 @@ public class XML {
                             throw x.syntaxError("Missing value");
                         }
                         jsonobject.accumulate(string,
-                                keepStrings ? unescape((String)token) : stringToValue((String) token));
+                                keepStrings ? ((String)token) : stringToValue((String) token));
                         token = null;
                     } else {
                         jsonobject.accumulate(string, "");
@@ -396,7 +372,7 @@ public class XML {
                             string = (String) token;
                             if (string.length() > 0) {
                                 jsonobject.accumulate("content",
-                                        keepStrings ? unescape(string) : stringToValue(string));
+                                        keepStrings ? string : stringToValue(string));
                             }
 
                         } else if (token == LT) {
@@ -430,11 +406,7 @@ public class XML {
      * @return JSON value of this string or the string
      */
     public static Object stringToValue(String string) {
-        Object ret = JSONObject.stringToValue(string);
-        if(ret instanceof String){
-            return unescape((String)ret);
-        }
-        return ret;
+        return JSONObject.stringToValue(string);
     }
 
     /**

--- a/XMLTokener.java
+++ b/XMLTokener.java
@@ -138,8 +138,37 @@ public class XMLTokener extends JSONTokener {
             }
         }
         String string = sb.toString();
-        Object object = entity.get(string);
-        return object != null ? object : ampersand + string + ";";
+        return unescapeEntity(string);
+    }
+    
+    /**
+     * Unescapes an XML entity encoding;
+     * @param e entity (only the actual entity value, not the preceding & or ending ;
+     * @return
+     */
+    static String unescapeEntity(String e) {
+        // validate
+        if (e == null || e.isEmpty()) {
+            return "";
+        }
+        // if our entity is an encoded unicode point, parse it.
+        if (e.charAt(0) == '#') {
+            int cp;
+            if (e.charAt(1) == 'x') {
+                // hex encoded unicode
+                cp = Integer.parseInt(e.substring(2), 16);
+            } else {
+                // decimal encoded unicode
+                cp = Integer.parseInt(e.substring(1));
+            }
+            return new String(new int[] {cp},0,1);
+        } 
+        Character knownEntity = entity.get(e);
+        if(knownEntity==null) {
+            // we don't know the entity so keep it encoded
+            return '&' + e + ';';
+        }
+        return knownEntity.toString();
     }
 
 


### PR DESCRIPTION
**Key Changes:**

Fixes #361

* Removes unescape from the XML class calls
* fixes bug with unescape method
* moves unescape logic into the XMLTokener class for more consistency

**What problem does this code solve?**
Bug fix for XML Escaping that was included in a2d3b59394d62074debc4903e46c3aa97179172e as part of a fix supporting unicode entities (i.e. `&#xA` which maps to a new line character)

The original fix was causing XML string to be unescaped twice which was also causing the bug as mentioned in #361.

**Risks**
Low/none. This is a bug fix to correct incorrect parsing of XML entities.

**Changes to the API?**
One new package level method was added to `XMLTokener` that handles all valid XML entity unescaping.

**Will this require a new release?**
Yes. The bug affects processing XML documents only, however, the bug prevents valid XML files from being read.

**Should the documentation be updated?**
No

**Does it break the unit tests?**
No. All unit tests should pass. New unit tests were added in order to test the changes and ensure that entities are only unencoded once. See https://github.com/stleary/JSON-Java-unit-test/pull/79

**Was any code refactored in this commit?**
Yes. The actual implementation for the unescapeing was moved from the `XML` class to the `XMLTokener` class.

`XMLTokener` was already unescaping named entities (i.e. `&lt;` to `<` and `&amp;` to `&`) however it was not converting unicode entities back to their codepoints (i.e `&#34` to `"` or `&#x34` to `4`). To compensate for that I originally created the `XML.unescape` method and incorrectly injected it into the XML processing.

This PR corrects that by moving all the entity handling into the `XMLTokener` class and removing the `unescape` injection that I placed into the processing last time.

**Review status**
**APPROVED** Starting 3 day window for comments.