### PR TITLE
Fix for #484

### DIFF
--- a/XMLTokener.java
+++ b/XMLTokener.java
@@ -232,6 +232,7 @@ public class XMLTokener extends JSONTokener {
                 }
                 switch (c) {
                 case 0:
+                    throw syntaxError("Unterminated string");
                 case '<':
                 case '>':
                 case '/':


### PR DESCRIPTION
**What problem does this code solve?**
Fix for #484 that corrects EOF error when the Meta tag isn't closed properly and we reach the end of the input.

**Risks**
None. Bug fix

**Changes to the API?**
No

**Will this require a new release?**
Yes

**Should the documentation be updated?**
No

**Does it break the unit tests?**
No. But a new unit test was created to prevent regressions. See: https://github.com/stleary/JSON-Java-unit-test/pull/94

**Was any code refactored in this commit?**
No

**Review status**
**APPROVED**
