### PR TITLE
Fix for invalid processing of trailing / for JSON Pointer

### DIFF
--- a/JSONPointer.java
+++ b/JSONPointer.java
@@ -158,9 +158,28 @@ public class JSONPointer {
             throw new IllegalArgumentException("a JSON pointer should start with '/' or '#/'");
         }
         this.refTokens = new ArrayList<String>();
-        for (String token : refs.split("/")) {
-            this.refTokens.add(unescape(token));
-        }
+        int slashIdx = -1;
+        int prevSlashIdx = 0;
+        do {
+            prevSlashIdx = slashIdx + 1;
+            slashIdx = refs.indexOf('/', prevSlashIdx);
+            if(prevSlashIdx == slashIdx || prevSlashIdx == refs.length()) {
+                // found 2 slashes in a row ( obj//next )
+                // or single slash at the end of a string ( obj/test/ )
+                this.refTokens.add("");
+            } else if (slashIdx >= 0) {
+                final String token = refs.substring(prevSlashIdx, slashIdx);
+                this.refTokens.add(unescape(token));
+            } else {
+                // last item after separator, or no separator at all.
+                final String token = refs.substring(prevSlashIdx);
+                this.refTokens.add(unescape(token));
+            }
+        } while (slashIdx >= 0);
+        // using split does not take into account consecutive separators or "ending nulls"
+        //for (String token : refs.split("/")) {
+        //    this.refTokens.add(unescape(token));
+        //}
     }
 
     public JSONPointer(List<String> refTokens) {


### PR DESCRIPTION
**What problem does this code solve?**
Fixes #410.  `String.split` does not take into account trailing nulls when splitting. It instead trims them off and they are "lost".

**Risks**
Moderate. This is a bug fix to account for faulty processing of the token string in a JSONPointer expression. There is some change to existing behavior.

**Changes to the API?**
No

**Will this require a new release?**
Yes

**Should the documentation be updated?**
No

**Does it break the unit tests?**
Yes. One test case accidentally had a trailing `/` that causes an error with the corrected code. That test case has been corrected to use the correct JSONPointer expression. There were no unit tests to cover this type of input as expected input. New test cases have been created in https://github.com/stleary/JSON-Java-unit-test/pull/85

**Was any code refactored in this commit?**
Yes. I replaced the String.split call with custom processing of the token string.

**Review status**
**ACCEPTED** 
Changes to existing behavior are not usually accepted, but in this case the new code changes an edge case of a new feature.  For  more information please see the updated Wiki page: https://github.com/stleary/JSON-java/wiki/FAQ#what-kind-of-changes-will-be-accepted-for-this-project