### PR TITLE
JSONPointer should not process reverse solidus or double-quote chars in tokens

### DIFF
--- a/src/main/java/org/json/JSONPointer.java
+++ b/src/main/java/org/json/JSONPointer.java
@@ -187,10 +187,11 @@ public class JSONPointer {
         this.refTokens = new ArrayList<String>(refTokens);
     }
 
+    /**
+     * @see https://tools.ietf.org/html/rfc6901#section-3
+     */
     private static String unescape(String token) {
-        return token.replace("~1", "/").replace("~0", "~")
-                .replace("\\\"", "\"")
-                .replace("\\\\", "\\");
+        return token.replace("~1", "/").replace("~0", "~");
     }
 
     /**
@@ -263,16 +264,15 @@ public class JSONPointer {
     /**
      * Escapes path segment values to an unambiguous form.
      * The escape char to be inserted is '~'. The chars to be escaped 
-     * are ~, which maps to ~0, and /, which maps to ~1. Backslashes
-     * and double quote chars are also escaped.
+     * are ~, which maps to ~0, and /, which maps to ~1.
      * @param token the JSONPointer segment value to be escaped
      * @return the escaped value for the token
+     * 
+     * @see https://tools.ietf.org/html/rfc6901#section-3
      */
     private static String escape(String token) {
         return token.replace("~", "~0")
-                .replace("/", "~1")
-                .replace("\\", "\\\\")
-                .replace("\"", "\\\"");
+                .replace("/", "~1");
     }
 
     /**

--- a/src/test/java/org/json/junit/JSONPointerTest.java
+++ b/src/test/java/org/json/junit/JSONPointerTest.java
@@ -117,14 +117,24 @@ public class JSONPointerTest {
         assertSame(document.get("m~n"), query("/m~0n"));
     }
 
+    /**
+     * We pass backslashes as-is
+     * 
+     * @see https://tools.ietf.org/html/rfc6901#section-3
+     */
     @Test
-    public void backslashEscaping() {
-        assertSame(document.get("i\\j"), query("/i\\\\j"));
+    public void backslashHandling() {
+        assertSame(document.get("i\\j"), query("/i\\j"));
     }
 
+    /**
+     * We pass quotations as-is
+     * 
+     * @see https://tools.ietf.org/html/rfc6901#section-3
+     */
     @Test
-    public void quotationEscaping() {
-        assertSame(document.get("k\"l"), query("/k\\\\\\\"l"));
+    public void quotationHandling() {
+        assertSame(document.get("k\"l"), query("/k\"l"));
     }
 
     @Test
@@ -189,7 +199,7 @@ public class JSONPointerTest {
                 .append("\"")
                 .append(0)
                 .build();
-        assertEquals("/obj/other~0key/another~1key/\\\"/0", pointer.toString());
+        assertEquals("/obj/other~0key/another~1key/\"/0", pointer.toString());
     }
     
     @Test


### PR DESCRIPTION
1. As never defined in https://tools.ietf.org/html/rfc6901#section-3 and
2. as discussed in https://github.com/stleary/JSON-java/issues/563,

backslashes(\\) and quotes(") are not to be treated any special by JSONPointer