### PR TITLE
Changes NULL handling in XML output

### DIFF
--- a/XML.java
+++ b/XML.java
@@ -591,7 +591,7 @@ public class XML {
             jo = (JSONObject) object;
             for (final String key : jo.keySet()) {
                 Object value = jo.opt(key);
-                if (value == null) {
+                if (JSONObject.NULL.equals(value)) {
                     value = "";
                 } else if (value.getClass().isArray()) {
                     value = new JSONArray(value);

--- a/XML.java
+++ b/XML.java
@@ -356,7 +356,7 @@ public class XML {
                     if (jsonobject.length() > 0) {
                         context.accumulate(tagName, jsonobject);
                     } else {
-                        context.accumulate(tagName, "");
+                        context.accumulate(tagName, JSONObject.NULL);
                     }
                     return false;
 


### PR DESCRIPTION
**What problem does this code solve?**
Adjusts null handling in XML output in reference to #429.

**Risks**
Due to the change in `null`  handling, release notes should be updated to reflect the change in behavior. Previously, `{ "key": null }` would output to `<key>null</key>`. It will now output to `<key/>`. Also,  empty string values `""` would output to `<key/>`, but will now output to `<key></key>`.

**Changes to the API?**
None.

**Will this require a new release?**
Yes

**Should the documentation be updated?**
Yes

**Does it break the unit tests?**
Yes. New unit test are provided in a separate PR (https://github.com/stleary/JSON-Java-unit-test/pull/87)

**Was any code refactored in this commit?**
no

**Review status**
NOT REVIEWED