### PR TITLE
New JSONObject.optJSONObject method with defaultValue parameter

### DIFF
--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -1370,9 +1370,21 @@ public class JSONObject {
      *            A key string.
      * @return A JSONObject which is the value.
      */
-    public JSONObject optJSONObject(String key) {
+    public JSONObject optJSONObject(String key) { return this.optJSONObject(key, null); }
+
+    /**
+     * Get an optional JSONObject associated with a key, or the default if there
+     * is no such key or if the value is not a JSONObject.
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
+     * @return An JSONObject which is the value.
+     */
+    public JSONObject optJSONObject(String key, JSONObject defaultValue) {
         Object object = this.opt(key);
-        return object instanceof JSONObject ? (JSONObject) object : null;
+        return object instanceof JSONObject ? (JSONObject) object : defaultValue;
     }
 
     /**

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -2404,8 +2404,8 @@ public class JSONObjectTest {
                 MyEnum.VAL1.equals(jsonObject.optEnum(MyEnum.class, "myKey", MyEnum.VAL1)));
         assertTrue("optJSONArray() should return null ",
                 null==jsonObject.optJSONArray("myKey"));
-        assertTrue("optJSONObject() should return null ",
-                null==jsonObject.optJSONObject("myKey"));
+        assertTrue("optJSONObject() should return default JSONObject ",
+                jsonObject.optJSONObject("myKey", new JSONObject("{\"testKey\":\"testValue\"}")).getString("testKey").equals("testValue"));
         assertTrue("optLong() should return default long",
                 42l == jsonObject.optLong("myKey", 42l));
         assertTrue("optDouble() should return default double",
@@ -2440,8 +2440,8 @@ public class JSONObjectTest {
                  MyEnum.VAL1.equals(jsonObject.optEnum(MyEnum.class, "myKey", MyEnum.VAL1)));
          assertTrue("optJSONArray() should return null ",
                  null==jsonObject.optJSONArray("myKey"));
-         assertTrue("optJSONObject() should return null ",
-                 null==jsonObject.optJSONObject("myKey"));
+         assertTrue("optJSONObject() should return default JSONObject ",
+                jsonObject.optJSONObject("myKey", new JSONObject("{\"testKey\":\"testValue\"}")).getString("testKey").equals("testValue"));
          assertTrue("optLong() should return default long",
                  42l == jsonObject.optLong("myKey", 42l));
          assertTrue("optDouble() should return default double",


### PR DESCRIPTION
I found myself often needing a version of **optJSONObject** where I could define my own default value as the 2nd argument (as you can on most of the other 'opt' methods).

The use case is when I need to access something that is nested deep in a json object, I currently have to check for null for every level of nesting, but if I could just set the default value to be and empty jsonobject instead of null, I could do something like this:
`String nestedvalue = jsonObject.optJSONObject("key", new JSONObject()).optJSONObject("key", new JSONObject()).optJSONObject("key", new JSONObject()).optString("nestedvalue")`

Let me know what you think :)