### PR TITLE
Updates Cookie class to be more generic in attribute parsing and emit.

### DIFF
--- a/src/main/java/org/json/Cookie.java
+++ b/src/main/java/org/json/Cookie.java
@@ -27,6 +27,7 @@ SOFTWARE.
 /**
  * Convert a web browser cookie specification to a JSONObject and back.
  * JSON and Cookies are both notations for name/value pairs.
+ * See also: <a href="https://tools.ietf.org/html/rfc6265">https://tools.ietf.org/html/rfc6265</a>
  * @author JSON.org
  * @version 2015-12-09
  */
@@ -65,10 +66,11 @@ public class Cookie {
 
     /**
      * Convert a cookie specification string into a JSONObject. The string
-     * will contain a name value pair separated by '='. The name and the value
+     * must contain a name value pair separated by '='. The name and the value
      * will be unescaped, possibly converting '+' and '%' sequences. The
      * cookie properties may follow, separated by ';', also represented as
-     * name=value (except the secure property, which does not have a value).
+     * name=value (except the Attribute properties like "Secure" or "HttpOnly",
+     * which do not have a value. The value {@link Boolean#TRUE} will be used for these).
      * The name will be stored under the key "name", and the value will be
      * stored under the key "value". This method does not do checking or
      * validation of the parameters. It only converts the cookie string into
@@ -76,30 +78,51 @@ public class Cookie {
      * @param string The cookie specification string.
      * @return A JSONObject containing "name", "value", and possibly other
      *  members.
-     * @throws JSONException if a called function fails or a syntax error
+     * @throws JSONException If there is an error parsing the Cookie String.
+     * Cookie strings must have at least one '=' character and the 'name'
+     * portion of the cookie must not be blank.
      */
-    public static JSONObject toJSONObject(String string) throws JSONException {
+    public static JSONObject toJSONObject(String string) {
+        final JSONObject     jo = new JSONObject();
         String         name;
-        JSONObject     jo = new JSONObject();
         Object         value;
+        
+        
         JSONTokener x = new JSONTokener(string);
-        jo.put("name", x.nextTo('='));
+        
+        name = unescape(x.nextTo('=').trim());
+        //per RFC6265, if the name is blank, the cookie should be ignored.
+        if("".equals(name)) {
+            throw new JSONException("Cookies must have a 'name'");
+        }
+        jo.put("name", name);
+        // per RFC6265, if there is no '=', the cookie should be ignored.
+        // the 'next' call here throws an exception if the '=' is not found.
         x.next('=');
-        jo.put("value", x.nextTo(';'));
+        jo.put("value", unescape(x.nextTo(';')).trim());
+        // discard the ';'
         x.next();
+        // parse the remaining cookie attributes
         while (x.more()) {
-            name = unescape(x.nextTo("=;"));
+            name = unescape(x.nextTo("=;")).trim();
+            // don't allow a cookies attributes to overwrite it's name or value.
+            if("name".equalsIgnoreCase(name)) {
+                throw new JSONException("Illegal attribute name: 'name'");
+            }
+            if("value".equalsIgnoreCase(name)) {
+                throw new JSONException("Illegal attribute name: 'value'");
+            }
+            // check to see if it's a flag property
             if (x.next() != '=') {
-                if (name.equals("secure")) {
-                    value = Boolean.TRUE;
-                } else {
-                    throw x.syntaxError("Missing '=' in cookie parameter.");
-                }
+                value = Boolean.TRUE;
             } else {
-                value = unescape(x.nextTo(';'));
+                value = unescape(x.nextTo(';')).trim();
                 x.next();
             }
-            jo.put(name, value);
+            // only store non-blank attributes
+            if(!"".equals(name) && !"".equals(value)) {
+                jo.put(name, value);
+            }
         }
         return jo;
     }
@@ -108,9 +131,10 @@ public class Cookie {
     /**
      * Convert a JSONObject into a cookie specification string. The JSONObject
      * must contain "name" and "value" members.
-     * If the JSONObject contains "expires", "domain", "path", or "secure"
-     * members, they will be appended to the cookie specification string.
-     * All other members are ignored.
+     * If the JSONObject contains other members, they will be appended to the cookie
+     * specification string. User-Agents are instructed to ignore unknown attributes,
+     * so ensure your JSONObject is using only known attributes.
+     * See also: <a href="https://tools.ietf.org/html/rfc6265">https://tools.ietf.org/html/rfc6265</a>
      * @param jo A JSONObject
      * @return A cookie specification string
      * @throws JSONException if a called function fails
@@ -121,21 +145,21 @@ public class Cookie {
         sb.append(escape(jo.getString("name")));
         sb.append("=");
         sb.append(escape(jo.getString("value")));
-        if (jo.has("expires")) {
-            sb.append(";expires=");
-            sb.append(jo.getString("expires"));
+        
+        for(String key : jo.keySet()){
+            if("name".equalsIgnoreCase(key)
+                    || "value".equalsIgnoreCase(key)) {
+                // already processed above
+                continue;
+            }
+            Object value = jo.opt(key);
+            if(value instanceof Boolean) {
+                sb.append(';').append(key);
+            } else {
+                sb.append(';').append(key).append('=').append(escape(value.toString()));
+            }
         }
-        if (jo.has("domain")) {
-            sb.append(";domain=");
-            sb.append(escape(jo.getString("domain")));
-        }
-        if (jo.has("path")) {
-            sb.append(";path=");
-            sb.append(escape(jo.getString("path")));
-        }
-        if (jo.optBoolean("secure")) {
-            sb.append(";secure");
-        }
+        
         return sb.toString();
     }
 

--- a/src/main/java/org/json/Cookie.java
+++ b/src/main/java/org/json/Cookie.java
@@ -1,5 +1,7 @@
 package org.json;
 
+import java.util.Locale;
+
 /*
 Copyright (c) 2002 JSON.org
 
@@ -74,7 +76,9 @@ public class Cookie {
      * The name will be stored under the key "name", and the value will be
      * stored under the key "value". This method does not do checking or
      * validation of the parameters. It only converts the cookie string into
-     * a JSONObject.
+     * a JSONObject. All attribute names are converted to lower case keys in the
+     * JSONObject (HttpOnly =&gt; httponly). If an attribute is specified more than
+     * once, only the value found closer to the end of the cookie-string is kept.
      * @param string The cookie specification string.
      * @return A JSONObject containing "name", "value", and possibly other
      *  members.
@@ -104,7 +108,7 @@ public class Cookie {
         x.next();
         // parse the remaining cookie attributes
         while (x.more()) {
-            name = unescape(x.nextTo("=;")).trim();
+            name = unescape(x.nextTo("=;")).trim().toLowerCase(Locale.ROOT);
             // don't allow a cookies attributes to overwrite it's name or value.
             if("name".equalsIgnoreCase(name)) {
                 throw new JSONException("Illegal attribute name: 'name'");

--- a/src/test/java/org/json/junit/CookieTest.java
+++ b/src/test/java/org/json/junit/CookieTest.java
@@ -84,7 +84,7 @@ public class CookieTest {
             JSONObject jo = Cookie.toJSONObject(cookieStr);
             assertTrue("has key 'name'", jo.has("name"));
             assertTrue("has key 'value'", jo.has("value"));
-            assertTrue("has key 'myAttribute'", jo.has("myAttribute"));
+            assertTrue("has key 'myAttribute'", jo.has("myattribute"));
     }
 
     /**
@@ -177,7 +177,7 @@ public class CookieTest {
             "thisWont=beIncluded;"+
             "secure";
         String expectedCookieStr = 
-            "{\"thisWont\":\"beIncluded\","+
+            "{\"thiswont\":\"beIncluded\","+
             "\"path\":\"/\","+
             "\"expires\":\"Wed, 19-Mar-2014 17:53:53 GMT\","+
             "\"domain\":\".yahoo.com\","+

--- a/src/test/java/org/json/junit/CookieTest.java
+++ b/src/test/java/org/json/junit/CookieTest.java
@@ -79,16 +79,12 @@ public class CookieTest {
      * Expects a JSONException.
      */
     @Test
-    public void malFormedAttributeException() {
+    public void booleanAttribute() {
         String cookieStr = "this=Cookie;myAttribute";
-        try {
-            Cookie.toJSONObject(cookieStr);
-            fail("Expecting an exception");
-        } catch (JSONException e) {
-            assertEquals("Expecting an exception message",
-                    "Missing '=' in cookie parameter. at 23 [character 24 line 1]",
-                    e.getMessage());
-        }
+            JSONObject jo = Cookie.toJSONObject(cookieStr);
+            assertTrue("has key 'name'", jo.has("name"));
+            assertTrue("has key 'value'", jo.has("value"));
+            assertTrue("has key 'myAttribute'", jo.has("myAttribute"));
     }
 
     /**
@@ -104,7 +100,25 @@ public class CookieTest {
             fail("Expecting an exception");
         } catch (JSONException e) {
             assertEquals("Expecting an exception message",
-                    "Expected '=' and instead saw '' at 0 [character 1 line 1]",
+                    "Cookies must have a 'name'",
+                    e.getMessage());
+        }
+    }
+    /**
+     * 
+     * Attempts to create a JSONObject from an cookie string where the name is blank.<br>
+     * Note: Cookie throws an exception, but CookieList does not.<br>
+     * Expects a JSONException
+     */
+    @Test
+    public void emptyNameCookieException() {
+        String cookieStr = " = value ";
+        try {
+            Cookie.toJSONObject(cookieStr);
+            fail("Expecting an exception");
+        } catch (JSONException e) {
+            assertEquals("Expecting an exception message",
+                    "Cookies must have a 'name'",
                     e.getMessage());
         }
     }
@@ -149,8 +163,8 @@ public class CookieTest {
     }
 
     /**
-     * Cookie.toString() will omit the non-standard "thiswont=beIncluded"
-     * attribute, but the attribute is still stored in the JSONObject.
+     * Cookie.toString() will emit the non-standard "thiswont=beIncluded"
+     * attribute, and the attribute is still stored in the JSONObject.
      * This test confirms both behaviors.
      */
     @Test
@@ -163,15 +177,15 @@ public class CookieTest {
             "thisWont=beIncluded;"+
             "secure";
         String expectedCookieStr = 
-            "{\"path\":\"/\","+
+            "{\"thisWont\":\"beIncluded\","+
+            "\"path\":\"/\","+
             "\"expires\":\"Wed, 19-Mar-2014 17:53:53 GMT\","+
             "\"domain\":\".yahoo.com\","+
             "\"name\":\"PH\","+
             "\"secure\":true,"+
             "\"value\":\"deleted\"}";
         // Add the nonstandard attribute to the expected cookie string
-        String expectedDirectCompareCookieStr = 
-            expectedCookieStr.replaceAll("\\{", "\\{\"thisWont\":\"beIncluded\",");
+        String expectedDirectCompareCookieStr = expectedCookieStr;
         // convert all strings into JSONObjects
         JSONObject jsonObject = Cookie.toJSONObject(cookieStr);
         JSONObject expectedJsonObject = new JSONObject(expectedCookieStr);


### PR DESCRIPTION
**What problem does this code solve?**
See #517 
Brings the Cookie implementation closer to the RFC specification (https://tools.ietf.org/html/rfc6265)
This is so the library can age better as new attributes are added or removed in future RFC revisions.

This also fixes bugs in the implementation:
* Allowed empty cookie names which should be ignored
* Attribute names were case sensitive when they should not be
* Name and Value of the cookie were not ensured trimmed
* Attributes were not ensured to have white space removed

**Risks**
Low to Medium. I doubt many people were using this since the problems brought up in #517 were not found until now. They seem to be pretty glaring gaps in the parsing and emit logic.

**Changes to the API?**
No

**Will this require a new release?**
Yes

**Should the documentation be updated?**
I don't think it's needed

**Does it break the unit tests?**
Yes, corrections were made

**Was any code refactored in this commit?**
No, bug fixes and support for new attributes only.

**Review status**
**APPROVED**

Starting 3 day comment window
