### PR TITLE
fix double ctor in JSONWriter

### DIFF
--- a/JSONWriter.java
+++ b/JSONWriter.java
@@ -391,7 +391,7 @@ public class JSONWriter {
      * @throws JSONException If the number is not finite.
      */
     public JSONWriter value(double d) throws JSONException {
-        return this.value(new Double(d));
+        return this.value(Double.valueOf(d));
     }
 
     /**


### PR DESCRIPTION
This replaces #414 which had a coding standards error (tab instead of spaces). Also just noticed we don't have any coding standards published. Will update the Wiki.