### PR TITLE
JSONObject constructor with custom map supplier

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -98,7 +98,7 @@ import java.util.regex.Pattern;
  * </ul>
  *
  * @author JSON.org
- * @version 2016-08-15
+ * @version 2019-07-01
  */
 public class JSONObject {
     /**
@@ -182,6 +182,21 @@ public class JSONObject {
         // retrieval based on associative access.
         // Therefore, an implementation mustn't rely on the order of the item.
         this.map = new HashMap<String, Object>();
+    }
+    
+    /**
+     * Construct an emtpy JSONObject with a user-defined factory function for the object's property map.
+     * The caller can choose the map implementation by passing a map supplier which should always create a new, empty map. 
+     * This may be used especially to influence the iteration order of {@link #keySet()} or {@link #toString(int)}'s output:
+     * By choosing a sorted map, the output will be ordered by key.
+     * By choosing a linked map, the output will be in insertion order (oder of put calls).
+     * <p>Example call with Java 8 function reference syntax:
+     * <code>JSONObject o = new JSONObject(LinkedHashMap::new);</code>
+     * <p>In Java 6 and 7 you'll need to create a class implementing the MapSupplier interface instead (which may be an anonymous inner class).</p>
+     * @param mapSupplier Supplier for a new map, typically a method reference to a constructor or factory method.
+     */
+    public JSONObject(MapSupplier mapSupplier) {
+        this.map = mapSupplier.get();
     }
 
     /**

--- a/MapSupplier.java
+++ b/MapSupplier.java
@@ -1,0 +1,20 @@
+package org.json;
+
+import java.util.Map;
+
+/**
+ * Interface for a map supplier which may be passed to {@link JSONObject#JSONObject(org.json.MapSupplier) }.
+ * Basically a non-generic version (with fixed return type {@code Map<String, Object>}) of java.util.function.Supplier which has been introduced in Java 8.
+ * This local interface has been created in order to maintain backwards compatibility with Java 6 and 7.
+ * @author JSON.org
+ * @version 2019-07-01
+ */
+public interface MapSupplier {
+    
+    /**
+     * Returns a new, empty map for storing any Objects with keys of type String.
+     * @return new, empty map of a desired implementation class
+     */
+    Map<String, Object> get();
+    
+}


### PR DESCRIPTION
Added a constructor for JSONObject allowing the user to choose the Map implementation (instead of the default HashMap).
By choice of map implementations like LinkedHashMap or some sorted map the user can influence the iteration order and thus especially the order of the toString-methods' output. While this is not important for machine-readable JSON, for a pretty-printed, human-readable JSON created by #toString(int) (probably meant for humans to edit the data), a custom order may increase readability and maintainability of the generated code.

# Background
I needed to create JSON files which should be easily readable and editable by humans. The JSON should meet two criteria:

* It should be pretty-printed, and
* the properties of certain JSON objects should be printed in a certain order.

While the JSONStringer outputs all properties in the order of the .key().value()-calls, it does not support pretty printing. The alternative is to create JSONObjects with the default constructor, add properties by its put() methods and then call the toString(int) method, which performs pretty-printing – but the default HashMap container of JSONObject does not support outputting the properties in insertion order (order of the put() calls).

That's why I added a possibility to create a new, empty JSONObject with a new constructor allowing to select a different Map implementation, like a SortedMap oder a LinkedMap (the latter preserving insertion order, which is precisely what I needed).

Instead of passing a newly created map as parameter I decided to use a supplier argument in order to reduce the risk that the caller passes a non-empty map or retains a reference to the created map, enabling him to manipulate it other than by the JSONObject's methods. Also, a new constructor with a Map argument would have clashed with the existing one taking a map and putting all it's content into a new internal HashMap.

Normally I'd have used `java.util.function.Supplier<Map<String, Object>>` as argument type, but since that would have meant to drop support for Java 1.6 and 1.7, I instead introduced a new (functional) interface.