### PR TITLE
Address #561: Add unit tests for multiple backslashes

### DIFF
--- a/src/test/java/org/json/junit/JSONPointerTest.java
+++ b/src/test/java/org/json/junit/JSONPointerTest.java
@@ -134,6 +134,14 @@ public class JSONPointerTest {
     public void quotationHandling() {
         assertEquals(6, query("/k\"l"));
     }
+    
+    /**
+     * KD Added
+     * */
+    @Test
+    public void quotationEscaping() {
+        assertEquals(document.get("k\"l"), query("/k\\\"l"));
+    }
 
     @Test
     public void whitespaceKey() {
@@ -388,5 +396,34 @@ public class JSONPointerTest {
         assertTrue("Expected bVal", "bVal".equals(obj));
         obj = jsonArray.optQuery(new JSONPointer("/a/b/c"));
         assertTrue("Expected null", obj == null);
+    }
+    
+    /**
+     * KD added
+     * Coverage for JSONObject query(JSONPointer)
+     */
+    @Test
+    public void queryFromJSONObjectUsingPointer2() {
+        String str = "{"+
+            "\"string\\\\\\\\Key\":\"hello world!\","+
+            "}"+
+            "}";
+        JSONObject jsonObject = new JSONObject(str);
+        Object obj = jsonObject.optQuery(new JSONPointer("/string\\\\\\\\Key"));
+        assertTrue("Expected 'hello world!'", "hello world!".equals(obj));
+    }
+    /**
+     * KD added - understanding behavior
+     * Coverage for JSONObject query(JSONPointer)
+     */
+    @Test
+    public void queryFromJSONObjectUsingPointer0() {
+        String str = "{"+
+            "\"string\\\\Key\":\"hello world!\","+
+            "}"+
+            "}";
+        JSONObject jsonObject = new JSONObject(str);
+        Object obj = jsonObject.optQuery(new JSONPointer("/string\\Key"));
+        assertTrue("Expected 'hello world!'", "hello world!".equals(obj));
     }
 }

--- a/src/test/java/org/json/junit/JSONPointerTest.java
+++ b/src/test/java/org/json/junit/JSONPointerTest.java
@@ -43,7 +43,7 @@ public class JSONPointerTest {
     private static final String EXPECTED_COMPLETE_DOCUMENT = "{\"\":0,\" \":7,\"g|h\":4,\"c%d\":2,\"k\\\"l\":6,\"a/b\":1,\"i\\\\j\":5," +
     		"\"obj\":{\"\":{\"\":\"empty key of an object with an empty key\",\"subKey\":\"Some other value\"}," +
             "\"other~key\":{\"another/key\":[\"val\"]},\"key\":\"value\"},\"foo\":[\"bar\",\"baz\"],\"e^f\":3," +
-            "\"m~n\":8,\"four\\\\\\\\slashes\":\"slash test!\"}";
+            "\"m~n\":8}";
 
     
     static {
@@ -124,17 +124,6 @@ public class JSONPointerTest {
     @Test
     public void backslashHandling() {
         assertEquals(5, query("/i\\j"));
-    }
-
-    /**
-     * When creating a jsonObject we need to parse escaped characters "\\\\"
-     *  --> it's the string representation of  "\\", so when query'ing via the JSONPointer 
-     *  we DON'T escape them
-     *  
-     */
-    @Test
-    public void multipleBackslashHandling() {
-        assertEquals("slash test!", query("/four\\\\slashes"));
     }
     
     /**
@@ -403,8 +392,10 @@ public class JSONPointerTest {
     }
     
     /**
-     * KD added - this should pass
-     * Coverage for JSONObject query(JSONPointer)
+     * When creating a jsonObject we need to parse escaped characters "\\\\"
+     *  --> it's the string representation of  "\\", so when query'ing via the JSONPointer 
+     *  we DON'T escape them
+     *  
      */
     @Test
     public void queryFromJSONObjectUsingPointer0() {
@@ -416,8 +407,11 @@ public class JSONPointerTest {
                 "}";
             JSONObject jsonObject = new JSONObject(str);
             //Summary of issue: When a KEY in the jsonObject is "\\\\" --> it's held
-            // as "\\" which makes it impossible to get back where expected
-            Object obj = jsonObject.optQuery(new JSONPointer("/\\"));
-            assertEquals("slash test", obj);
+            // as "\\" which means when querying, we need to use "\\"
+            Object twoBackslahObj = jsonObject.optQuery(new JSONPointer("/\\"));
+            assertEquals("slash test", twoBackslahObj);
+
+            Object fourBackslashObj = jsonObject.optQuery(new JSONPointer("/string\\\\Key"));
+            assertEquals("hello world!", fourBackslashObj);
     }
 }


### PR DESCRIPTION
### [#561]Queries involving keys containing four backslashes ("\\\\") failing.

### Summary of Issue
jimblackler noticed that different behavior occurs between parsing a string to create JSONObject and querying a JSONObject using JSONPointer(). There is not special handling for JSONPoiner \s in querying as mentioned in the fix for #588 . 

I do think the [documentation](https://datatracker.ietf.org/doc/html/rfc6901#section-5) needs to be updated from


    ""           // the whole document
    "/foo"       ["bar", "baz"]
    "/foo/0"     "bar"
    "/"          0
    "/a~1b"      1
    "/c%d"       2
    "/e^f"       3
    "/g|h"       4
    "/i\\j"      5
    "/k\"l"      6
    "/ "         7
    "/m~0n"      8`

to 

    ""           // the whole document
    "/foo"       ["bar", "baz"]
    "/foo/0"     "bar"
    "/"          0
    "/a~1b"      1
    "/c%d"       2
    "/e^f"       3
    "/g|h"       4
    "/i\j"       5 // Change to demonstrate intended behavior
    "/k\"l"      6
    "/ "         7
    "/m~0n"      8`

### Summary of Changes
- Additional unit test that clarifies backslash behavior differences between JSONObject() and JSONPointer()

### Expected Behavior
- No regression behavior
- All unit tests pass
