### PR TITLE
Added a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please follow the instructions in the ["How are vulnerabilities and exploits handled?"](https://github.com/stleary/JSON-java/wiki/FAQ#how-are-vulnerabilities-and-exploits-handled) section in the FAQ.


### PR DESCRIPTION
The process of reporting security issues should be documented and easy to find.

I'd like to propose adding a security policy to the project that would be integrated with other GitHub features

https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository

I think `SECURITY.md` would make it a bit easier to find the docs that describe how security issues should be reported.