### PR TITLE
Improve JSONObject's equals function

### DIFF
--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -128,8 +128,13 @@ public class JSONObject {
          *         null.
          */
         @Override
-        public boolean equals(Object object) {
-            return object == null || object == this;
+        public static boolean equals(Object object) {
+            if(object == null) return false;
+            if(this.getClass().equals(object.getClass()))
+                 if(this.toString().equals(object.toString())) 
+                     return true;
+
+            return false;
         }
         /**
          * A Null object is equal to the null value and to itself.

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -128,7 +128,7 @@ public class JSONObject {
          *         null.
          */
         @Override
-        public static boolean equals(Object object) {
+        public boolean equals(Object object) {
             if(object == null) return false;
             if(this.getClass().equals(object.getClass()))
                  if(this.toString().equals(object.toString())) 


### PR DESCRIPTION
Now compares classtype and data instead of object ID.