### PR TITLE
Added clear() methods to JSONObject and JSONArray

### DIFF
--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -568,6 +568,14 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
+     * Removes all of the elements from this JSONArray.
+     * The JSONArray will be empty after this call returns.
+     */
+    public void clear() {
+        return this.map.clear();
+    }
+
+    /**
      * Get the optional object value associated with an index.
      *
      * @param index

--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -572,7 +572,7 @@ public class JSONArray implements Iterable<Object> {
      * The JSONArray will be empty after this call returns.
      */
     public void clear() {
-        return this.myArrayList.clear();
+        this.myArrayList.clear();
     }
 
     /**

--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -572,7 +572,7 @@ public class JSONArray implements Iterable<Object> {
      * The JSONArray will be empty after this call returns.
      */
     public void clear() {
-        return this.map.clear();
+        return this.myArrayList.clear();
     }
 
     /**

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -974,6 +974,14 @@ public class JSONObject {
     }
 
     /**
+     * Removes all of the elements from this JSONObject.
+     * The JSONObject will be empty after this call returns.
+     */
+    public void clear() {
+        return this.map.clear();
+    }
+
+    /**
      * Check if JSONObject is empty.
      *
      * @return true if JSONObject is empty, otherwise false.

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -978,7 +978,7 @@ public class JSONObject {
      * The JSONObject will be empty after this call returns.
      */
     public void clear() {
-        return this.map.clear();
+        this.map.clear();
     }
 
     /**

--- a/src/test/java/org/json/junit/JSONArrayTest.java
+++ b/src/test/java/org/json/junit/JSONArrayTest.java
@@ -1254,4 +1254,19 @@ public class JSONArrayTest {
             assertEquals("index " + i + " are equal", a1.get(i), a2.get(i));
         }
     }
+
+    /**
+	 * Tests if calling JSONArray clear() method actually makes the JSONArray empty
+	 */
+	@Test(expected = JSONException.class)
+	public void jsonArrayClearMethodTest() {
+		//Adds random stuff to the JSONArray
+		JSONArray jsonArray = new JSONArray();
+		jsonArray.put(123);
+		jsonArray.put("456");
+		jsonArray.put(new JSONArray());
+		jsonArray.clear(); //Clears the JSONArray
+		assertTrue("expected jsonArray.length() == 0", jsonArray.length() == 0); //Check if its length is 0
+		jsonArray.getInt(0); //Should throws org.json.JSONException: JSONArray[0] not found
+	}
 }

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -3215,4 +3215,19 @@ public class JSONObjectTest {
         assertNotNull("'empty_json_array' should be an array", jsonObject.getJSONArray("empty_json_array"));
         assertEquals("'empty_json_array' should have a length of 0", 0, jsonObject.getJSONArray("empty_json_array").length());
     }
+
+    /**
+    * Tests if calling JSONObject clear() method actually makes the JSONObject empty
+    */
+    @Test(expected = JSONException.class)
+    public void jsonObjectClearMethodTest() {
+        //Adds random stuff to the JSONObject
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("key1", 123);
+        jsonObject.put("key2", "456");
+        jsonObject.put("key3", new JSONObject());
+        jsonObject.clear(); //Clears the JSONObject
+        assertTrue("expected jsonObject.length() == 0", jsonObject.length() == 0); //Check if its length is 0
+        jsonObject.getInt("key1"); //Should throws org.json.JSONException: JSONObject["asd"] not found
+    }
 }


### PR DESCRIPTION
I noticed that there wasn't this easy way to clear all the childs of a JSONObject or a JSONArray, so I added it.
Changes in code are really simple