### PR TITLE
Fix problem with precision when retrieving BigDecimal JSON properties.

### DIFF
--- a/JSONObject.java
+++ b/JSONObject.java
@@ -1139,7 +1139,7 @@ public class JSONObject {
             if(Double.isNaN(d)) {
                 return defaultValue;
             }
-            return new BigDecimal(((Number) val).doubleValue());
+            return BigDecimal.valueOf(((Number) val).doubleValue());
         }
         if (val instanceof Long || val instanceof Integer
                 || val instanceof Short || val instanceof Byte){


### PR DESCRIPTION
As it is now, retrieving a property with value "0.01" with `JSONObject.getBigDecimal(key)` will return "0.01000000000000000020816681711721685132943093776702880859375" instead "0.01".