### PR TITLE
Fixed incorrect cast getting float from array

### DIFF
--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -326,7 +326,7 @@ public class JSONArray implements Iterable<Object> {
     public float getFloat(int index) throws JSONException {
         final Object object = this.get(index);
         if(object instanceof Number) {
-            return ((Float)object).floatValue();
+            return ((Number)object).floatValue();
         }
         try {
             return Float.parseFloat(object.toString());

--- a/src/test/java/org/json/junit/JSONArrayTest.java
+++ b/src/test/java/org/json/junit/JSONArrayTest.java
@@ -364,6 +364,8 @@ public class JSONArrayTest {
                 new Double(23.45e-4).equals(jsonArray.getDouble(5)));
         assertTrue("Array string double",
                 new Double(23.45).equals(jsonArray.getDouble(6)));
+        assertTrue("Array double can be float",
+                new Float(23.45e-4f).equals(jsonArray.getFloat(5)));
         // ints
         assertTrue("Array value int",
                 new Integer(42).equals(jsonArray.getInt(7)));


### PR DESCRIPTION
Hello,

I noticed that if a double is added to a JSONArray and then retrieved with getFloat(), a class cast exception was raised. This case is handled correctly by JSONObject (as opposed to array).

The root cause turned out to be an incorrect cast. I corrected the cast and also added a test for this case. I tried to closely follow the existing coding conventions as well as the corresponding code in JSONObject.

Please let me know if you need any more information. Thanks for maintaining this project!

Sincerely,
Ian Lovejoy