### PR TITLE
Make private methods static where possible

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -1496,11 +1496,11 @@ public class JSONObject {
         }
     }
 
-    private boolean isValidMethodName(String name) {
+    private static boolean isValidMethodName(String name) {
         return !"getClass".equals(name) && !"getDeclaringClass".equals(name);
     }
 
-    private String getKeyNameFromMethod(Method method) {
+    private static String getKeyNameFromMethod(Method method) {
         final int ignoreDepth = getAnnotationDepth(method, JSONPropertyIgnore.class);
         if (ignoreDepth > 0) {
             final int forcedNameDepth = getAnnotationDepth(method, JSONPropertyName.class);

--- a/JSONPointer.java
+++ b/JSONPointer.java
@@ -186,7 +186,7 @@ public class JSONPointer {
         this.refTokens = new ArrayList<String>(refTokens);
     }
 
-    private String unescape(String token) {
+    private static String unescape(String token) {
         return token.replace("~1", "/").replace("~0", "~")
                 .replace("\\\"", "\"")
                 .replace("\\\\", "\\");
@@ -228,7 +228,7 @@ public class JSONPointer {
      * @return the matched object. If no matching item is found a
      * @throws JSONPointerException is thrown if the index is out of bounds
      */
-    private Object readByIndexToken(Object current, String indexToken) throws JSONPointerException {
+    private static Object readByIndexToken(Object current, String indexToken) throws JSONPointerException {
         try {
             int index = Integer.parseInt(indexToken);
             JSONArray currentArr = (JSONArray) current;
@@ -267,7 +267,7 @@ public class JSONPointer {
      * @param token the JSONPointer segment value to be escaped
      * @return the escaped value for the token
      */
-    private String escape(String token) {
+    private static String escape(String token) {
         return token.replace("~", "~0")
                 .replace("/", "~1")
                 .replace("\\", "\\\\")


### PR DESCRIPTION
This avoids an unneeded object reference.  Found via error-prone.