### PR TITLE
changes number parsing to use BigDecimal as the backing type

### DIFF
--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -75,7 +75,6 @@ import org.json.junit.data.Singleton;
 import org.json.junit.data.SingletonEnum;
 import org.json.junit.data.WeirdList;
 import org.junit.Test;
-import org.junit.Ignore;
 
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
@@ -268,7 +267,7 @@ public class JSONObjectTest {
         assertTrue("expected \"falseKey\":false", Boolean.FALSE.equals(jsonObjectByName.query("/falseKey")));
         assertTrue("expected \"nullKey\":null", JSONObject.NULL.equals(jsonObjectByName.query("/nullKey")));
         assertTrue("expected \"stringKey\":\"hello world!\"", "hello world!".equals(jsonObjectByName.query("/stringKey")));
-        assertTrue("expected \"doubleKey\":-23.45e67", Double.valueOf("-23.45e67").equals(jsonObjectByName.query("/doubleKey")));
+        assertTrue("expected \"doubleKey\":-23.45e67", new BigDecimal("-23.45e67").equals(jsonObjectByName.query("/doubleKey")));
     }
 
     /**
@@ -891,14 +890,14 @@ public class JSONObjectTest {
                 jsonObject.optNumber("intKey") instanceof Integer);
         assertTrue("optNumber long should return Long",
                 jsonObject.optNumber("longKey") instanceof Long);
-        assertTrue("optNumber double should return Double",
-                jsonObject.optNumber("doubleKey") instanceof Double);
+        assertTrue("optNumber double should return BigDecimal",
+                jsonObject.optNumber("doubleKey") instanceof BigDecimal);
         assertTrue("optNumber Str int should return Integer",
                 jsonObject.optNumber("intStrKey") instanceof Integer);
         assertTrue("optNumber Str long should return Long",
                 jsonObject.optNumber("longStrKey") instanceof Long);
-        assertTrue("optNumber Str double should return Double",
-                jsonObject.optNumber("doubleStrKey") instanceof Double);
+        assertTrue("optNumber Str double should return BigDecimal",
+                jsonObject.optNumber("doubleStrKey") instanceof BigDecimal);
         assertTrue("optNumber BigDecimalStrKey should return BigDecimal",
                 jsonObject.optNumber("BigDecimalStrKey") instanceof BigDecimal);
         assertTrue("xKey should not exist",
@@ -933,27 +932,27 @@ public class JSONObjectTest {
         assertTrue("-0.0 Should be a Double!",JSONObject.stringToValue("-0.0") instanceof Double);
         assertTrue("'-' Should be a String!",JSONObject.stringToValue("-") instanceof String);
         assertTrue( "0.2 should be a Double!",
-                JSONObject.stringToValue( "0.2" ) instanceof Double );
-        assertTrue( "Doubles should be Doubles, even when incorrectly converting floats!",
-                JSONObject.stringToValue( new Double( "0.2f" ).toString() ) instanceof Double );
+                JSONObject.stringToValue( "0.2" ) instanceof BigDecimal );
+        assertTrue( "Doubles should be BigDecimal, even when incorrectly converting floats!",
+                JSONObject.stringToValue( new Double( "0.2f" ).toString() ) instanceof BigDecimal );
         /**
          * This test documents a need for BigDecimal conversion.
          */
         Object obj = JSONObject.stringToValue( "299792.457999999984" );
-        assertTrue( "evaluates to 299792.458 double instead of 299792.457999999984 BigDecimal!",
-                 obj.equals(new Double(299792.458)) );
+        assertTrue( "does not evaluate to 299792.457999999984 BigDecimal!",
+                 obj.equals(new BigDecimal("299792.457999999984")) );
         assertTrue( "1 should be an Integer!",
                 JSONObject.stringToValue( "1" ) instanceof Integer );
         assertTrue( "Integer.MAX_VALUE should still be an Integer!",
                 JSONObject.stringToValue( new Integer( Integer.MAX_VALUE ).toString() ) instanceof Integer );
-//        assertTrue( "Large integers should be a Long!",
-//                JSONObject.stringToValue( new Long( Long.sum( Integer.MAX_VALUE, 1 ) ).toString() ) instanceof Long );
+        assertTrue( "Large integers should be a Long!",
+                JSONObject.stringToValue( new Long( Long.sum( Integer.MAX_VALUE, 1 ) ).toString() ) instanceof Long );
         assertTrue( "Long.MAX_VALUE should still be an Integer!",
                 JSONObject.stringToValue( new Long( Long.MAX_VALUE ).toString() ) instanceof Long );
 
         String str = new BigInteger( new Long( Long.MAX_VALUE ).toString() ).add( BigInteger.ONE ).toString();
-        assertTrue( "Really large integers currently evaluate to string",
-                JSONObject.stringToValue(str).equals("9223372036854775808"));
+        assertTrue( "Really large integers currently evaluate to BigInteger",
+                JSONObject.stringToValue(str).equals(new BigInteger("9223372036854775808")));
     }
 
     /**
@@ -974,16 +973,16 @@ public class JSONObjectTest {
         JSONObject jsonObject = new JSONObject(str);
         // Comes back as a double, but loses precision
         assertTrue( "numberWithDecimals currently evaluates to double 299792.458",
-                jsonObject.get( "numberWithDecimals" ).equals( new Double( "299792.458" ) ) );
+                jsonObject.get( "numberWithDecimals" ).equals( new BigDecimal( "299792.457999999984" ) ) );
         Object obj = jsonObject.get( "largeNumber" );
-        assertTrue("largeNumber currently evaluates to string",
-                "12345678901234567890".equals(obj));
+        assertTrue("largeNumber currently evaluates to BigInteger",
+                new BigInteger("12345678901234567890").equals(obj));
         // comes back as a double but loses precision
-        assertTrue( "preciseNumber currently evaluates to double 0.2",
-                jsonObject.get( "preciseNumber" ).equals(new Double(0.2)));
+        assertEquals( "preciseNumber currently evaluates to double 0.2",
+                0.2, jsonObject.getDouble( "preciseNumber" ), 0.0);
         obj = jsonObject.get( "largeExponent" );
-        assertTrue("largeExponent should currently evaluates as a string",
-                "-23.45e2327".equals(obj));
+        assertTrue("largeExponent should evaluate as a BigDecimal",
+                new BigDecimal("-23.45e2327").equals(obj));
     }
 
     /**
@@ -1021,17 +1020,17 @@ public class JSONObjectTest {
         assertTrue( "negativeNaN currently evaluates to string",
                 obj.equals("-NaN"));
         assertTrue( "negativeFraction currently evaluates to double -0.01",
-                jsonObject.get( "negativeFraction" ).equals(new Double(-0.01)));
+                jsonObject.get( "negativeFraction" ).equals(BigDecimal.valueOf(-0.01)));
         assertTrue( "tooManyZerosFraction currently evaluates to double 0.001",
-                jsonObject.get( "tooManyZerosFraction" ).equals(new Double(0.001)));
+                jsonObject.get( "tooManyZerosFraction" ).equals(BigDecimal.valueOf(0.001)));
         assertTrue( "negativeHexFloat currently evaluates to double -3.99951171875",
-                jsonObject.get( "negativeHexFloat" ).equals(new Double(-3.99951171875)));
+                jsonObject.get( "negativeHexFloat" ).equals(Double.valueOf(-3.99951171875)));
         assertTrue("hexFloat currently evaluates to double 4.9E-324",
-                jsonObject.get("hexFloat").equals(new Double(4.9E-324)));
+                jsonObject.get("hexFloat").equals(Double.valueOf(4.9E-324)));
         assertTrue("floatIdentifier currently evaluates to double 0.1",
-                jsonObject.get("floatIdentifier").equals(new Double(0.1)));
+                jsonObject.get("floatIdentifier").equals(Double.valueOf(0.1)));
         assertTrue("doubleIdentifier currently evaluates to double 0.1",
-                jsonObject.get("doubleIdentifier").equals(new Double(0.1)));
+                jsonObject.get("doubleIdentifier").equals(Double.valueOf(0.1)));
     }
 
     /**
@@ -1311,11 +1310,11 @@ public class JSONObjectTest {
          * might inconvenience users.
          */
         obj = JSONObject.stringToValue(bigInteger.toString());
-        assertTrue("stringToValue() turns bigInteger string into string",
-                obj instanceof String);
+        assertTrue("stringToValue() turns bigInteger string into Number",
+                obj instanceof Number);
         obj = JSONObject.stringToValue(bigDecimal.toString());
-        assertTrue("stringToValue() changes bigDecimal string",
-                !obj.toString().equals(bigDecimal.toString()));
+        assertTrue("stringToValue() changes bigDecimal Number",
+                obj instanceof Number);
 
         /**
          * wrap() vs put() big number behavior is now the same.
@@ -1580,7 +1579,7 @@ public class JSONObjectTest {
         assertTrue("expected 6 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 6);
         assertTrue("expected 3", Integer.valueOf(3).equals(jsonObject.query("/keyInt")));
         assertTrue("expected 9999999993", Long.valueOf(9999999993L).equals(jsonObject.query("/keyLong")));
-        assertTrue("expected 3.1", Double.valueOf(3.1).equals(jsonObject.query("/keyDouble")));
+        assertTrue("expected 3.1", BigDecimal.valueOf(3.1).equals(jsonObject.query("/keyDouble")));
         assertTrue("expected 123456789123456789123456789123456781", new BigInteger("123456789123456789123456789123456781").equals(jsonObject.query("/keyBigInt")));
         assertTrue("expected 123456789123456789123456789123456781.1", new BigDecimal("123456789123456789123456789123456781.1").equals(jsonObject.query("/keyBigDec")));
 
@@ -2083,7 +2082,7 @@ public class JSONObjectTest {
     /**
      * Explore how JSONObject handles parsing errors.
      */
-    @SuppressWarnings("boxing")
+    @SuppressWarnings({"boxing", "unused"})
     @Test
     public void jsonObjectParsingErrors() {
         try {
@@ -2629,14 +2628,11 @@ public class JSONObjectTest {
         String str = "{\"key1\":\"value1\",\"key2\":[1,2,3]}";
         String expectedStr = str;
         JSONObject jsonObject = new JSONObject(str);
-        StringWriter stringWriter = new StringWriter();
-        try {
+        try (StringWriter stringWriter = new StringWriter()) {
             String actualStr = jsonObject.write(stringWriter).toString();
             assertTrue("write() expected " +expectedStr+
                     " but found " +actualStr,
                     expectedStr.equals(actualStr));
-        } finally {
-            stringWriter.close();
         }
     }
     
@@ -2739,21 +2735,15 @@ public class JSONObjectTest {
                 " }";
         JSONObject jsonObject = new JSONObject(str0);
         String expectedStr = str0;
-        StringWriter stringWriter = new StringWriter();
-        try {
+        try (StringWriter stringWriter = new StringWriter();) {
             String actualStr = jsonObject.write(stringWriter,0,0).toString();
             assertEquals(expectedStr, actualStr);
-        } finally {
-            stringWriter.close();
         }
 
         expectedStr = str2;
-        stringWriter = new StringWriter();
-        try {
+        try (StringWriter stringWriter = new StringWriter();) {
             String actualStr = jsonObject.write(stringWriter,2,1).toString();
             assertEquals(expectedStr, actualStr);
-        } finally {
-            stringWriter.close();
         }
     }
 
@@ -2965,7 +2955,7 @@ public class JSONObjectTest {
         assertTrue("key3 list val 1 should not be null", key3Val1List != null);
         assertTrue("key3 list val 1 should have 2 elements", key3Val1List.size() == 2);
         assertTrue("key3 list val 1 list element 1 should be value1", key3Val1List.get(0).equals("value1"));
-        assertTrue("key3 list val 1 list element 2 should be 2.1", key3Val1List.get(1).equals(Double.valueOf("2.1")));
+        assertTrue("key3 list val 1 list element 2 should be 2.1", key3Val1List.get(1).equals(new BigDecimal("2.1")));
 
         List<?> key3Val2List = (List<?>)key3List.get(1);
         assertTrue("key3 list val 2 should not be null", key3Val2List != null);
@@ -2984,8 +2974,7 @@ public class JSONObjectTest {
     /**
      * test that validates a singleton can be serialized as a bean.
      */
-    // @todo: investigate, re-enable this test
-    @Ignore
+    @SuppressWarnings("boxing")
     @Test
     public void testSingletonBean() {
         final JSONObject jo = new JSONObject(Singleton.getInstance());
@@ -3009,8 +2998,7 @@ public class JSONObjectTest {
     /**
      * test that validates a singleton can be serialized as a bean.
      */
-    // @todo: investigate, re-enable this test
-    @Ignore
+    @SuppressWarnings("boxing")
     @Test
     public void testSingletonEnumBean() {
         final JSONObject jo = new JSONObject(SingletonEnum.getInstance());
@@ -3034,6 +3022,7 @@ public class JSONObjectTest {
     /**
      * Test to validate that a generic class can be serialized as a bean.
      */
+    @SuppressWarnings("boxing")
     @Test
     public void testGenericBean() {
         GenericBean<Integer> bean = new GenericBean<>(42);
@@ -3048,6 +3037,7 @@ public class JSONObjectTest {
     /**
      * Test to validate that a generic class can be serialized as a bean.
      */
+    @SuppressWarnings("boxing")
     @Test
     public void testGenericIntBean() {
         GenericBeanInt bean = new GenericBeanInt(42);
@@ -3064,6 +3054,7 @@ public class JSONObjectTest {
      */
     @Test
     public void testWierdListBean() {
+        @SuppressWarnings("boxing")
         WeirdList bean = new WeirdList(42, 43, 44);
         final JSONObject jo = new JSONObject(bean);
         // get() should have a key of 0 length

--- a/src/test/java/org/json/junit/JSONPointerTest.java
+++ b/src/test/java/org/json/junit/JSONPointerTest.java
@@ -29,7 +29,6 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.IOException;
 import java.io.InputStream;
 
 import org.json.JSONArray;
@@ -61,6 +60,7 @@ public class JSONPointerTest {
         assertSame(document, query(""));
     }
 
+    @SuppressWarnings("unused")
     @Test(expected = NullPointerException.class)
     public void nullPointer() {
         new JSONPointer((String) null);
@@ -150,6 +150,7 @@ public class JSONPointerTest {
         assertSame(document.get("m~n"), query("#/m~0n"));
     }
 
+    @SuppressWarnings("unused")
     @Test(expected = IllegalArgumentException.class)
     public void syntaxError() {
         new JSONPointer("key");

--- a/src/test/java/org/json/junit/JSONStringTest.java
+++ b/src/test/java/org/json/junit/JSONStringTest.java
@@ -26,7 +26,6 @@ SOFTWARE.
 
 import static org.junit.Assert.*;
 
-import java.io.IOException;
 import java.io.StringWriter;
 import java.util.*;
 
@@ -50,105 +49,84 @@ public class JSONStringTest {
         JSONArray jsonArray = new JSONArray();
         jsonArray.put((Object)null);
 
-        StringWriter writer = new StringWriter();
-        try {
+        try (StringWriter writer = new StringWriter();) {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[null]".equals(output));
     
             jsonArray = new JSONArray();
             jsonArray.put(JSONObject.NULL);
-        } finally {
-            writer.close();
         }
-        writer = new StringWriter();
-        try {
+
+        try (StringWriter writer = new StringWriter();) {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[null]".equals(output));
     
             jsonArray = new JSONArray();
             jsonArray.put(new JSONObject());
-        } finally {
-            writer.close();
         }
-        writer = new StringWriter();
-        try {
+        
+        try (StringWriter writer = new StringWriter();) {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[{}]".equals(output));
     
             jsonArray = new JSONArray();
             jsonArray.put(new JSONArray());
-        } finally {
-            writer.close();
         }
-        writer = new StringWriter();
-        try {
+
+        try (StringWriter writer = new StringWriter();) {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[[]]".equals(output));
     
             jsonArray = new JSONArray();
             Map<?,?> singleMap = Collections.singletonMap("key1", "value1");
             jsonArray.put((Object)singleMap);
-        } finally {
-            writer.close();
         }
-        writer = new StringWriter();
-        try {
+        
+        try (StringWriter writer = new StringWriter();) {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[{\"key1\":\"value1\"}]".equals(output));
     
             jsonArray = new JSONArray();
             List<?> singleList = Collections.singletonList("entry1");
             jsonArray.put((Object)singleList);
-        } finally {
-            writer.close();
         }
-        writer = new StringWriter();
-        try {
+
+        try (StringWriter writer = new StringWriter();) {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[[\"entry1\"]]".equals(output));
     
             jsonArray = new JSONArray();
             int[] intArray = new int[] { 1, 2, 3 };
             jsonArray.put(intArray);
-        } finally {
-            writer.close();
         }
-        writer = new StringWriter();
-        try {
+
+        try (StringWriter writer = new StringWriter();) {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[[1,2,3]]".equals(output));
     
             jsonArray = new JSONArray();
             jsonArray.put(24);
-        } finally {
-            writer.close();
         }
-        writer = new StringWriter();
-        try {
+        
+        try (StringWriter writer = new StringWriter();) {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[24]".equals(output));
     
             jsonArray = new JSONArray();
             jsonArray.put("string value");
-        } finally {
-            writer.close();
         }
-        writer = new StringWriter();
-        try {
+
+        try (StringWriter writer = new StringWriter();) {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[\"string value\"]".equals(output));
     
             jsonArray = new JSONArray();
             jsonArray.put(true);
-        } finally {
-            writer.close();
         }
-        writer = new StringWriter();
-        try {
+
+        try (StringWriter writer = new StringWriter();) {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[true]".equals(output));
-        } finally {
-            writer.close();
         }
 
     }
@@ -207,15 +185,13 @@ public class JSONStringTest {
 
         jsonArray.put(jsonString);
 
-        StringWriter writer = new StringWriter();
-        try {
+        
+        try (StringWriter writer = new StringWriter();) {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[\"the JSON string value\"]".equals(output));
     
             output = JSONObject.valueToString(jsonString);
             assertTrue("String values should be equal", "\"the JSON string value\"".equals(output));
-        } finally {
-            writer.close();
         }
     }
 
@@ -230,8 +206,7 @@ public class JSONStringTest {
 
         jsonArray.put(jsonString);
 
-        StringWriter writer = new StringWriter();
-        try {
+        try (StringWriter writer = new StringWriter();) {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[\"the toString value\"]".equals(output));
     
@@ -244,8 +219,6 @@ public class JSONStringTest {
                 assertTrue("Expected JSONException", e instanceof JSONException);
                 assertTrue("Exception message does not match", "Bad value from toJSONString: null".equals(e.getMessage()));
             }
-        } finally {
-            writer.close();
         }
     }
 
@@ -255,22 +228,19 @@ public class JSONStringTest {
      * the original exception.
      */
     @Test
-    public void testJSONStringExceptionValue() throws IOException {
+    public void testJSONStringExceptionValue() {
         JSONStringExceptionValue jsonString = new JSONStringExceptionValue();
         JSONArray jsonArray = new JSONArray();
 
         jsonArray.put(jsonString);
 
-        StringWriter writer = new StringWriter();
-        try {
+        try (StringWriter writer = new StringWriter();) {
             jsonArray.write(writer).toString();
             fail("Expected an exception, got a String value");
         } catch (JSONException e) {
             assertEquals("Unable to write JSONArray value at index: 0", e.getMessage());
         } catch(Exception e) {
             fail("Expected JSONException");
-        } finally {
-            writer.close();
         }
 
         try {
@@ -294,15 +264,12 @@ public class JSONStringTest {
 
         jsonArray.put(nonJsonString);
 
-        StringWriter writer = new StringWriter();
-        try {
+        try (StringWriter writer = new StringWriter();) {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[\"the toString value for StringValue\"]".equals(output));
     
             output = JSONObject.valueToString(nonJsonString);
             assertTrue("String values should be equal", "\"the toString value for StringValue\"".equals(output));
-        } finally {
-            writer.close();
         }
     }
 
@@ -317,15 +284,13 @@ public class JSONStringTest {
 
         jsonArray.put(nonJsonString);
 
-        StringWriter writer = new StringWriter();
-        try {
+        
+        try (StringWriter writer = new StringWriter();) {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[\"\"]".equals(output));
     
             output = JSONObject.valueToString(nonJsonString);
             assertTrue("String values should be equal", "\"\"".equals(output));
-        } finally {
-            writer.close();
         }
     }
 

--- a/src/test/java/org/json/junit/JSONStringerTest.java
+++ b/src/test/java/org/json/junit/JSONStringerTest.java
@@ -26,6 +26,7 @@ SOFTWARE.
 
 import static org.junit.Assert.*;
 
+import java.math.BigDecimal;
 import java.util.*;
 
 import org.json.*;
@@ -269,7 +270,7 @@ public class JSONStringerTest {
         assertTrue("expected hello world!", "hello world!".equals(jsonObject.query("/stringValue")));
         assertTrue("expected h\be\tllo w\u1234orld!", "h\be\tllo w\u1234orld!".equals(jsonObject.query("/complexStringValue")));
         assertTrue("expected 42", Integer.valueOf(42).equals(jsonObject.query("/intValue")));
-        assertTrue("expected -23.45e67", Double.valueOf(-23.45e67).equals(jsonObject.query("/doubleValue")));
+        assertTrue("expected -23.45e67", BigDecimal.valueOf(-23.45e67).equals(jsonObject.query("/doubleValue")));
     }
 
     /**
@@ -298,7 +299,7 @@ public class JSONStringerTest {
         assertTrue("expected null", JSONObject.NULL.equals(jsonArray.query("/2")));
         assertTrue("expected hello world!", "hello world!".equals(jsonArray.query("/3")));
         assertTrue("expected 42", Integer.valueOf(42).equals(jsonArray.query("/4")));
-        assertTrue("expected -23.45e67", Double.valueOf(-23.45e67).equals(jsonArray.query("/5")));
+        assertTrue("expected -23.45e67", BigDecimal.valueOf(-23.45e67).equals(jsonArray.query("/5")));
     }
 
     /**
@@ -355,7 +356,7 @@ public class JSONStringerTest {
         assertTrue("expected null", JSONObject.NULL.equals(jsonObject.query("/nullValue")));
         assertTrue("expected hello world!", "hello world!".equals(jsonObject.query("/stringValue")));
         assertTrue("expected 42", Integer.valueOf(42).equals(jsonObject.query("/intValue")));
-        assertTrue("expected -23.45e67", Double.valueOf(-23.45e67).equals(jsonObject.query("/doubleValue")));
+        assertTrue("expected -23.45e67", BigDecimal.valueOf(-23.45e67).equals(jsonObject.query("/doubleValue")));
         assertTrue("expected h\be\tllo w\u1234orld!", "h\be\tllo w\u1234orld!".equals(jsonObject.query("/complexStringValue")));
         assertTrue("expected v1", "v1".equals(jsonObject.query("/object2/k1")));
         assertTrue("expected v2", "v2".equals(jsonObject.query("/object2/k2")));

--- a/src/test/java/org/json/junit/data/ExceptionalBean.java
+++ b/src/test/java/org/json/junit/data/ExceptionalBean.java
@@ -7,8 +7,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 
-import org.json.JSONObject;
-
 /**
  * Object for testing the exception handling in {@link JSONObject#populateMap}.
  * 
@@ -56,7 +54,6 @@ public class ExceptionalBean {
         /**
          * @return a string
          */
-        @SuppressWarnings("unused")
         public String getString() {
             return "Yup, it's closeable";
         }

--- a/src/test/java/org/json/junit/data/MyEnumClass.java
+++ b/src/test/java/org/json/junit/data/MyEnumClass.java
@@ -8,13 +8,13 @@ public class MyEnumClass {
     private MyEnumField myEnumField;
 
     public MyEnum getMyEnum() {
-        return myEnum;
+        return this.myEnum;
     }
     public void setMyEnum(MyEnum myEnum) {
         this.myEnum = myEnum;
     }
     public MyEnumField getMyEnumField() {
-        return myEnumField;
+        return this.myEnumField;
     }
     public void setMyEnumField(MyEnumField myEnumField) {
         this.myEnumField = myEnumField;

--- a/src/test/java/org/json/junit/data/MyLocaleBean.java
+++ b/src/test/java/org/json/junit/data/MyLocaleBean.java
@@ -4,9 +4,9 @@ public class MyLocaleBean {
     private final String id = "beanId";
     private final String i = "beanI";
     public String getId() {
-        return id;
+        return this.id;
     }
     public String getI() {
-        return i;
+        return this.i;
     }
 }

--- a/src/test/java/org/json/junit/data/Singleton.java
+++ b/src/test/java/org/json/junit/data/Singleton.java
@@ -33,7 +33,7 @@ public final class Singleton {
 
     /** @return someInt */
     public int getSomeInt() {
-        return someInt;
+        return this.someInt;
     }
 
     /**
@@ -48,7 +48,7 @@ public final class Singleton {
 
     /** @return someString */
     public String getSomeString() {
-        return someString;
+        return this.someString;
     }
 
     /**
@@ -65,8 +65,8 @@ public final class Singleton {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + someInt;
-        result = prime * result + ((someString == null) ? 0 : someString.hashCode());
+        result = prime * result + this.someInt;
+        result = prime * result + ((this.someString == null) ? 0 : this.someString.hashCode());
         return result;
     }
 
@@ -79,12 +79,12 @@ public final class Singleton {
         if (getClass() != obj.getClass())
             return false;
         Singleton other = (Singleton) obj;
-        if (someInt != other.someInt)
+        if (this.someInt != other.someInt)
             return false;
-        if (someString == null) {
+        if (this.someString == null) {
             if (other.someString != null)
                 return false;
-        } else if (!someString.equals(other.someString))
+        } else if (!this.someString.equals(other.someString))
             return false;
         return true;
     }

--- a/src/test/java/org/json/junit/data/SingletonEnum.java
+++ b/src/test/java/org/json/junit/data/SingletonEnum.java
@@ -19,7 +19,7 @@ public enum SingletonEnum {
     /** single instance. */
 
     /**
-     * @return the singleton instance. I a real application, I'd hope no one did
+     * @return the singleton instance. In a real application, I'd hope no one did
      *         this to an enum singleton.
      */
     public static final SingletonEnum getInstance() {
@@ -32,7 +32,7 @@ public enum SingletonEnum {
 
     /** @return someInt */
     public int getSomeInt() {
-        return someInt;
+        return this.someInt;
     }
 
     /**
@@ -47,7 +47,7 @@ public enum SingletonEnum {
 
     /** @return someString */
     public String getSomeString() {
-        return someString;
+        return this.someString;
     }
 
     /**

--- a/src/test/java/org/json/junit/data/WeirdList.java
+++ b/src/test/java/org/json/junit/data/WeirdList.java
@@ -53,6 +53,7 @@ public class WeirdList {
      *            index to get
      * @return the value at the index
      */
+    @SuppressWarnings("boxing")
     public int getInt(int i) {
         return this.list.get(i);
     }


### PR DESCRIPTION
**What problem does this code solve?**
See issue #441 (use BigDecimal for underlying storage of decimal number types)

**Risks**
Medium

**Changes to the API?**
No, but it changes how certain API calls work for decimal/floating-point types work.

for example a JSON document list this:
```json
{ "float":1234 }
```
would parse like this:
```java
JSONObject jo = new JSONObject("{\"float\":1234}");
jo.get("float"); // used to return a Double, now returns a BigDecimal
jo.getDouble("float"); // still returns the value/object as in the old version (Double)
```
In general, the raw "get/opt" methods with no type information (like getDouble, getInt, optDouble, etc) are not guaranteed to be useful as the backing types were never guaranteed. However, people may be using them without the knowledge that the backing types are semi-dynamic (i.e. number types have always been backed differently if an `Integer` was parsed vs a `float`). So even a "standard" document like this:
```json
{
"items": [
 { "floatValue": 123.4 },
 { "floatValue": 321 }
]
}
```
Would have a `Double` stored for the first `floatValue` and an `Integer` for the second `floatValue` before the change. After the change they would be stored as `BigDecimal` and `Integer` respectively.

**Will this require a new release?**
Yes.

**Should the documentation be updated?**
Yes. we should probably mention that the backing type has changed and how that may affect existing code.

**Does it break the unit tests?**
Yes, many of the tests depend on the data type stored for numbers. The tests have been updated to reflect the new backing type.

**Was any code refactored in this commit?**
Yes, changes were made to the number parsing methods for XML and JSONObject (they need to be kept in sync for Android support)

**Review status**
**APPROVED**