### PR TITLE
Bring Junit tests to Java 1.6 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,8 +118,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/org/json/junit/JSONArrayTest.java
+++ b/src/test/java/org/json/junit/JSONArrayTest.java
@@ -940,18 +940,21 @@ public class JSONArrayTest {
         String str = "[\"value1\",\"value2\",{\"key1\":1,\"key2\":2,\"key3\":3}]";
         JSONArray jsonArray = new JSONArray(str);
         String expectedStr = str;
-        try (StringWriter stringWriter = new StringWriter();) {
-            jsonArray.write(stringWriter);
-            String actualStr = stringWriter.toString();
+        StringWriter stringWriter = new StringWriter();
+        jsonArray.write(stringWriter);
+        String actualStr = stringWriter.toString();
+        try {
             JSONArray finalArray = new JSONArray(actualStr);
             Util.compareActualVsExpectedJsonArrays(jsonArray, finalArray);
             assertTrue("write() expected " + expectedStr +
-                " but found " + actualStr,
-                actualStr.startsWith("[\"value1\",\"value2\",{")
-                && actualStr.contains("\"key1\":1")
-                && actualStr.contains("\"key2\":2")
-                && actualStr.contains("\"key3\":3")
-                );
+                    " but found " + actualStr,
+                    actualStr.startsWith("[\"value1\",\"value2\",{")
+                    && actualStr.contains("\"key1\":1")
+                    && actualStr.contains("\"key2\":2")
+                    && actualStr.contains("\"key3\":3")
+                    );
+        } finally {
+            stringWriter.close();
         }
     }
 
@@ -981,7 +984,8 @@ public class JSONArrayTest {
         String str0 = "[\"value1\",\"value2\",{\"key1\":1,\"key2\":false,\"key3\":3.14}]";
         JSONArray jsonArray = new JSONArray(str0);
         String expectedStr = str0;
-        try (StringWriter stringWriter = new StringWriter();) {
+        StringWriter stringWriter = new StringWriter();
+        try {
             String actualStr = jsonArray.write(stringWriter, 0, 0).toString();
             JSONArray finalArray = new JSONArray(actualStr);
             Util.compareActualVsExpectedJsonArrays(jsonArray, finalArray);
@@ -992,9 +996,12 @@ public class JSONArrayTest {
                 && actualStr.contains("\"key2\":false")
                 && actualStr.contains("\"key3\":3.14")
             );
+        } finally {
+            stringWriter.close();
         }
         
-        try (StringWriter stringWriter = new StringWriter();) {
+        stringWriter = new StringWriter();
+        try {
             String actualStr = jsonArray.write(stringWriter, 2, 1).toString();
             JSONArray finalArray = new JSONArray(actualStr);
             Util.compareActualVsExpectedJsonArrays(jsonArray, finalArray);
@@ -1008,6 +1015,8 @@ public class JSONArrayTest {
                 && actualStr.contains("\"key2\": false")
                 && actualStr.contains("\"key3\": 3.14")
             );
+        } finally {
+            stringWriter.close();
         }
     }
 

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -1879,7 +1879,7 @@ public class JSONObjectTest {
     @Test
     public void jsonObjectToStringSuppressWarningOnCastToMap() {
         JSONObject jsonObject = new JSONObject();
-        Map<String, String> map = new HashMap<>();
+        Map<String, String> map = new HashMap();
         map.put("abc", "def");
         jsonObject.put("key", map);
 
@@ -2632,12 +2632,15 @@ public class JSONObjectTest {
         String str = "{\"key1\":\"value1\",\"key2\":[1,2,3]}";
         String expectedStr = str;
         JSONObject jsonObject = new JSONObject(str);
-        try (StringWriter stringWriter = new StringWriter()) {
+        StringWriter stringWriter = new StringWriter();
+        try {
             String actualStr = jsonObject.write(stringWriter).toString();
             // key order may change. verify length and individual key content
             assertEquals("length", expectedStr.length(), actualStr.length());
             assertTrue("key1", actualStr.contains("\"key1\":\"value1\""));
             assertTrue("key2", actualStr.contains("\"key2\":[1,2,3]"));
+        } finally {
+            stringWriter.close();
         }
     }
     
@@ -2651,29 +2654,40 @@ public class JSONObjectTest {
         jsonObject.put("someKey",new BrokenToString());
 
         // test single element JSONObject
-        try(StringWriter writer = new StringWriter();) {
+        StringWriter writer = new StringWriter();
+        try {
             jsonObject.write(writer).toString();
             fail("Expected an exception, got a String value");
         } catch (JSONException e) {
             assertEquals("Unable to write JSONObject value for key: someKey", e.getMessage());
         } catch(Exception e) {
             fail("Expected JSONException");
+        } finally {
+            try {
+                writer.close();
+            } catch (Exception e) {}
         }
 
         //test multiElement
         jsonObject.put("somethingElse", "a value");
         
-        try (StringWriter writer = new StringWriter()) {
+        writer = new StringWriter();
+        try {
             jsonObject.write(writer).toString();
             fail("Expected an exception, got a String value");
         } catch (JSONException e) {
             assertEquals("Unable to write JSONObject value for key: someKey", e.getMessage());
         } catch(Exception e) {
             fail("Expected JSONException");
+        } finally {
+            try {
+                writer.close();
+            } catch (Exception e) {}
         }
         
         // test a more complex object
-        try (StringWriter writer = new StringWriter()) {
+        writer = new StringWriter();
+        try {
             new JSONObject()
                 .put("somethingElse", "a value")
                 .put("someKey", new JSONArray()
@@ -2684,10 +2698,15 @@ public class JSONObjectTest {
             assertEquals("Unable to write JSONObject value for key: someKey", e.getMessage());
         } catch(Exception e) {
             fail("Expected JSONException");
+        } finally {
+            try {
+                writer.close();
+            } catch (Exception e) {}
         }
        
         // test a more slightly complex object
-        try (StringWriter writer = new StringWriter()) {
+        writer = new StringWriter();
+        try {
             new JSONObject()
                 .put("somethingElse", "a value")
                 .put("someKey", new JSONArray()
@@ -2700,6 +2719,10 @@ public class JSONObjectTest {
             assertEquals("Unable to write JSONObject value for key: someKey", e.getMessage());
         } catch(Exception e) {
             fail("Expected JSONException");
+        } finally {
+            try {
+                writer.close();
+            } catch (Exception e) {}
         }
        
     }
@@ -2739,15 +2762,21 @@ public class JSONObjectTest {
                 "   ]\n" +
                 " }";
         JSONObject jsonObject = new JSONObject(str0);
-        try (StringWriter stringWriter = new StringWriter();) {
+        StringWriter stringWriter = new StringWriter();
+        try {
             String actualStr = jsonObject.write(stringWriter,0,0).toString();
             
             assertEquals("length", str0.length(), actualStr.length());
             assertTrue("key1", actualStr.contains("\"key1\":\"value1\""));
             assertTrue("key2", actualStr.contains("\"key2\":[1,false,3.14]"));
+        } finally {
+            try {
+                stringWriter.close();
+            } catch (Exception e) {}
         }
         
-        try (StringWriter stringWriter = new StringWriter();) {
+        stringWriter = new StringWriter();
+        try {
             String actualStr = jsonObject.write(stringWriter,2,1).toString();
 
             assertEquals("length", str2.length(), actualStr.length());
@@ -2758,6 +2787,10 @@ public class JSONObjectTest {
                             "     3.14\n" +
                             "   ]")
             );
+        } finally {
+            try {
+                stringWriter.close();
+            } catch (Exception e) {}
         }
     }
 
@@ -3039,7 +3072,7 @@ public class JSONObjectTest {
     @SuppressWarnings("boxing")
     @Test
     public void testGenericBean() {
-        GenericBean<Integer> bean = new GenericBean<>(42);
+        GenericBean<Integer> bean = new GenericBean(42);
         final JSONObject jo = new JSONObject(bean);
         assertEquals(jo.keySet().toString(), 8, jo.length());
         assertEquals(42, jo.get("genericValue"));

--- a/src/test/java/org/json/junit/JSONStringTest.java
+++ b/src/test/java/org/json/junit/JSONStringTest.java
@@ -49,84 +49,114 @@ public class JSONStringTest {
         JSONArray jsonArray = new JSONArray();
         jsonArray.put((Object)null);
 
-        try (StringWriter writer = new StringWriter();) {
+        StringWriter writer = new StringWriter();
+        try {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[null]".equals(output));
     
             jsonArray = new JSONArray();
             jsonArray.put(JSONObject.NULL);
+        } finally {
+            writer.close();
         }
 
-        try (StringWriter writer = new StringWriter();) {
+        writer = new StringWriter();
+        try {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[null]".equals(output));
     
             jsonArray = new JSONArray();
             jsonArray.put(new JSONObject());
+        } finally {
+            writer.close();
         }
         
-        try (StringWriter writer = new StringWriter();) {
+        writer = new StringWriter();
+        try  {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[{}]".equals(output));
     
             jsonArray = new JSONArray();
             jsonArray.put(new JSONArray());
+        } finally {
+            writer.close();
         }
 
-        try (StringWriter writer = new StringWriter();) {
+        writer = new StringWriter(); 
+        try {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[[]]".equals(output));
     
             jsonArray = new JSONArray();
             Map<?,?> singleMap = Collections.singletonMap("key1", "value1");
             jsonArray.put((Object)singleMap);
+        } finally {
+            writer.close();
         }
         
-        try (StringWriter writer = new StringWriter();) {
+        writer = new StringWriter(); 
+        try {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[{\"key1\":\"value1\"}]".equals(output));
     
             jsonArray = new JSONArray();
             List<?> singleList = Collections.singletonList("entry1");
             jsonArray.put((Object)singleList);
+        } finally {
+            writer.close();
         }
 
-        try (StringWriter writer = new StringWriter();) {
+        writer = new StringWriter(); 
+        try {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[[\"entry1\"]]".equals(output));
     
             jsonArray = new JSONArray();
             int[] intArray = new int[] { 1, 2, 3 };
             jsonArray.put(intArray);
+        } finally {
+            writer.close();
         }
 
-        try (StringWriter writer = new StringWriter();) {
+        writer = new StringWriter(); 
+        try {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[[1,2,3]]".equals(output));
     
             jsonArray = new JSONArray();
             jsonArray.put(24);
+        } finally {
+            writer.close();
         }
         
-        try (StringWriter writer = new StringWriter();) {
+        writer = new StringWriter(); 
+        try {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[24]".equals(output));
     
             jsonArray = new JSONArray();
             jsonArray.put("string value");
+        } finally {
+            writer.close();
         }
 
-        try (StringWriter writer = new StringWriter();) {
+        writer = new StringWriter(); 
+        try {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[\"string value\"]".equals(output));
     
             jsonArray = new JSONArray();
             jsonArray.put(true);
+        } finally {
+            writer.close();
         }
 
-        try (StringWriter writer = new StringWriter();) {
+        writer = new StringWriter();
+        try {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[true]".equals(output));
+        } finally {
+            writer.close();
         }
 
     }
@@ -185,13 +215,15 @@ public class JSONStringTest {
 
         jsonArray.put(jsonString);
 
-        
-        try (StringWriter writer = new StringWriter();) {
+        StringWriter writer = new StringWriter(); 
+        try {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[\"the JSON string value\"]".equals(output));
     
             output = JSONObject.valueToString(jsonString);
             assertTrue("String values should be equal", "\"the JSON string value\"".equals(output));
+        } finally {
+            writer.close();
         }
     }
 
@@ -206,7 +238,8 @@ public class JSONStringTest {
 
         jsonArray.put(jsonString);
 
-        try (StringWriter writer = new StringWriter();) {
+        StringWriter writer = new StringWriter(); 
+        try {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[\"the toString value\"]".equals(output));
     
@@ -219,6 +252,8 @@ public class JSONStringTest {
                 assertTrue("Expected JSONException", e instanceof JSONException);
                 assertTrue("Exception message does not match", "Bad value from toJSONString: null".equals(e.getMessage()));
             }
+        } finally {
+            writer.close();
         }
     }
 
@@ -234,13 +269,18 @@ public class JSONStringTest {
 
         jsonArray.put(jsonString);
 
-        try (StringWriter writer = new StringWriter();) {
+        StringWriter writer = new StringWriter(); 
+        try {
             jsonArray.write(writer).toString();
             fail("Expected an exception, got a String value");
         } catch (JSONException e) {
             assertEquals("Unable to write JSONArray value at index: 0", e.getMessage());
         } catch(Exception e) {
             fail("Expected JSONException");
+        } finally {
+            try {
+                writer.close();
+            } catch (Exception e){}
         }
 
         try {
@@ -264,12 +304,15 @@ public class JSONStringTest {
 
         jsonArray.put(nonJsonString);
 
-        try (StringWriter writer = new StringWriter();) {
+        StringWriter writer = new StringWriter(); 
+        try {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[\"the toString value for StringValue\"]".equals(output));
     
             output = JSONObject.valueToString(nonJsonString);
             assertTrue("String values should be equal", "\"the toString value for StringValue\"".equals(output));
+        } finally {
+            writer.close();
         }
     }
 
@@ -284,13 +327,15 @@ public class JSONStringTest {
 
         jsonArray.put(nonJsonString);
 
-        
-        try (StringWriter writer = new StringWriter();) {
+        StringWriter writer = new StringWriter(); 
+        try {
             String output = jsonArray.write(writer).toString();
             assertTrue("String values should be equal", "[\"\"]".equals(output));
     
             output = JSONObject.valueToString(nonJsonString);
             assertTrue("String values should be equal", "\"\"".equals(output));
+        } finally {
+            writer.close();
         }
     }
 

--- a/src/test/java/org/json/junit/JSONTokenerTest.java
+++ b/src/test/java/org/json/junit/JSONTokenerTest.java
@@ -55,7 +55,8 @@ public class JSONTokenerTest {
      */
     @Test
     public void verifyBackFailureZeroIndex() throws IOException {
-        try(Reader reader = new StringReader("some test string")) {
+        Reader reader = new StringReader("some test string"); 
+        try {
             final JSONTokener tokener = new JSONTokener(reader);
             try {
                 // this should fail since the index is 0;
@@ -67,6 +68,8 @@ public class JSONTokenerTest {
                 fail("Unknown Exception type " + e.getClass().getCanonicalName()+" with message "+e.getMessage());
             }
             
+        } finally {
+            reader.close();
         }
     }
     /**
@@ -75,7 +78,8 @@ public class JSONTokenerTest {
      */
     @Test
     public void verifyBackFailureDoubleBack() throws IOException {
-        try(Reader reader = new StringReader("some test string")) {
+        Reader reader = new StringReader("some test string");
+        try {
             final JSONTokener tokener = new JSONTokener(reader);
             tokener.next();
             tokener.back();
@@ -88,6 +92,8 @@ public class JSONTokenerTest {
             } catch (Exception e) {
                 fail("Unknown Exception type " + e.getClass().getCanonicalName()+" with message "+e.getMessage());
             }
+       } finally {
+           reader.close();
        }
     }
     
@@ -164,7 +170,8 @@ public class JSONTokenerTest {
      * @throws Exception
      */
     private Object nextValue(String testStr) throws JSONException {
-        try(StringReader sr = new StringReader(testStr);){
+        StringReader sr = new StringReader(testStr);
+        try {
             JSONTokener tokener = new JSONTokener(sr);
     
             Object result = tokener.nextValue();
@@ -179,6 +186,8 @@ public class JSONTokenerTest {
             }
     
             return result;
+        } finally {
+            sr.close();
         }
 
     }
@@ -196,7 +205,10 @@ public class JSONTokenerTest {
         for(int i=0;i<superLongBuffer.length;i++) {
             superLongBuffer[i] = 'A';
         }
-        try(Reader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(superLongBuffer)))) {
+        
+        Reader reader = new BufferedReader(new InputStreamReader(
+                new ByteArrayInputStream(superLongBuffer)));
+        try {
             final JSONTokener tokener = new JSONTokener(reader);
             try {
                 // this should fail since the internal markAhead buffer is only 1,000,000
@@ -208,6 +220,8 @@ public class JSONTokenerTest {
             } catch (Exception e) {
                 fail("Unknown Exception type " + e.getClass().getCanonicalName()+" with message "+e.getMessage());
             }
+        } finally {
+            reader.close();
         }
     }
 
@@ -223,7 +237,8 @@ public class JSONTokenerTest {
         for(int i=0;i<superLongBuffer.length();i++) {
             superLongBuffer.append('A');
         }
-        try(Reader reader = new StringReader(superLongBuffer.toString())) {
+        Reader reader = new StringReader(superLongBuffer.toString());
+        try {
             final JSONTokener tokener = new JSONTokener(reader);
             try {
                 // this should not fail since the internal markAhead is ignored for StringReaders
@@ -231,6 +246,8 @@ public class JSONTokenerTest {
             } catch (Exception e) {
                 fail("Unknown Exception type " + e.getClass().getCanonicalName()+" with message "+e.getMessage());
             }
+        } finally {
+            reader.close();
         }
     }
 

--- a/src/test/java/org/json/junit/XMLConfigurationTest.java
+++ b/src/test/java/org/json/junit/XMLConfigurationTest.java
@@ -918,11 +918,16 @@ public class XMLConfigurationTest {
          * to support XML.toJSONObject(reader)
          */
         JSONObject expectedJsonObject = new JSONObject(expectedStr);
-        try(Reader reader = new StringReader(xmlStr);) {
+        Reader reader = new StringReader(xmlStr);
+        try {
             JSONObject jsonObject = XML.toJSONObject(reader, config);
             Util.compareActualVsExpectedJsonObjects(jsonObject,expectedJsonObject);
-        } catch (IOException e) {
-            assertTrue("IO Reader error: " +e.getMessage(), false);
+        } catch (Exception e) {
+            assertTrue("Reader error: " +e.getMessage(), false);
+        } finally {
+            try {
+                reader.close();
+            } catch (Exception e) {}
         }
     }
 
@@ -944,15 +949,22 @@ public class XMLConfigurationTest {
         try {
             JSONObject expectedJsonObject = new JSONObject(expectedStr);
             File tempFile = this.testFolder.newFile("fileToJSONObject.xml");
-            try(FileWriter fileWriter = new FileWriter(tempFile);){
+            FileWriter fileWriter = new FileWriter(tempFile);
+            try {
                 fileWriter.write(xmlStr);
+            } finally {
+                fileWriter.close();
             }
-            try(Reader reader = new FileReader(tempFile);){
+
+            Reader reader = new FileReader(tempFile);
+            try {
                 JSONObject jsonObject = XML.toJSONObject(reader);
                 Util.compareActualVsExpectedJsonObjects(jsonObject,expectedJsonObject);
+            } finally {
+                reader.close();
             }
         } catch (IOException e) {
-            assertTrue("file writer error: " +e.getMessage(), false);
+            assertTrue("Error: " +e.getMessage(), false);
         }
     }
 }

--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -784,15 +784,22 @@ public class XMLTest {
         try {
             JSONObject expectedJsonObject = new JSONObject(expectedStr);
             File tempFile = this.testFolder.newFile("fileToJSONObject.xml");
-            try(FileWriter fileWriter = new FileWriter(tempFile);){
+            FileWriter fileWriter = new FileWriter(tempFile);
+            try {
                 fileWriter.write(xmlStr);
+            } finally {
+                fileWriter.close();
             }
-            try(Reader reader = new FileReader(tempFile);){
+
+            Reader reader = new FileReader(tempFile);
+            try {
                 JSONObject jsonObject = XML.toJSONObject(reader);
                 Util.compareActualVsExpectedJsonObjects(jsonObject,expectedJsonObject);
+            } finally {
+                reader.close();
             }
         } catch (IOException e) {
-            fail("file writer error: " +e.getMessage());
+            fail("Error: " +e.getMessage());
         }
     }
 

--- a/src/test/java/org/json/junit/data/WeirdList.java
+++ b/src/test/java/org/json/junit/data/WeirdList.java
@@ -12,7 +12,7 @@ import java.util.List;
  */
 public class WeirdList {
     /** */
-    private final List<Integer> list = new ArrayList<>();
+    private final List<Integer> list = new ArrayList();
 
     /**
      * @param vals
@@ -25,14 +25,14 @@ public class WeirdList {
      * @return a copy of the list
      */
     public List<Integer> get() {
-        return new ArrayList<>(this.list);
+        return new ArrayList(this.list);
     }
 
     /**
      * @return a copy of the list
      */
     public List<Integer> getALL() {
-        return new ArrayList<>(this.list);
+        return new ArrayList(this.list);
     }
 
     /**


### PR DESCRIPTION
**What problem does this code solve?**
The project code is 1.6-compatible, but the unit tests require Java 1.7. This makes building and testing clumsy, and 
can't be sure the lib works correctly in a Jave 1.6 environment.  Remove diamond operators: <> and 
autoclose expressions from several junit modules.  Updated Maven pom.xml to use Java 1.6.
Confirmed that Maven (1.6) and Gradlew (1.8) build and test correctly.

**Risks**
No risk to production code, moderate risk to unit tests.

**Changes to the API?**
No

**Will this require a new release?**
No

**Should the documentation be updated?**
Yes - readme will need to be updated, but it's currently in review on another branch.
CI build will be updated on approval/merge, to add testing to the 1.6 build.

**Does it break the unit tests?**
No

**Was any code refactored in this commit?**
No

**Review status**
**Approved - by myself**