### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ public class Test {
 
 *Execute the Test file*
 ```` 
-java -cp .;json-java.jar Test
+java -cp .;json-java.jar Test.java
 ````
 
 *Expected output*


### PR DESCRIPTION
There was a mistake in line 66. The command we must type to execute the test is "javac -cp .;json-java.jar Test.java" instead of "java -cp .;json-java.jar Test".