### PR TITLE
Fixes Issue #611 JsonObject.similar() returns after number entry check

### DIFF
--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -1383,7 +1383,9 @@ public class JSONArray implements Iterable<Object> {
                     return false;
                 }
             } else if (valueThis instanceof Number && valueOther instanceof Number) {
-                return JSONObject.isNumberSimilar((Number)valueThis, (Number)valueOther);
+                if (!JSONObject.isNumberSimilar((Number)valueThis, (Number)valueOther)) {
+                	return false;
+                }
             } else if (!valueThis.equals(valueOther)) {
                 return false;
             }

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -2092,7 +2092,9 @@ public class JSONObject {
                         return false;
                     }
                 } else if (valueThis instanceof Number && valueOther instanceof Number) {
-                    return isNumberSimilar((Number)valueThis, (Number)valueOther);
+                    if (!isNumberSimilar((Number)valueThis, (Number)valueOther)) {
+                    	return false;
+                    };
                 } else if (!valueThis.equals(valueOther)) {
                     return false;
                 }

--- a/src/test/java/org/json/junit/JSONArrayTest.java
+++ b/src/test/java/org/json/junit/JSONArrayTest.java
@@ -87,6 +87,7 @@ public class JSONArrayTest {
     @Test
     public void verifySimilar() {
         final String string1 = "HasSameRef";
+        final String string2 = "HasDifferentRef";
         JSONArray obj1 = new JSONArray()
                 .put("abc")
                 .put(string1)
@@ -101,10 +102,20 @@ public class JSONArrayTest {
                 .put("abc")
                 .put(new String(string1))
                 .put(2);
+
+        JSONArray obj4 = new JSONArray()
+                .put("abc")
+                .put(2.0)
+        		.put(new String(string1));
+
+        JSONArray obj5 = new JSONArray()
+                .put("abc")
+                .put(2.0)
+        		.put(new String(string2));
         
-        assertFalse("Should eval to false", obj1.similar(obj2));
-        
-        assertTrue("Should eval to true", obj1.similar(obj3));
+        assertFalse("obj1-obj2 Should eval to false", obj1.similar(obj2));
+        assertTrue("obj1-obj3 Should eval to true", obj1.similar(obj3));
+        assertFalse("obj4-obj5 Should eval to false", obj4.similar(obj5));
     }
         
     /**

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -130,10 +130,13 @@ public class JSONObjectTest {
         assertTrue("obj1-obj3 Should eval to true", obj1.similar(obj3));
         assertTrue("obj1-obj4 Should eval to true", obj1.similar(obj4));
         assertFalse("obj1-obj5 Should eval to false", obj1.similar(obj5));
-        
         // verify that a double and big decimal are "similar"
         assertTrue("should eval to true",new JSONObject().put("a",1.1d).similar(new JSONObject("{\"a\":1.1}")));
-        
+        // Confirm #618 is fixed (compare should not exit early if similar numbers are found)
+        // Note that this test may not work if the JSONObject map entry order changes
+        JSONObject first = new JSONObject("{\"a\": 1, \"b\": 2, \"c\": 3}");
+        JSONObject second = new JSONObject("{\"a\": 1, \"b\": 2.0, \"c\": 4}");
+        assertFalse("first-second should eval to false", first.similar(second));
     }
     
     @Test

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -100,6 +100,7 @@ public class JSONObjectTest {
     @Test
     public void verifySimilar() {
         final String string1 = "HasSameRef";
+        final String string2 = "HasDifferentRef";
         JSONObject obj1 = new JSONObject()
                 .put("key1", "abc")
                 .put("key2", 2)
@@ -119,12 +120,16 @@ public class JSONObjectTest {
                 .put("key1", "abc")
                 .put("key2", 2.0)
                 .put("key3", new String(string1));
-        
-        assertFalse("Should eval to false", obj1.similar(obj2));
 
-        assertTrue("Should eval to true", obj1.similar(obj3));
+        JSONObject obj5 = new JSONObject()
+                .put("key1", "abc")
+                .put("key2", 2.0)
+                .put("key3", new String(string2));
         
-        assertTrue("Should eval to true", obj1.similar(obj4));
+        assertFalse("obj1-obj2 Should eval to false", obj1.similar(obj2));
+        assertTrue("obj1-obj3 Should eval to true", obj1.similar(obj3));
+        assertTrue("obj1-obj4 Should eval to true", obj1.similar(obj4));
+        assertFalse("obj1-obj5 Should eval to false", obj1.similar(obj5));
         
     }
     


### PR DESCRIPTION
#611 reported that similar returns too soon on success when a Number entry type is checked. Fixed by returning only if the Number check fails. Added unit test to exercise the new code.