### PR TITLE
Fix xml hex entity parse

### DIFF
--- a/src/main/java/org/json/XMLTokener.java
+++ b/src/main/java/org/json/XMLTokener.java
@@ -167,7 +167,7 @@ public class XMLTokener extends JSONTokener {
         // if our entity is an encoded unicode point, parse it.
         if (e.charAt(0) == '#') {
             int cp;
-            if (e.charAt(1) == 'x') {
+            if (e.charAt(1) == 'x' || e.charAt(1) == 'X') {
                 // hex encoded unicode
                 cp = Integer.parseInt(e.substring(2), 16);
             } else {

--- a/src/test/java/org/json/junit/Util.java
+++ b/src/test/java/org/json/junit/Util.java
@@ -103,20 +103,18 @@ public class Util {
              */
             if (!(value instanceof Number && expectedValue instanceof Number)) {
                 // Non-Number and non-matching types
-                assertTrue("object types should be equal for actual: "+
-                    value.toString()+" ("+
-                    value.getClass().toString()+") expected: "+
-                    expectedValue.toString()+" ("+
-                    expectedValue.getClass().toString()+")",
-                    value.getClass().toString().equals(
-                            expectedValue.getClass().toString()));
+                assertEquals("object types should be equal ",
+                    expectedValue.getClass().toString(),
+                    value.getClass().toString()
+                );
             }
             /**
              * Same types or both Numbers, compare by toString()
              */
-            assertTrue("string values should be equal for actual: "+
-                value.toString()+" expected: "+expectedValue.toString(),
-                value.toString().equals(expectedValue.toString()));
+            assertEquals("values should be equal",
+                expectedValue.toString(),
+                value.toString()
+            );
         }
     }
 }

--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -939,4 +939,19 @@ public class XMLTest {
             fail("file writer error: " +e.getMessage());
         }
     }
+
+    /**
+     * Tests to verify that supported escapes in XML are converted to actual values.
+     */
+    @Test
+    public void testIssue537CaseSensitiveHexUnEscapeDirect(){
+        String origStr = 
+            "Neutrophils.Hypersegmented &#X7C; Bld-Ser-Plas";
+        String expectedStr = 
+            "Neutrophils.Hypersegmented | Bld-Ser-Plas";
+        String actualStr = XML.unescape(origStr);
+        
+        assertEquals("Case insensitive Entity unescape",  expectedStr, actualStr);
+    }
+    
 }

--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -34,12 +34,15 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.json.JSONTokener;
 import org.json.XML;
 import org.json.XMLParserConfiguration;
 import org.junit.Rule;
@@ -897,5 +900,43 @@ public class XMLTest {
 
         final JSONObject json = XML.toJSONObject(originalXml, new XMLParserConfiguration());
         assertEquals(expectedJsonString, json.toString());
+    }
+
+    /**
+     * Tests to verify that supported escapes in XML are converted to actual values.
+     */
+    @Test
+    public void testIssue537CaseSensitiveHexEscapeMinimal(){
+        String xmlStr = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+
+            "<root>Neutrophils.Hypersegmented &#X7C; Bld-Ser-Plas</root>";
+        String expectedStr = 
+            "{\"root\":\"Neutrophils.Hypersegmented | Bld-Ser-Plas\"}";
+        JSONObject xmlJSONObj = XML.toJSONObject(xmlStr, true);
+        JSONObject expected = new JSONObject(expectedStr);
+        Util.compareActualVsExpectedJsonObjects(xmlJSONObj, expected);
+    }
+
+    /**
+     * Tests to verify that supported escapes in XML are converted to actual values.
+     */
+    @Test
+    public void testIssue537CaseSensitiveHexEscapeFullFile(){
+        try {
+            try(
+                    InputStream xmlStream = XMLTest.class.getClassLoader().getResourceAsStream("Issue537.xml");
+                    Reader xmlReader = new InputStreamReader(xmlStream);
+                ){
+                JSONObject actual = XML.toJSONObject(xmlReader, true);
+                try(
+                        InputStream jsonStream = XMLTest.class.getClassLoader().getResourceAsStream("Issue537.json");
+                    ){
+                    final JSONObject expected = new JSONObject(new JSONTokener(jsonStream));
+                    Util.compareActualVsExpectedJsonObjects(actual,expected);
+                }
+            }
+        } catch (IOException e) {
+            fail("file writer error: " +e.getMessage());
+        }
     }
 }

--- a/src/test/resources/Issue537.json
+++ b/src/test/resources/Issue537.json
@@ -1,0 +1,189 @@
+{
+ "clinical_study": {
+  "brief_summary": {
+   "textblock": "CLEAR SYNERGY is an international multi center 2x2 randomized placebo controlled trial of\r\n      colchicine and spironolactone in patients with STEMI. Subjects enrolled in the main CLEAR\r\n      SYNERGY trial will be asked to participate in this sub study (n=670) to undergo:\r\n\r\n        1. Evaluation of markers of neutrophil activity at randomization (baseline) and 3 months\r\n           follow-up in the colchicine versus placebo groups, and;\r\n\r\n        2. Examination of clinical and genetic factors that determine heterogeneity of treatment\r\n           response and distinguish colchicine responders from non- responders.\r\n\r\n      Participants undergo a blood draw at baseline and 3 months follow-up as part of the main\r\n      trial, and participants who also participate in this sub study will have an additional 2\r\n      tablespoons of blood drawn.\r\n\r\n      The sub study objectives are to:\r\n\r\n        1. Assess the effect of colchicine on neutrophil activation in response to STEMI.\r\n\r\n        2. Examine clinical and genetic factors that determine heterogeneity of treatment response\r\n           anddistinguish colchicine responders from non- responders.\r\n\r\n        3. Explore the derivation of a risk score that includes markers of neutrophil activity and\r\n           is associated with adjudicated MACE over 3 years after STEMI, and assess the impact of\r\n           colchicine on the relation between this risk score and MACE."
+  },
+  "brief_title": "CLEAR SYNERGY Neutrophil Substudy",
+  "overall_status": "Recruiting",
+  "eligibility": {
+   "study_pop": {
+    "textblock": "Patients who are randomized to the drug RCT portion of the CLEAR SYNERGY (OASIS 9) trial\r\n        will be eligible for participation in this Neutrophil biomarker substudy. These are\r\n        patients who present with STEMI."
+   },
+   "minimum_age": "19 Years",
+   "sampling_method": "Non-Probability Sample",
+   "gender": "All",
+   "criteria": {
+    "textblock": "Inclusion Criteria:\r\n\r\n          -  Patients who are randomized to the drug RCT portion of the CLEAR SYNERGY (OASIS 9)\r\n             trial will be eligible for participation in this Neutrophil biomarker substudy.\r\n\r\n        Exclusion Criteria:\r\n\r\n          -  Use of anti-inflammatory agents (except aspirin)\r\n\r\n          -  Active infection"
+   },
+   "healthy_volunteers": "No",
+   "maximum_age": "110 Years"
+  },
+  "number_of_groups": "2",
+  "source": "NYU Langone Health",
+  "location_countries": {
+   "country": "United States"
+  },
+  "study_design_info": {
+   "time_perspective": "Prospective",
+   "observational_model": "Other"
+  },
+  "last_update_submitted_qc": "September 10, 2019",
+  "intervention_browse": {
+   "mesh_term": "Colchicine"
+  },
+  "official_title": "Studies on the Effects of Colchicine on Neutrophil Biology in Acute Myocardial Infarction: A Substudy of the CLEAR SYNERGY (OASIS 9) Trial",
+  "primary_completion_date": {
+   "type": "Anticipated",
+   "content": "February 1, 2021"
+  },
+  "sponsors": {
+   "lead_sponsor": {
+    "agency_class": "Other",
+    "agency": "NYU Langone Health"
+   },
+   "collaborator": [
+    {
+     "agency_class": "Other",
+     "agency": "Population Health Research Institute"
+    },
+    {
+     "agency_class": "NIH",
+     "agency": "National Heart, Lung, and Blood Institute (NHLBI)"
+    }
+   ]
+  },
+  "overall_official": {
+   "role": "Principal Investigator",
+   "affiliation": "NYU School of Medicine",
+   "last_name": "Binita Shah, MD"
+  },
+  "overall_contact_backup": {
+   "last_name": "Binita Shah, MD"
+  },
+  "condition_browse": {
+   "mesh_term": [
+    "Myocardial Infarction",
+    "ST Elevation Myocardial Infarction",
+    "Infarction"
+   ]
+  },
+  "overall_contact": {
+   "phone": "646-501-9648",
+   "last_name": "Fatmira Curovic",
+   "email": "fatmira.curovic@nyumc.org"
+  },
+  "responsible_party": {
+   "responsible_party_type": "Principal Investigator",
+   "investigator_title": "Assistant Professor of Medicine",
+   "investigator_full_name": "Binita Shah",
+   "investigator_affiliation": "NYU Langone Health"
+  },
+  "study_first_submitted_qc": "March 12, 2019",
+  "start_date": {
+   "type": "Actual",
+   "content": "March 4, 2019"
+  },
+  "has_expanded_access": "No",
+  "study_first_posted": {
+   "type": "Actual",
+   "content": "March 14, 2019"
+  },
+  "arm_group": [
+   {
+    "arm_group_label": "Colchicine"
+   },
+   {
+    "arm_group_label": "Placebo"
+   }
+  ],
+  "primary_outcome": {
+   "measure": "soluble L-selectin",
+   "time_frame": "between baseline and 3 months",
+   "description": "Change in soluble L-selectin between baseline and 3 mo after STEMI in the placebo vs. colchicine groups."
+  },
+  "secondary_outcome": [
+   {
+    "measure": "Other soluble markers of neutrophil activity",
+    "time_frame": "between baseline and 3 months",
+    "description": "Other markers of neutrophil activity will be evaluated at baseline and 3 months after STEMI (myeloperoxidase, matrix metalloproteinase-9, neutrophil gelatinase-associated lipocalin, neutrophil elastase, intercellular/vascular cellular adhesion molecules)"
+   },
+   {
+    "measure": "Markers of systemic inflammation",
+    "time_frame": "between baseline and 3 months",
+    "description": "Markers of systemic inflammation will be evaluated at baseline and 3 months after STEMI (high sensitive CRP, IL-1β)"
+   },
+   {
+    "measure": "Neutrophil-driven responses that may further propagate injury",
+    "time_frame": "between baseline and 3 months",
+    "description": "Neutrophil-driven responses that may further propagate injury will be evaluated at baseline and 3 months after STEMI (neutrophil extracellular traps, neutrophil-derived microparticles)"
+   }
+  ],
+  "oversight_info": {
+   "is_fda_regulated_drug": "No",
+   "is_fda_regulated_device": "No",
+   "has_dmc": "No"
+  },
+  "last_update_posted": {
+   "type": "Actual",
+   "content": "September 12, 2019"
+  },
+  "id_info": {
+   "nct_id": "NCT03874338",
+   "org_study_id": "18-01323",
+   "secondary_id": "1R01HL146206"
+  },
+  "enrollment": {
+   "type": "Anticipated",
+   "content": "670"
+  },
+  "study_first_submitted": "March 12, 2019",
+  "condition": [
+   "Neutrophils.Hypersegmented | Bld-Ser-Plas",
+   "STEMI - ST Elevation Myocardial Infarction"
+  ],
+  "study_type": "Observational",
+  "required_header": {
+   "download_date": "ClinicalTrials.gov processed this data on July 19, 2020",
+   "link_text": "Link to the current ClinicalTrials.gov record.",
+   "url": "https://clinicaltrials.gov/show/NCT03874338"
+  },
+  "last_update_submitted": "September 10, 2019",
+  "completion_date": {
+   "type": "Anticipated",
+   "content": "February 1, 2022"
+  },
+  "location": {
+   "contact": {
+    "phone": "646-501-9648",
+    "last_name": "Fatmira Curovic",
+    "email": "fatmira.curovic@nyumc.org"
+   },
+   "facility": {
+    "address": {
+     "zip": "10016",
+     "country": "United States",
+     "city": "New York",
+     "state": "New York"
+    },
+    "name": "NYU School of Medicine"
+   },
+   "status": "Recruiting",
+   "contact_backup": {
+    "last_name": "Binita Shah, MD"
+   }
+  },
+  "intervention": {
+   "intervention_type": "Drug",
+   "arm_group_label": [
+    "Colchicine",
+    "Placebo"
+   ],
+   "description": "Participants in the main CLEAR SYNERGY trial are randomized to colchicine/spironolactone versus placebo in a 2x2 factorial design. The substudy is interested in the evaluation of biospecimens obtained from patients in the colchicine vs placebo group.",
+   "intervention_name": "Colchicine Pill"
+  },
+  "patient_data": {
+   "sharing_ipd": "No"
+  },
+  "verification_date": "September 2019"
+ }
+}

--- a/src/test/resources/Issue537.json
+++ b/src/test/resources/Issue537.json
@@ -1,19 +1,19 @@
 {
  "clinical_study": {
   "brief_summary": {
-   "textblock": "CLEAR SYNERGY is an international multi center 2x2 randomized placebo controlled trial of\r\n      colchicine and spironolactone in patients with STEMI. Subjects enrolled in the main CLEAR\r\n      SYNERGY trial will be asked to participate in this sub study (n=670) to undergo:\r\n\r\n        1. Evaluation of markers of neutrophil activity at randomization (baseline) and 3 months\r\n           follow-up in the colchicine versus placebo groups, and;\r\n\r\n        2. Examination of clinical and genetic factors that determine heterogeneity of treatment\r\n           response and distinguish colchicine responders from non- responders.\r\n\r\n      Participants undergo a blood draw at baseline and 3 months follow-up as part of the main\r\n      trial, and participants who also participate in this sub study will have an additional 2\r\n      tablespoons of blood drawn.\r\n\r\n      The sub study objectives are to:\r\n\r\n        1. Assess the effect of colchicine on neutrophil activation in response to STEMI.\r\n\r\n        2. Examine clinical and genetic factors that determine heterogeneity of treatment response\r\n           anddistinguish colchicine responders from non- responders.\r\n\r\n        3. Explore the derivation of a risk score that includes markers of neutrophil activity and\r\n           is associated with adjudicated MACE over 3 years after STEMI, and assess the impact of\r\n           colchicine on the relation between this risk score and MACE."
+   "textblock": "CLEAR SYNERGY is an international multi center 2x2 randomized placebo controlled trial of"
   },
   "brief_title": "CLEAR SYNERGY Neutrophil Substudy",
   "overall_status": "Recruiting",
   "eligibility": {
    "study_pop": {
-    "textblock": "Patients who are randomized to the drug RCT portion of the CLEAR SYNERGY (OASIS 9) trial\r\n        will be eligible for participation in this Neutrophil biomarker substudy. These are\r\n        patients who present with STEMI."
+    "textblock": "Patients who are randomized to the drug RCT portion of the CLEAR SYNERGY (OASIS 9) trial"
    },
    "minimum_age": "19 Years",
    "sampling_method": "Non-Probability Sample",
    "gender": "All",
    "criteria": {
-    "textblock": "Inclusion Criteria:\r\n\r\n          -  Patients who are randomized to the drug RCT portion of the CLEAR SYNERGY (OASIS 9)\r\n             trial will be eligible for participation in this Neutrophil biomarker substudy.\r\n\r\n        Exclusion Criteria:\r\n\r\n          -  Use of anti-inflammatory agents (except aspirin)\r\n\r\n          -  Active infection"
+    "textblock": "Inclusion Criteria:"
    },
    "healthy_volunteers": "No",
    "maximum_age": "110 Years"

--- a/src/test/resources/Issue537.xml
+++ b/src/test/resources/Issue537.xml
@@ -37,29 +37,6 @@
   <brief_summary>
     <textblock>
       CLEAR SYNERGY is an international multi center 2x2 randomized placebo controlled trial of
-      colchicine and spironolactone in patients with STEMI. Subjects enrolled in the main CLEAR
-      SYNERGY trial will be asked to participate in this sub study (n=670) to undergo:
-
-        1. Evaluation of markers of neutrophil activity at randomization (baseline) and 3 months
-           follow-up in the colchicine versus placebo groups, and;
-
-        2. Examination of clinical and genetic factors that determine heterogeneity of treatment
-           response and distinguish colchicine responders from non- responders.
-
-      Participants undergo a blood draw at baseline and 3 months follow-up as part of the main
-      trial, and participants who also participate in this sub study will have an additional 2
-      tablespoons of blood drawn.
-
-      The sub study objectives are to:
-
-        1. Assess the effect of colchicine on neutrophil activation in response to STEMI.
-
-        2. Examine clinical and genetic factors that determine heterogeneity of treatment response
-           anddistinguish colchicine responders from non- responders.
-
-        3. Explore the derivation of a risk score that includes markers of neutrophil activity and
-           is associated with adjudicated MACE over 3 years after STEMI, and assess the impact of
-           colchicine on the relation between this risk score and MACE.
     </textblock>
   </brief_summary>
   <overall_status>Recruiting</overall_status>
@@ -113,23 +90,12 @@
     <study_pop>
       <textblock>
         Patients who are randomized to the drug RCT portion of the CLEAR SYNERGY (OASIS 9) trial
-        will be eligible for participation in this Neutrophil biomarker substudy. These are
-        patients who present with STEMI.
       </textblock>
     </study_pop>
     <sampling_method>Non-Probability Sample</sampling_method>
     <criteria>
       <textblock>
         Inclusion Criteria:
-
-          -  Patients who are randomized to the drug RCT portion of the CLEAR SYNERGY (OASIS 9)
-             trial will be eligible for participation in this Neutrophil biomarker substudy.
-
-        Exclusion Criteria:
-
-          -  Use of anti-inflammatory agents (except aspirin)
-
-          -  Active infection
       </textblock>
     </criteria>
     <gender>All</gender>

--- a/src/test/resources/Issue537.xml
+++ b/src/test/resources/Issue537.xml
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<clinical_study>
+  <!-- This xml conforms to an XML Schema at:
+    https://clinicaltrials.gov/ct2/html/images/info/public.xsd -->
+  <required_header>
+    <download_date>ClinicalTrials.gov processed this data on July 19, 2020</download_date>
+    <link_text>Link to the current ClinicalTrials.gov record.</link_text>
+    <url>https://clinicaltrials.gov/show/NCT03874338</url>
+  </required_header>
+  <id_info>
+    <org_study_id>18-01323</org_study_id>
+    <secondary_id>1R01HL146206</secondary_id>
+    <nct_id>NCT03874338</nct_id>
+  </id_info>
+  <brief_title>CLEAR SYNERGY Neutrophil Substudy</brief_title>
+  <official_title>Studies on the Effects of Colchicine on Neutrophil Biology in Acute Myocardial Infarction: A Substudy of the CLEAR SYNERGY (OASIS 9) Trial</official_title>
+  <sponsors>
+    <lead_sponsor>
+      <agency>NYU Langone Health</agency>
+      <agency_class>Other</agency_class>
+    </lead_sponsor>
+    <collaborator>
+      <agency>Population Health Research Institute</agency>
+      <agency_class>Other</agency_class>
+    </collaborator>
+    <collaborator>
+      <agency>National Heart, Lung, and Blood Institute (NHLBI)</agency>
+      <agency_class>NIH</agency_class>
+    </collaborator>
+  </sponsors>
+  <source>NYU Langone Health</source>
+  <oversight_info>
+    <has_dmc>No</has_dmc>
+    <is_fda_regulated_drug>No</is_fda_regulated_drug>
+    <is_fda_regulated_device>No</is_fda_regulated_device>
+  </oversight_info>
+  <brief_summary>
+    <textblock>
+      CLEAR SYNERGY is an international multi center 2x2 randomized placebo controlled trial of
+      colchicine and spironolactone in patients with STEMI. Subjects enrolled in the main CLEAR
+      SYNERGY trial will be asked to participate in this sub study (n=670) to undergo:
+
+        1. Evaluation of markers of neutrophil activity at randomization (baseline) and 3 months
+           follow-up in the colchicine versus placebo groups, and;
+
+        2. Examination of clinical and genetic factors that determine heterogeneity of treatment
+           response and distinguish colchicine responders from non- responders.
+
+      Participants undergo a blood draw at baseline and 3 months follow-up as part of the main
+      trial, and participants who also participate in this sub study will have an additional 2
+      tablespoons of blood drawn.
+
+      The sub study objectives are to:
+
+        1. Assess the effect of colchicine on neutrophil activation in response to STEMI.
+
+        2. Examine clinical and genetic factors that determine heterogeneity of treatment response
+           anddistinguish colchicine responders from non- responders.
+
+        3. Explore the derivation of a risk score that includes markers of neutrophil activity and
+           is associated with adjudicated MACE over 3 years after STEMI, and assess the impact of
+           colchicine on the relation between this risk score and MACE.
+    </textblock>
+  </brief_summary>
+  <overall_status>Recruiting</overall_status>
+  <start_date type="Actual">March 4, 2019</start_date>
+  <completion_date type="Anticipated">February 1, 2022</completion_date>
+  <primary_completion_date type="Anticipated">February 1, 2021</primary_completion_date>
+  <study_type>Observational</study_type>
+  <has_expanded_access>No</has_expanded_access>
+  <study_design_info>
+    <observational_model>Other</observational_model>
+    <time_perspective>Prospective</time_perspective>
+  </study_design_info>
+  <primary_outcome>
+    <measure>soluble L-selectin</measure>
+    <time_frame>between baseline and 3 months</time_frame>
+    <description>Change in soluble L-selectin between baseline and 3 mo after STEMI in the placebo vs. colchicine groups.</description>
+  </primary_outcome>
+  <secondary_outcome>
+    <measure>Other soluble markers of neutrophil activity</measure>
+    <time_frame>between baseline and 3 months</time_frame>
+    <description>Other markers of neutrophil activity will be evaluated at baseline and 3 months after STEMI (myeloperoxidase, matrix metalloproteinase-9, neutrophil gelatinase-associated lipocalin, neutrophil elastase, intercellular/vascular cellular adhesion molecules)</description>
+  </secondary_outcome>
+  <secondary_outcome>
+    <measure>Markers of systemic inflammation</measure>
+    <time_frame>between baseline and 3 months</time_frame>
+    <description>Markers of systemic inflammation will be evaluated at baseline and 3 months after STEMI (high sensitive CRP, IL-1β)</description>
+  </secondary_outcome>
+  <secondary_outcome>
+    <measure>Neutrophil-driven responses that may further propagate injury</measure>
+    <time_frame>between baseline and 3 months</time_frame>
+    <description>Neutrophil-driven responses that may further propagate injury will be evaluated at baseline and 3 months after STEMI (neutrophil extracellular traps, neutrophil-derived microparticles)</description>
+  </secondary_outcome>
+  <number_of_groups>2</number_of_groups>
+  <enrollment type="Anticipated">670</enrollment>
+  <condition>Neutrophils.Hypersegmented &#X7C; Bld-Ser-Plas</condition>
+  <condition>STEMI - ST Elevation Myocardial Infarction</condition>
+  <arm_group>
+    <arm_group_label>Colchicine</arm_group_label>
+  </arm_group>
+  <arm_group>
+    <arm_group_label>Placebo</arm_group_label>
+  </arm_group>
+  <intervention>
+    <intervention_type>Drug</intervention_type>
+    <intervention_name>Colchicine Pill</intervention_name>
+    <description>Participants in the main CLEAR SYNERGY trial are randomized to colchicine/spironolactone versus placebo in a 2x2 factorial design. The substudy is interested in the evaluation of biospecimens obtained from patients in the colchicine vs placebo group.</description>
+    <arm_group_label>Colchicine</arm_group_label>
+    <arm_group_label>Placebo</arm_group_label>
+  </intervention>
+  <eligibility>
+    <study_pop>
+      <textblock>
+        Patients who are randomized to the drug RCT portion of the CLEAR SYNERGY (OASIS 9) trial
+        will be eligible for participation in this Neutrophil biomarker substudy. These are
+        patients who present with STEMI.
+      </textblock>
+    </study_pop>
+    <sampling_method>Non-Probability Sample</sampling_method>
+    <criteria>
+      <textblock>
+        Inclusion Criteria:
+
+          -  Patients who are randomized to the drug RCT portion of the CLEAR SYNERGY (OASIS 9)
+             trial will be eligible for participation in this Neutrophil biomarker substudy.
+
+        Exclusion Criteria:
+
+          -  Use of anti-inflammatory agents (except aspirin)
+
+          -  Active infection
+      </textblock>
+    </criteria>
+    <gender>All</gender>
+    <minimum_age>19 Years</minimum_age>
+    <maximum_age>110 Years</maximum_age>
+    <healthy_volunteers>No</healthy_volunteers>
+  </eligibility>
+  <overall_official>
+    <last_name>Binita Shah, MD</last_name>
+    <role>Principal Investigator</role>
+    <affiliation>NYU School of Medicine</affiliation>
+  </overall_official>
+  <overall_contact>
+    <last_name>Fatmira Curovic</last_name>
+    <phone>646-501-9648</phone>
+    <email>fatmira.curovic@nyumc.org</email>
+  </overall_contact>
+  <overall_contact_backup>
+    <last_name>Binita Shah, MD</last_name>
+  </overall_contact_backup>
+  <location>
+    <facility>
+      <name>NYU School of Medicine</name>
+      <address>
+        <city>New York</city>
+        <state>New York</state>
+        <zip>10016</zip>
+        <country>United States</country>
+      </address>
+    </facility>
+    <status>Recruiting</status>
+    <contact>
+      <last_name>Fatmira Curovic</last_name>
+      <phone>646-501-9648</phone>
+      <email>fatmira.curovic@nyumc.org</email>
+    </contact>
+    <contact_backup>
+      <last_name>Binita Shah, MD</last_name>
+    </contact_backup>
+  </location>
+  <location_countries>
+    <country>United States</country>
+  </location_countries>
+  <verification_date>September 2019</verification_date>
+  <study_first_submitted>March 12, 2019</study_first_submitted>
+  <study_first_submitted_qc>March 12, 2019</study_first_submitted_qc>
+  <study_first_posted type="Actual">March 14, 2019</study_first_posted>
+  <last_update_submitted>September 10, 2019</last_update_submitted>
+  <last_update_submitted_qc>September 10, 2019</last_update_submitted_qc>
+  <last_update_posted type="Actual">September 12, 2019</last_update_posted>
+  <responsible_party>
+    <responsible_party_type>Principal Investigator</responsible_party_type>
+    <investigator_affiliation>NYU Langone Health</investigator_affiliation>
+    <investigator_full_name>Binita Shah</investigator_full_name>
+    <investigator_title>Assistant Professor of Medicine</investigator_title>
+  </responsible_party>
+  <condition_browse>
+    <!-- CAUTION:  The following MeSH terms are assigned with an imperfect algorithm            -->
+    <mesh_term>Myocardial Infarction</mesh_term>
+    <mesh_term>ST Elevation Myocardial Infarction</mesh_term>
+    <mesh_term>Infarction</mesh_term>
+  </condition_browse>
+  <intervention_browse>
+    <!-- CAUTION:  The following MeSH terms are assigned with an imperfect algorithm            -->
+    <mesh_term>Colchicine</mesh_term>
+  </intervention_browse>
+  <patient_data>
+    <sharing_ipd>No</sharing_ipd>
+  </patient_data>
+  <!-- Results have not yet been posted for this study                                          -->
+</clinical_study>


### PR DESCRIPTION
fixes #537 

**What problem does this code solve?**

Corrects bug in `XML.unescape` where it was incorrectly passing entities to be unescaped without lower-casing first as the tokener does internally. This corrects the issue at the tokener level by not requiring the entity to be lowercase before processing.

**Risks**

None. Bug fix

**Changes to the API?**

No

**Will this require a new release?**

Yes

**Should the documentation be updated?**

No need

**Does it break the unit tests?**

No. New unit tests have been added showing the tokener properly parsing, but the direct call failing, then succeeding after the code change

**Was any code refactored in this commit?**

Just some test calls to make error reporting easier to read:
changed some calls that looked like this:
```java
// hard to read in error logs
assertTrue("some message", actual.equals(expected));
```
to
```java
// easier to read in error logs
assertEquals("some message", expected, actual);
````

**Review status**
**APPROVED**