### PR TITLE
Create module-info.java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
     }
 
     maven {
-        url = uri('http://repo.maven.apache.org/maven2')
+        url = uri('https://repo.maven.apache.org/maven2')
     }
 }
 
@@ -35,7 +35,7 @@ subprojects {
 group = 'org.json'
 version = 'v20200429-SNAPSHOT'
 description = 'JSON in Java'
-sourceCompatibility = '1.7'
+sourceCompatibility = '9'
 
 configurations.all {
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module hjson {
+    exports org.json
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,3 +1,3 @@
 module hjson {
-    exports org.json
+    exports org.json;
 }


### PR DESCRIPTION
When using this library in a modular app you need to add to `module-info.java`:
```
requires hjson;
```
Which will raise a warning, e.g. `Name of automatic module 'hjson' is unstable, it is derived from the module's file name`, as obviously it is an automatic module. By adding a `module-info.java` we formalize the name as `hjson` (which makes it backward compatible with current automatic module resolution).

More on automatic modules: https://stackoverflow.com/a/46742802 correctly, this should be all that's needed in order for hjson