### PR TITLE
JSONTokener implements Closeable

### DIFF
--- a/src/main/java/org/json/JSONTokener.java
+++ b/src/main/java/org/json/JSONTokener.java
@@ -1,11 +1,6 @@
 package org.json;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.StringReader;
+import java.io.*;
 
 /*
 Copyright (c) 2002 JSON.org
@@ -38,7 +33,7 @@ SOFTWARE.
  * @author JSON.org
  * @version 2014-05-03
  */
-public class JSONTokener {
+public class JSONTokener implements Closeable {
     /** current read character position on the current line. */
     private long character;
     /** flag to indicate if the end of the input has been found. */
@@ -58,7 +53,7 @@ public class JSONTokener {
 
 
     /**
-     * Construct a JSONTokener from a Reader. The caller must close the Reader.
+     * Construct a JSONTokener from a Reader.
      *
      * @param reader     A reader.
      */
@@ -77,7 +72,7 @@ public class JSONTokener {
 
 
     /**
-     * Construct a JSONTokener from an InputStream. The caller must close the input stream.
+     * Construct a JSONTokener from an InputStream.
      * @param inputStream The source.
      */
     public JSONTokener(InputStream inputStream) {
@@ -527,5 +522,10 @@ public class JSONTokener {
     public String toString() {
         return " at " + this.index + " [character " + this.character + " line " +
                 this.line + "]";
+    }
+
+    @Override
+    public void close() throws IOException {
+        reader.close();
     }
 }

--- a/src/test/java/org/json/junit/JSONTokenerTest.java
+++ b/src/test/java/org/json/junit/JSONTokenerTest.java
@@ -333,4 +333,22 @@ public class JSONTokenerTest {
         assertEquals(0, t2.next());
         assertFalse(t2.more());
    }
+
+    @Test
+    public void testClose() throws IOException {
+        Reader reader = new StringReader("some test string");
+        JSONTokener tokener = null;
+        try {
+            tokener = new JSONTokener(reader);
+        } finally {
+            tokener.close();
+        }
+
+        try {
+            reader.read();
+            fail("Expected exception");
+        } catch (Exception e) {
+            assertTrue(e instanceof IOException);
+        }
+    }
 }


### PR DESCRIPTION
What problem does this code solve?

- When create JSONTokener's object by String (Ex: new JSONTokener("String")), JSONTokener's reader is not closed 

Risks
High

Changes to the API?
Yes

Will this require a new release?
Yes

Should the documentation be updated?
Yes

Does it break the unit tests?
No. I run unit tests in my local.

Was any code refactored in this commit?
No

Review status