### PR TITLE
Added JSONObject.put for char

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -1589,6 +1589,22 @@ public class JSONObject {
     }
 
     /**
+     * Put a key/char pair in the JSONObject.
+     *
+     * @param key
+     *            A key string.
+     * @param value
+     *            A char which is the value.
+     * @return this.
+     * @throws JSONException
+     *             If the key is null.
+     */
+    public JSONObject put(String key, char value) throws JSONException {
+	    this.put(key, (Character)value);
+        return this;
+    }
+
+    /**
      * Put a key/value pair in the JSONObject. If the value is null, then the
      * key will be removed from the JSONObject if it is present.
      *


### PR DESCRIPTION
JSONObject.put("key", 'x');
   and
JSONObject.put("key", (Character) 'x');

used to give different results.  The first one would treat 'x' as in int.  This code makes them work the same (treat as a character not an int).
