### PR TITLE
In JSONTokener.nextValue(), accepts erroneous values

### DIFF
--- a/JSONTokener.java
+++ b/JSONTokener.java
@@ -444,11 +444,13 @@ public class JSONTokener {
          */
 
         StringBuilder sb = new StringBuilder();
-        while (c >= ' ' && ",:]}/\\\"[{;=#".indexOf(c) < 0) {
+        while (c > ' ' && ",:]}/\\\"[{;=#".indexOf(c) < 0) {
             sb.append(c);
             c = this.next();
         }
-        this.back();
+        if( false == this.eof ) {
+            this.back();
+        }
 
         string = sb.toString().trim();
         if ("".equals(string)) {


### PR DESCRIPTION
This change fixes an issue where the JSONTokener mis-behaves on nextValue() on values close to end of stream, or values with spaces in them.