### PR TITLE
Added type conversion support

### DIFF
--- a/src/main/java/org/json/XML.java
+++ b/src/main/java/org/json/XML.java
@@ -360,9 +360,9 @@ public class XML {
                                 && NULL_ATTR.equals(string)
                                 && Boolean.parseBoolean((String) token)) {
                             nilAttributeFound = true;
-                        } else if(config.xsiTypeMap != null
+                        } else if(config.getXsiTypeMap() != null && !config.getXsiTypeMap().isEmpty()
                                 && TYPE_ATTR.equals(string)) {
-                            xmlXsiTypeConverter = config.xsiTypeMap.get(token);
+                            xmlXsiTypeConverter = config.getXsiTypeMap().get(token);
                         } else if (!nilAttributeFound) {
                             jsonObject.accumulate(string,
                                     config.isKeepStrings()

--- a/src/main/java/org/json/XMLParserConfiguration.java
+++ b/src/main/java/org/json/XMLParserConfiguration.java
@@ -23,6 +23,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+import java.util.Map;
+
+
 /**
  * Configuration object for the XML parser. The configuration is immutable.
  * @author AylwardJ
@@ -57,10 +60,9 @@ public class XMLParserConfiguration {
     private boolean convertNilAttributeToNull;
 
     /**
-     * When parsing the XML into JSON, specifies if values with attribute xsi:type="java.lang.Integer"
-     * should be kept as attribute(false), or they should be converted to the given type
+     * This will allow type conversion for values in XML if xsi:type attribute is defined
      */
-    public boolean useValueTypeCast;
+    public Map<String, XMLXsiTypeConverter<?>> xsiTypeMap;
 
     /**
      * Default parser configuration. Does not keep strings (tries to implicitly convert
@@ -129,7 +131,7 @@ public class XMLParserConfiguration {
      */
     @Deprecated
     public XMLParserConfiguration (final boolean keepStrings, final String cDataTagName, final boolean convertNilAttributeToNull) {
-        this(keepStrings, cDataTagName, convertNilAttributeToNull, false);
+        this(keepStrings, cDataTagName, convertNilAttributeToNull, null);
     }
 
     /**
@@ -140,16 +142,16 @@ public class XMLParserConfiguration {
      *      to use that value as the JSONObject key name to process as CDATA.
      * @param convertNilAttributeToNull <code>true</code> to parse values with attribute xsi:nil="true" as null.
      *                                  <code>false</code> to parse values with attribute xsi:nil="true" as {"xsi:nil":true}.
-     * @param useValueTypeCast  <code>true</code> to parse values with attribute xsi:type="java.lang.Integer" as
-     *                          integer,  xsi:type="java.lang.String" as string
-     *                          <code>false</code> to parse values with attribute xsi:type="java.lang.Integer" as {"xsi:type":"java.lang.Integer"}.
+     * @param xsiTypeMap  <code>new HashMap<String, XMLXsiTypeConverter<?>>()</code> to parse values with attribute
+     *                   xsi:type="integer" as integer,  xsi:type="string" as string
+     *                    <code>null</code> to use default behaviour.
      */
     public XMLParserConfiguration (final boolean keepStrings, final String cDataTagName,
-            final boolean convertNilAttributeToNull, final boolean useValueTypeCast ) {
+            final boolean convertNilAttributeToNull, final Map<String, XMLXsiTypeConverter<?>> xsiTypeMap ) {
         this.keepStrings = keepStrings;
         this.cDataTagName = cDataTagName;
         this.convertNilAttributeToNull = convertNilAttributeToNull;
-        this.useValueTypeCast = useValueTypeCast;
+        this.xsiTypeMap = xsiTypeMap;
     }
     
     /**

--- a/src/main/java/org/json/XMLParserConfiguration.java
+++ b/src/main/java/org/json/XMLParserConfiguration.java
@@ -114,7 +114,9 @@ public class XMLParserConfiguration {
      */
     @Deprecated
     public XMLParserConfiguration (final boolean keepStrings, final String cDataTagName) {
-        this(keepStrings, cDataTagName, false);
+        this.keepStrings = keepStrings;
+        this.cDataTagName = cDataTagName;
+        this.convertNilAttributeToNull = false;
     }
 
     /**
@@ -131,7 +133,9 @@ public class XMLParserConfiguration {
      */
     @Deprecated
     public XMLParserConfiguration (final boolean keepStrings, final String cDataTagName, final boolean convertNilAttributeToNull) {
-        this(keepStrings, cDataTagName, convertNilAttributeToNull, null);
+        this.keepStrings = keepStrings;
+        this.cDataTagName = cDataTagName;
+        this.convertNilAttributeToNull = convertNilAttributeToNull;
     }
 
     /**

--- a/src/main/java/org/json/XMLParserConfiguration.java
+++ b/src/main/java/org/json/XMLParserConfiguration.java
@@ -24,6 +24,7 @@ SOFTWARE.
 */
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 
@@ -278,7 +279,8 @@ public class XMLParserConfiguration {
      */
     public XMLParserConfiguration withXsiTypeMap(final Map<String, XMLXsiTypeConverter<?>> xsiTypeMap) {
         XMLParserConfiguration newConfig = this.clone();
-        newConfig.xsiTypeMap = Collections.unmodifiableMap(xsiTypeMap);
+        Map<String, XMLXsiTypeConverter<?>> cloneXsiTypeMap = new HashMap<String, XMLXsiTypeConverter<?>>(xsiTypeMap);
+        newConfig.xsiTypeMap = Collections.unmodifiableMap(cloneXsiTypeMap);
         return newConfig;
     }
 }

--- a/src/main/java/org/json/XMLParserConfiguration.java
+++ b/src/main/java/org/json/XMLParserConfiguration.java
@@ -57,6 +57,12 @@ public class XMLParserConfiguration {
     private boolean convertNilAttributeToNull;
 
     /**
+     * When parsing the XML into JSON, specifies if values with attribute xsi:type="java.lang.Integer"
+     * should be kept as attribute(false), or they should be converted to the given type
+     */
+    public boolean useValueTypeCast;
+
+    /**
      * Default parser configuration. Does not keep strings (tries to implicitly convert
      * values), and the CDATA Tag Name is "content".
      */
@@ -106,9 +112,7 @@ public class XMLParserConfiguration {
      */
     @Deprecated
     public XMLParserConfiguration (final boolean keepStrings, final String cDataTagName) {
-        this.keepStrings = keepStrings;
-        this.cDataTagName = cDataTagName;
-        this.convertNilAttributeToNull = false;
+        this(keepStrings, cDataTagName, false);
     }
 
     /**
@@ -125,9 +129,27 @@ public class XMLParserConfiguration {
      */
     @Deprecated
     public XMLParserConfiguration (final boolean keepStrings, final String cDataTagName, final boolean convertNilAttributeToNull) {
+        this(keepStrings, cDataTagName, convertNilAttributeToNull, false);
+    }
+
+    /**
+     * Configure the parser to use custom settings.
+     * @param keepStrings <code>true</code> to parse all values as string.
+     *      <code>false</code> to try and convert XML string values into a JSON value.
+     * @param cDataTagName <code>null</code> to disable CDATA processing. Any other value
+     *      to use that value as the JSONObject key name to process as CDATA.
+     * @param convertNilAttributeToNull <code>true</code> to parse values with attribute xsi:nil="true" as null.
+     *                                  <code>false</code> to parse values with attribute xsi:nil="true" as {"xsi:nil":true}.
+     * @param useValueTypeCast  <code>true</code> to parse values with attribute xsi:type="java.lang.Integer" as
+     *                          integer,  xsi:type="java.lang.String" as string
+     *                          <code>false</code> to parse values with attribute xsi:type="java.lang.Integer" as {"xsi:type":"java.lang.Integer"}.
+     */
+    public XMLParserConfiguration (final boolean keepStrings, final String cDataTagName,
+            final boolean convertNilAttributeToNull, final boolean useValueTypeCast ) {
         this.keepStrings = keepStrings;
         this.cDataTagName = cDataTagName;
         this.convertNilAttributeToNull = convertNilAttributeToNull;
+        this.useValueTypeCast = useValueTypeCast;
     }
     
     /**

--- a/src/main/java/org/json/XMLParserConfiguration.java
+++ b/src/main/java/org/json/XMLParserConfiguration.java
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+import java.util.Collections;
 import java.util.Map;
 
 
@@ -62,7 +63,7 @@ public class XMLParserConfiguration {
     /**
      * This will allow type conversion for values in XML if xsi:type attribute is defined
      */
-    public Map<String, XMLXsiTypeConverter<?>> xsiTypeMap;
+    private Map<String, XMLXsiTypeConverter<?>> xsiTypeMap;
 
     /**
      * Default parser configuration. Does not keep strings (tries to implicitly convert
@@ -72,6 +73,7 @@ public class XMLParserConfiguration {
         this.keepStrings = false;
         this.cDataTagName = "content";
         this.convertNilAttributeToNull = false;
+        this.xsiTypeMap = Collections.emptyMap();
     }
 
     /**
@@ -148,16 +150,15 @@ public class XMLParserConfiguration {
      *                                  <code>false</code> to parse values with attribute xsi:nil="true" as {"xsi:nil":true}.
      * @param xsiTypeMap  <code>new HashMap<String, XMLXsiTypeConverter<?>>()</code> to parse values with attribute
      *                   xsi:type="integer" as integer,  xsi:type="string" as string
-     *                    <code>null</code> to use default behaviour.
      */
-    public XMLParserConfiguration (final boolean keepStrings, final String cDataTagName,
+    private XMLParserConfiguration (final boolean keepStrings, final String cDataTagName,
             final boolean convertNilAttributeToNull, final Map<String, XMLXsiTypeConverter<?>> xsiTypeMap ) {
         this.keepStrings = keepStrings;
         this.cDataTagName = cDataTagName;
         this.convertNilAttributeToNull = convertNilAttributeToNull;
-        this.xsiTypeMap = xsiTypeMap;
+        this.xsiTypeMap = Collections.unmodifiableMap(xsiTypeMap);
     }
-    
+
     /**
      * Provides a new instance of the same configuration.
      */
@@ -171,7 +172,8 @@ public class XMLParserConfiguration {
         return new XMLParserConfiguration(
                 this.keepStrings,
                 this.cDataTagName,
-                this.convertNilAttributeToNull
+                this.convertNilAttributeToNull,
+                this.xsiTypeMap
         );
     }
     
@@ -251,6 +253,32 @@ public class XMLParserConfiguration {
     public XMLParserConfiguration withConvertNilAttributeToNull(final boolean newVal) {
         XMLParserConfiguration newConfig = this.clone();
         newConfig.convertNilAttributeToNull = newVal;
+        return newConfig;
+    }
+
+    /**
+     * When parsing the XML into JSON, specifies that the values with attribute xsi:type
+     * will be converted to target type defined to client in this configuration
+     * <code>Map<String, XMLXsiTypeConverter<?>></code> to parse values with attribute
+     * xsi:type="integer" as integer,  xsi:type="string" as string
+     * @return {@link #xsiTypeMap} unmodifiable configuration map.
+     */
+    public Map<String, XMLXsiTypeConverter<?>> getXsiTypeMap() {
+        return this.xsiTypeMap;
+    }
+
+    /**
+     * When parsing the XML into JSON, specifies that the values with attribute xsi:type
+     * will be converted to target type defined to client in this configuration
+     * <code>Map<String, XMLXsiTypeConverter<?>></code> to parse values with attribute
+     * xsi:type="integer" as integer,  xsi:type="string" as string
+     * @param xsiTypeMap  <code>new HashMap<String, XMLXsiTypeConverter<?>>()</code> to parse values with attribute
+     *                   xsi:type="integer" as integer,  xsi:type="string" as string
+     * @return The existing configuration will not be modified. A new configuration is returned.
+     */
+    public XMLParserConfiguration withXsiTypeMap(final Map<String, XMLXsiTypeConverter<?>> xsiTypeMap) {
+        XMLParserConfiguration newConfig = this.clone();
+        newConfig.xsiTypeMap = Collections.unmodifiableMap(xsiTypeMap);
         return newConfig;
     }
 }

--- a/src/main/java/org/json/XMLParserConfiguration.java
+++ b/src/main/java/org/json/XMLParserConfiguration.java
@@ -259,7 +259,7 @@ public class XMLParserConfiguration {
     /**
      * When parsing the XML into JSON, specifies that the values with attribute xsi:type
      * will be converted to target type defined to client in this configuration
-     * <code>Map<String, XMLXsiTypeConverter<?>></code> to parse values with attribute
+     * {@code Map<String, XMLXsiTypeConverter<?>>} to parse values with attribute
      * xsi:type="integer" as integer,  xsi:type="string" as string
      * @return {@link #xsiTypeMap} unmodifiable configuration map.
      */
@@ -270,9 +270,9 @@ public class XMLParserConfiguration {
     /**
      * When parsing the XML into JSON, specifies that the values with attribute xsi:type
      * will be converted to target type defined to client in this configuration
-     * <code>Map<String, XMLXsiTypeConverter<?>></code> to parse values with attribute
+     * {@code Map<String, XMLXsiTypeConverter<?>>} to parse values with attribute
      * xsi:type="integer" as integer,  xsi:type="string" as string
-     * @param xsiTypeMap  <code>new HashMap<String, XMLXsiTypeConverter<?>>()</code> to parse values with attribute
+     * @param xsiTypeMap  {@code new HashMap<String, XMLXsiTypeConverter<?>>()} to parse values with attribute
      *                   xsi:type="integer" as integer,  xsi:type="string" as string
      * @return The existing configuration will not be modified. A new configuration is returned.
      */

--- a/src/main/java/org/json/XMLXsiTypeConverter.java
+++ b/src/main/java/org/json/XMLXsiTypeConverter.java
@@ -1,5 +1,66 @@
 package org.json;
+/*
+Copyright (c) 2002 JSON.org
 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+The Software shall be used for Good, not Evil.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/**
+ * Type conversion configuration interface to be used with xsi:type attributes.
+ * <pre>
+ * <h1>XML Sample</h1>
+ * {@code
+ *      <root>
+ *          <asString xsi:type="string">12345</asString>
+ *          <asInt xsi:type="integer">54321</asInt>
+ *      </root>
+ * }
+ * <h1>JSON Output</h1>
+ * {@code
+ *     {
+ *         "root" : {
+ *             "asString" : "12345",
+ *             "asInt": 54321
+ *         }
+ *     }
+ * }
+ *
+ * <h1>Usage</h1>
+ * {@code
+ *      Map<String, XMLXsiTypeConverter<?>> xsiTypeMap = new HashMap<String, XMLXsiTypeConverter<?>>();
+ *      xsiTypeMap.put("string", new XMLXsiTypeConverter<String>() {
+ *          @Override public String convert(final String value) {
+ *              return value;
+ *          }
+ *      });
+ *      xsiTypeMap.put("integer", new XMLXsiTypeConverter<Integer>() {
+ *          @Override public Integer convert(final String value) {
+ *              return Integer.valueOf(value);
+ *          }
+ *      });
+ * }
+ * </pre>
+ * @author kumar529
+ * @param <T>
+ */
 public interface XMLXsiTypeConverter<T> {
     T convert(String value);
 }

--- a/src/main/java/org/json/XMLXsiTypeConverter.java
+++ b/src/main/java/org/json/XMLXsiTypeConverter.java
@@ -1,0 +1,5 @@
+package org.json;
+
+public interface XMLXsiTypeConverter<T> {
+    T convert(String value);
+}

--- a/src/main/java/org/json/XMLXsiTypeConverter.java
+++ b/src/main/java/org/json/XMLXsiTypeConverter.java
@@ -26,14 +26,14 @@ SOFTWARE.
 /**
  * Type conversion configuration interface to be used with xsi:type attributes.
  * <pre>
- * <h1>XML Sample</h1>
+ * <b>XML Sample</b>
  * {@code
  *      <root>
  *          <asString xsi:type="string">12345</asString>
  *          <asInt xsi:type="integer">54321</asInt>
  *      </root>
  * }
- * <h1>JSON Output</h1>
+ * <b>JSON Output</b>
  * {@code
  *     {
  *         "root" : {
@@ -43,23 +43,23 @@ SOFTWARE.
  *     }
  * }
  *
- * <h1>Usage</h1>
+ * <b>Usage</b>
  * {@code
  *      Map<String, XMLXsiTypeConverter<?>> xsiTypeMap = new HashMap<String, XMLXsiTypeConverter<?>>();
  *      xsiTypeMap.put("string", new XMLXsiTypeConverter<String>() {
- *          @Override public String convert(final String value) {
+ *          &#64;Override public String convert(final String value) {
  *              return value;
  *          }
  *      });
  *      xsiTypeMap.put("integer", new XMLXsiTypeConverter<Integer>() {
- *          @Override public Integer convert(final String value) {
+ *          &#64;Override public Integer convert(final String value) {
  *              return Integer.valueOf(value);
  *          }
  *      });
  * }
  * </pre>
  * @author kumar529
- * @param <T>
+ * @param <T> return type of convert method
  */
 public interface XMLXsiTypeConverter<T> {
     T convert(String value);

--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -972,5 +972,32 @@ public class XMLTest {
         
         assertEquals("Case insensitive Entity unescape",  expectedStr, actualStr);
     }
-    
+
+    /**
+     * test passes when xsi:type="java.lang.String" not converting to string
+     */
+    @Test
+    public void testToJsonWithTypeWhenTypeConversionDisabled() {
+        final String originalXml = "<root><id xsi:type=\"java.lang.String\">1234</id></root>";
+        final String expectedJsonString = "{\"root\":{\"id\":{\"xsi:type\":\"java.lang.String\",\"content\":1234}}}";
+        final JSONObject expectedJson = new JSONObject(expectedJsonString);
+        final JSONObject actualJson = XML.toJSONObject(originalXml, new XMLParserConfiguration());
+
+        Util.compareActualVsExpectedJsonObjects(actualJson,expectedJson);
+    }
+
+    /**
+     * test passes when xsi:type="java.lang.String" converting to String
+     */
+    @Test
+    public void testToJsonWithTypeWhenTypeConversionEnabled() {
+        final String originalXml = "<root><id1 xsi:type=\"java.lang.String\">1234</id1>"
+                + "<id2 xsi:type=\"java.lang.Integer\">1234</id2></root>";
+        final String expectedJsonString = "{\"root\":{\"id2\":1234,\"id1\":\"1234\"}}";
+        final JSONObject expectedJson = new JSONObject(expectedJsonString);
+        final JSONObject actualJson = XML.toJSONObject(originalXml, new XMLParserConfiguration(false,
+                "content", false, true));
+        Util.compareActualVsExpectedJsonObjects(actualJson,expectedJson);
+    }
+
 }

--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -1008,8 +1008,7 @@ public class XMLTest {
                 return Integer.valueOf(value);
             }
         });
-        JSONObject actualJson = XML.toJSONObject(originalXml, new XMLParserConfiguration(false,
-                "content", false, xsiTypeMap));
+        JSONObject actualJson = XML.toJSONObject(originalXml, new XMLParserConfiguration().withXsiTypeMap(xsiTypeMap));
         Util.compareActualVsExpectedJsonObjects(actualJson,expectedJson);
     }
 
@@ -1030,8 +1029,7 @@ public class XMLTest {
                 return Integer.valueOf(value);
             }
         });
-        JSONObject actualJson = XML.toJSONObject(originalXml, new XMLParserConfiguration(false,
-                "content", false, xsiTypeMap));
+        JSONObject actualJson = XML.toJSONObject(originalXml, new XMLParserConfiguration().withXsiTypeMap(xsiTypeMap));
         Util.compareActualVsExpectedJsonObjects(actualJson,expectedJson);
     }
 

--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -1013,4 +1013,26 @@ public class XMLTest {
         Util.compareActualVsExpectedJsonObjects(actualJson,expectedJson);
     }
 
+    @Test
+    public void testToJsonWithXSITypeWhenTypeConversionEnabled() {
+        String originalXml = "<root><asString xsi:type=\"string\">12345</asString><asInt "
+                + "xsi:type=\"integer\">54321</asInt></root>";
+        String expectedJsonString = "{\"root\":{\"asString\":\"12345\",\"asInt\":54321}}";
+        JSONObject expectedJson = new JSONObject(expectedJsonString);
+        Map<String, XMLXsiTypeConverter<?>> xsiTypeMap = new HashMap<String, XMLXsiTypeConverter<?>>();
+        xsiTypeMap.put("string", new XMLXsiTypeConverter<String>() {
+            @Override public String convert(final String value) {
+                return value;
+            }
+        });
+        xsiTypeMap.put("integer", new XMLXsiTypeConverter<Integer>() {
+            @Override public Integer convert(final String value) {
+                return Integer.valueOf(value);
+            }
+        });
+        JSONObject actualJson = XML.toJSONObject(originalXml, new XMLParserConfiguration(false,
+                "content", false, xsiTypeMap));
+        Util.compareActualVsExpectedJsonObjects(actualJson,expectedJson);
+    }
+
 }

--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -1033,4 +1033,39 @@ public class XMLTest {
         Util.compareActualVsExpectedJsonObjects(actualJson,expectedJson);
     }
 
+    @Test
+    public void testToJsonWithXSITypeWhenTypeConversionNotEnabledOnOne() {
+        String originalXml = "<root><asString xsi:type=\"string\">12345</asString><asInt>54321</asInt></root>";
+        String expectedJsonString = "{\"root\":{\"asString\":\"12345\",\"asInt\":54321}}";
+        JSONObject expectedJson = new JSONObject(expectedJsonString);
+        Map<String, XMLXsiTypeConverter<?>> xsiTypeMap = new HashMap<String, XMLXsiTypeConverter<?>>();
+        xsiTypeMap.put("string", new XMLXsiTypeConverter<String>() {
+            @Override public String convert(final String value) {
+                return value;
+            }
+        });
+        JSONObject actualJson = XML.toJSONObject(originalXml, new XMLParserConfiguration().withXsiTypeMap(xsiTypeMap));
+        Util.compareActualVsExpectedJsonObjects(actualJson,expectedJson);
+    }
+
+    @Test
+    public void testXSITypeMapNotModifiable() {
+        Map<String, XMLXsiTypeConverter<?>> xsiTypeMap = new HashMap<String, XMLXsiTypeConverter<?>>();
+        XMLParserConfiguration config = new XMLParserConfiguration().withXsiTypeMap(xsiTypeMap);
+        xsiTypeMap.put("string", new XMLXsiTypeConverter<String>() {
+            @Override public String convert(final String value) {
+                return value;
+            }
+        });
+        assertEquals("Config Conversion Map size is expected to be 0", 0, config.getXsiTypeMap().size());
+
+        try {
+            config.getXsiTypeMap().put("boolean", new XMLXsiTypeConverter<Boolean>() {
+                @Override public Boolean convert(final String value) {
+                    return Boolean.valueOf(value);
+                }
+            });
+            fail("Expected to be unable to modify the config");
+        } catch (Exception ignored) { }
+    }
 }


### PR DESCRIPTION
The lib doesn't support type conversion for a specific value.
I have added the feature to support type conversion for a specific tag.
Example:

//XML String
`<root><id1 xsi:type="java.lang.String">1234</id1><id2 xsi:type="java.lang.Integer">1234</id2></root>`

//Corresponding JSON String
`{"root":{"id2":1234,"id1":"1234"}}`