### PR TITLE
-0 get cast to a string.

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -2186,6 +2186,13 @@ public class JSONObject {
                     }
                 } else {
                     Long myLong = Long.valueOf(string);
+
+                    // If the value is equal to 0 then the prefix of negative should be removed.
+                    if (myLong.equals(0) && string.equals("-0"))
+                    {
+                        return Integer.valueOf(myLong.intValue());
+                    }
+
                     if (string.equals(myLong.toString())) {
                         if (myLong.longValue() == myLong.intValue()) {
                             return Integer.valueOf(myLong.intValue());


### PR DESCRIPTION
When serializing JSONObject {"key": -0.0} to string and then back again will result in a "-0" string.

Based on ECMA-404 -0 is a valid number.