### PR TITLE
Updates for JSONArray.putAll methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,45 @@ Some notable exceptions that the JSON Parser in this library accepts are:
 * Unescaped literals like "tab" in string values `{ "key": "value   with an unescaped tab" }`
 * Numbers out of range for `Double` or `Long` are parsed as strings
 
+Recent pull requests added a new method `putAll` on the JSONArray. The `putAll` method
+works similarly as other `put` mehtods in that it does not call `JSONObject.wrap` for items
+added. This can lead to inconsistent object representation in JSONArray structures.
+
+For example, code like this will create a mixed JSONArray, some items wrapped, others
+not:
+
+```java
+SomeBean[] myArr = new SomeBean[]{ new SomeBean(1), new SomeBean(2) };
+// these will be wrapped
+JSONArray jArr = new JSONArray(myArr);
+// these will not be wrapped
+jArr.putAll(new SomeBean[]{ new SomeBean(3), new SomeBean(4) });
+```
+
+For structure consistency, it would be recommended that the above code is changed
+to look like 1 of 2 ways.
+
+Option 1:
+```Java
+SomeBean[] myArr = new SomeBean[]{ new SomeBean(1), new SomeBean(2) };
+JSONArray jArr = new JSONArray();
+// these will not be wrapped
+jArr.putAll(myArr);
+// these will not be wrapped
+jArr.putAll(new SomeBean[]{ new SomeBean(3), new SomeBean(4) });
+// our jArr is now consistent.
+```
+
+Option 2:
+```Java
+SomeBean[] myArr = new SomeBean[]{ new SomeBean(1), new SomeBean(2) };
+// these will be wrapped
+JSONArray jArr = new JSONArray(myArr);
+// these will be wrapped
+jArr.putAll(new JSONArray(new SomeBean[]{ new SomeBean(3), new SomeBean(4) }));
+// our jArr is now consistent.
+```
+
 **Unit Test Conventions**
 
 Test filenames should consist of the name of the module being tested, with the suffix "Test". 

--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -1242,12 +1242,12 @@ public class JSONArray implements Iterable<Object> {
      * Put an array's elements in to the JSONArray.
      *
      * @param array
-     *            Array. If the parameter passed is null, or not an array, an
+     *            Array. If the parameter passed is null, or not an array or Iterable, an
      *            exception will be thrown.
      * @return this. 
      *
      * @throws JSONException
-     *            If not an array or if an array value is non-finite number.
+     *            If not an array, JSONArray, Iterable or if an value is non-finite number.
      * @throws NullPointerException
      *            Thrown if the array parameter is null.
      */

--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -194,15 +194,16 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Construct a JSONArray from another JSONArray. This is a shallow copy.
      *
-     * @param collection
-     *            A Collection.
+     * @param array
+     *            A array.
      */
     public JSONArray(JSONArray array) {
         if (array == null) {
             this.myArrayList = new ArrayList<Object>();
         } else {
-            this.myArrayList = new ArrayList<Object>(array.length());
-            this.addAll(array.myArrayList);
+            // shallow copy directly the internal array lists as any wrapping
+            // should have been done already in the original JSONArray
+            this.myArrayList = new ArrayList<Object>(array.myArrayList);
         }
     }
 
@@ -1213,7 +1214,7 @@ public class JSONArray implements Iterable<Object> {
      * Put an Iterable's elements in to the JSONArray.
      *
      * @param iter
-     *            A Collection.
+     *            An Iterable.
      * @return this. 
      */
     public JSONArray putAll(Iterable<?> iter) {
@@ -1229,7 +1230,9 @@ public class JSONArray implements Iterable<Object> {
      * @return this. 
      */
     public JSONArray putAll(JSONArray array) {
-        this.addAll(array.myArrayList);
+        // directly copy the elements from the source array to this one
+        // as all wrapping should have been done already in the source.
+        this.myArrayList.addAll(array.myArrayList);
         return this;
     }
 
@@ -1606,8 +1609,9 @@ public class JSONArray implements Iterable<Object> {
      * Add an array's elements to the JSONArray.
      *
      * @param array
-     *            Array. If the parameter passed is null, or not an array, an
-     *            exception will be thrown.
+     *            Array. If the parameter passed is null, or not an array,
+     *            JSONArray, Collection, or Iterable, an exception will be
+     *            thrown.
      *
      * @throws JSONException
      *            If not an array or if an array value is non-finite number.
@@ -1622,7 +1626,10 @@ public class JSONArray implements Iterable<Object> {
                 this.put(JSONObject.wrap(Array.get(array, i)));
             }
         } else if (array instanceof JSONArray) {
-            this.addAll(((JSONArray)array).myArrayList);
+            // use the built in array list `addAll` as all object
+            // wrapping should have been completed in the original
+            // JSONArray
+            this.myArrayList.addAll(((JSONArray)array).myArrayList);
         } else if (array instanceof Collection) {
             this.addAll((Collection<?>)array);
         } else if (array instanceof Iterable) {

--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -178,6 +178,35 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
+     * Construct a JSONArray from an Iterable. This is a shallow copy.
+     *
+     * @param iter
+     *            A Iterable collection.
+     */
+    public JSONArray(Iterable<?> iter) {
+        this();
+        if (iter == null) {
+            return;
+        }
+        this.addAll(iter);
+    }
+
+    /**
+     * Construct a JSONArray from another JSONArray. This is a shallow copy.
+     *
+     * @param collection
+     *            A Collection.
+     */
+    public JSONArray(JSONArray array) {
+        if (array == null) {
+            this.myArrayList = new ArrayList<Object>();
+        } else {
+            this.myArrayList = new ArrayList<Object>(array.length());
+            this.addAll(array.myArrayList);
+        }
+    }
+
+    /**
      * Construct a JSONArray from an array.
      *
      * @param array
@@ -191,6 +220,10 @@ public class JSONArray implements Iterable<Object> {
      */
     public JSONArray(Object array) throws JSONException {
         this();
+        if (!array.getClass().isArray()) {
+            throw new JSONException(
+                    "JSONArray initial value should be a string or collection or array.");
+        }
         this.addAll(array);
     }
 
@@ -208,6 +241,11 @@ public class JSONArray implements Iterable<Object> {
                     "JSONArray initial capacity cannot be negative.");
     	}
     	this.myArrayList = new ArrayList<Object>(initialCapacity);
+    }
+
+    @Override
+    protected Object clone() {
+        return new JSONArray(this.myArrayList);
     }
 
     @Override
@@ -1165,7 +1203,7 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Put or replace a collection's elements in the JSONArray.
+     * Put a collection's elements in to the JSONArray.
      *
      * @param collection
      *            A Collection.
@@ -1175,9 +1213,33 @@ public class JSONArray implements Iterable<Object> {
         this.addAll(collection);
         return this;
     }
+    
+    /**
+     * Put an Iterable's elements in to the JSONArray.
+     *
+     * @param iter
+     *            A Collection.
+     * @return this. 
+     */
+    public JSONArray putAll(Iterable<?> iter) {
+        this.addAll(iter);
+        return this;
+    }
 
     /**
-     * Put or replace an array's elements in the JSONArray.
+     * Put a JSONArray's elements in to the JSONArray.
+     *
+     * @param array
+     *            A JSONArray.
+     * @return this. 
+     */
+    public JSONArray putAll(JSONArray array) {
+        this.addAll(array.myArrayList);
+        return this;
+    }
+
+    /**
+     * Put an array's elements in to the JSONArray.
      *
      * @param array
      *            Array. If the parameter passed is null, or not an array, an
@@ -1520,7 +1582,6 @@ public class JSONArray implements Iterable<Object> {
         return this.myArrayList.isEmpty();
     }
 
-
     /**
      * Add a collection's elements to the JSONArray.
      *
@@ -1534,6 +1595,18 @@ public class JSONArray implements Iterable<Object> {
         }
     }
 
+    /**
+     * Add an Iterable's elements to the JSONArray.
+     *
+     * @param iter
+     *            An Iterable.
+     */
+    private void addAll(Iterable<?> iter) {
+        for (Object o: iter){
+            this.myArrayList.add(JSONObject.wrap(o));
+        }
+    }
+    
     /**
      * Add an array's elements to the JSONArray.
      *
@@ -1553,6 +1626,12 @@ public class JSONArray implements Iterable<Object> {
             for (int i = 0; i < length; i += 1) {
                 this.put(JSONObject.wrap(Array.get(array, i)));
             }
+        } else if (array instanceof JSONArray) {
+            this.addAll(((JSONArray)array).myArrayList);
+        } else if (array instanceof Collection) {
+            this.addAll((Collection<?>)array);
+        } else if (array instanceof Iterable) {
+            this.addAll((Iterable<?>)array);
         } else {
             throw new JSONException(
                     "JSONArray initial value should be a string or collection or array.");

--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -244,11 +244,6 @@ public class JSONArray implements Iterable<Object> {
     }
 
     @Override
-    protected Object clone() {
-        return new JSONArray(this.myArrayList);
-    }
-
-    @Override
     public Iterator<Object> iterator() {
         return this.myArrayList.iterator();
     }

--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -173,7 +173,7 @@ public class JSONArray implements Iterable<Object> {
             this.myArrayList = new ArrayList<Object>();
         } else {
             this.myArrayList = new ArrayList<Object>(collection.size());
-            this.addAll(collection);
+            this.addAll(collection, true);
         }
     }
 
@@ -188,7 +188,7 @@ public class JSONArray implements Iterable<Object> {
         if (iter == null) {
             return;
         }
-        this.addAll(iter);
+        this.addAll(iter, true);
     }
 
     /**
@@ -225,7 +225,7 @@ public class JSONArray implements Iterable<Object> {
             throw new JSONException(
                     "JSONArray initial value should be a string or collection or array.");
         }
-        this.addAll(array);
+        this.addAll(array, true);
     }
 
     /**
@@ -1206,7 +1206,7 @@ public class JSONArray implements Iterable<Object> {
      * @return this. 
      */
     public JSONArray putAll(Collection<?> collection) {
-        this.addAll(collection);
+        this.addAll(collection, false);
         return this;
     }
     
@@ -1218,7 +1218,7 @@ public class JSONArray implements Iterable<Object> {
      * @return this. 
      */
     public JSONArray putAll(Iterable<?> iter) {
-        this.addAll(iter);
+        this.addAll(iter, false);
         return this;
     }
 
@@ -1250,7 +1250,7 @@ public class JSONArray implements Iterable<Object> {
      *            Thrown if the array parameter is null.
      */
     public JSONArray putAll(Object array) throws JSONException {
-        this.addAll(array);
+        this.addAll(array, false);
         return this;
     }
     
@@ -1585,11 +1585,21 @@ public class JSONArray implements Iterable<Object> {
      *
      * @param collection
      *            A Collection.
+     * @param wrap
+     *            {@code true} to call {@link JSONObject#wrap(Object)} for each item,
+     *            {@code false} to add the items directly
+     *            
      */
-    private void addAll(Collection<?> collection) {
+    private void addAll(Collection<?> collection, boolean wrap) {
         this.myArrayList.ensureCapacity(this.myArrayList.size() + collection.size());
-        for (Object o: collection){
-            this.myArrayList.add(JSONObject.wrap(o));
+        if (wrap) {
+            for (Object o: collection){
+                this.put(JSONObject.wrap(o));
+            }
+        } else {
+            for (Object o: collection){
+                this.put(o);
+            }
         }
     }
 
@@ -1598,10 +1608,19 @@ public class JSONArray implements Iterable<Object> {
      *
      * @param iter
      *            An Iterable.
+     * @param wrap
+     *            {@code true} to call {@link JSONObject#wrap(Object)} for each item,
+     *            {@code false} to add the items directly
      */
-    private void addAll(Iterable<?> iter) {
-        for (Object o: iter){
-            this.myArrayList.add(JSONObject.wrap(o));
+    private void addAll(Iterable<?> iter, boolean wrap) {
+        if (wrap) {
+            for (Object o: iter){
+                this.put(JSONObject.wrap(o));
+            }
+        } else {
+            for (Object o: iter){
+                this.put(o);
+            }
         }
     }
     
@@ -1612,18 +1631,27 @@ public class JSONArray implements Iterable<Object> {
      *            Array. If the parameter passed is null, or not an array,
      *            JSONArray, Collection, or Iterable, an exception will be
      *            thrown.
+     * @param wrap
+     *            {@code true} to call {@link JSONObject#wrap(Object)} for each item,
+     *            {@code false} to add the items directly
      *
      * @throws JSONException
      *            If not an array or if an array value is non-finite number.
      * @throws NullPointerException
      *            Thrown if the array parameter is null.
      */
-    private void addAll(Object array) throws JSONException {
+    private void addAll(Object array, boolean wrap) throws JSONException {
         if (array.getClass().isArray()) {
             int length = Array.getLength(array);
             this.myArrayList.ensureCapacity(this.myArrayList.size() + length);
-            for (int i = 0; i < length; i += 1) {
-                this.put(JSONObject.wrap(Array.get(array, i)));
+            if (wrap) {
+                for (int i = 0; i < length; i += 1) {
+                    this.put(JSONObject.wrap(Array.get(array, i)));
+                }
+            } else {
+                for (int i = 0; i < length; i += 1) {
+                    this.put(Array.get(array, i));
+                }
             }
         } else if (array instanceof JSONArray) {
             // use the built in array list `addAll` as all object
@@ -1631,9 +1659,9 @@ public class JSONArray implements Iterable<Object> {
             // JSONArray
             this.myArrayList.addAll(((JSONArray)array).myArrayList);
         } else if (array instanceof Collection) {
-            this.addAll((Collection<?>)array);
+            this.addAll((Collection<?>)array, wrap);
         } else if (array instanceof Iterable) {
-            this.addAll((Iterable<?>)array);
+            this.addAll((Iterable<?>)array, wrap);
         } else {
             throw new JSONException(
                     "JSONArray initial value should be a string or collection or array.");

--- a/src/test/java/org/json/junit/JSONArrayTest.java
+++ b/src/test/java/org/json/junit/JSONArrayTest.java
@@ -979,9 +979,9 @@ public class JSONArrayTest {
         JSONArray jsonArray = new JSONArray(str);
         String expectedStr = str;
         StringWriter stringWriter = new StringWriter();
-        jsonArray.write(stringWriter);
-        String actualStr = stringWriter.toString();
         try {
+            jsonArray.write(stringWriter);
+            String actualStr = stringWriter.toString();
             JSONArray finalArray = new JSONArray(actualStr);
             Util.compareActualVsExpectedJsonArrays(jsonArray, finalArray);
             assertTrue("write() expected " + expectedStr +
@@ -1185,6 +1185,73 @@ public class JSONArrayTest {
             assertEquals("Expected an exception message", 
                     "JSONArray initial capacity cannot be negative.",
                     e.getMessage());
+        }
+    }
+    
+    /**
+     * Verifies that the object constructor can properly handle any supported collection object.
+     */
+    @Test
+    @SuppressWarnings({ "unchecked", "boxing" })
+    public void testObjectConstructor() {
+        // should copy the array
+        Object o = new Object[] {2, "test2", true};
+        JSONArray a = new JSONArray(o);
+        assertNotNull("Should not error", a);
+        assertEquals("length", 3, a.length());
+        
+        // should NOT copy the collection
+        // this is required for backwards compatibility
+        o = new ArrayList<Object>();
+        ((Collection<Object>)o).add(1);
+        ((Collection<Object>)o).add("test");
+        ((Collection<Object>)o).add(false);
+        try {
+            a = new JSONArray(o);
+            assertNull("Should error", a);
+        } catch (JSONException ex) {
+        }
+
+        // should NOT copy the JSONArray
+        // this is required for backwards compatibility
+        o = a;
+        try {
+            a = new JSONArray(o);
+            assertNull("Should error", a);
+        } catch (JSONException ex) {
+        }
+    }
+    
+    /**
+     * Verifies that the JSONArray constructor properly copies the original.
+     */
+    @Test
+    public void testJSONArrayConstructor() {
+        // should copy the array
+        JSONArray a1 = new JSONArray("[2, \"test2\", true]");
+        JSONArray a2 = new JSONArray(a1);
+        assertNotNull("Should not error", a2);
+        assertEquals("length", a1.length(), a2.length());
+        
+        for(int i = 0; i < a1.length(); i++) {
+            assertEquals("index " + i + " are equal", a1.get(i), a2.get(i));
+        }
+    }
+    
+    /**
+     * Verifies that the object constructor can properly handle any supported collection object.
+     */
+    @Test
+    public void testJSONArrayPutAll() {
+        // should copy the array
+        JSONArray a1 = new JSONArray("[2, \"test2\", true]");
+        JSONArray a2 = new JSONArray();
+        a2.putAll(a1);
+        assertNotNull("Should not error", a2);
+        assertEquals("length", a1.length(), a2.length());
+        
+        for(int i = 0; i < a1.length(); i++) {
+            assertEquals("index " + i + " are equal", a1.get(i), a2.get(i));
         }
     }
 }

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -3201,4 +3201,11 @@ public class JSONObjectTest {
         fail("Expected an exception");
     }
 
+    @Test
+    public void testIssue548ObjectWithEmptyJsonArray() {
+        JSONObject jsonObject = new JSONObject("{\"empty_json_array\": []}");
+        assertTrue("missing expected key 'empty_json_array'", jsonObject.has("empty_json_array"));
+        assertNotNull("'empty_json_array' should be an array", jsonObject.getJSONArray("empty_json_array"));
+        assertEquals("'empty_json_array' should have a length of 0", 0, jsonObject.getJSONArray("empty_json_array").length());
+    }
 }


### PR DESCRIPTION
**What problem does this code solve?**
The new `putAll` methods did not implement a way to concatenate JSONArray objects. It was an oversight during the review process, but should probably be allowed. This also adds in a shallow copy constructor for JSONArrays so the solution is a bit more holistic. I also added support for adding Generic `Iterable` objects which don't have a `size` function.

* Adds a copy constructor for JSONArray
* Updates the JSONArray.addAll(Object) method to be more lenient
* Adds support for JSONArray.putAll of generic Iterables
* Adds support for JSONArray.putAll of another JSONArray
* Updates some JavaDoc for clarification.
* Updates `putAll` methods to match other `put` methods and not wrap the items in the collection/array

**Risks**
Low. Just closes some gaps that were missed in the initial PR


**Changes to the API?**
New methods added, but no breaking changes

**Will this require a new release?**
No

**Should the documentation be updated?**
Yes. Notes should be added about the new `putAll` methods and information on expected use cases

**Does it break the unit tests?**
No. New tests were added to verify existing functionality and show new functions

**Was any code refactored in this commit?**
Yes. The internal `addAll` methods created in #529 were modified to optionally wrap the contents of the collection/array instead of always wrapping them.

**Review status**
**APPROVED**