### PR TITLE
XMLParserConfiguration support for xml to json arrays

### DIFF
--- a/src/main/java/org/json/XML.java
+++ b/src/main/java/org/json/XML.java
@@ -413,14 +413,26 @@ public class XML {
                         } else if (token == LT) {
                             // Nested element
                             if (parse(x, jsonObject, tagName, config)) {
-                                if (jsonObject.length() == 0) {
-                                    context.accumulate(tagName, "");
-                                } else if (jsonObject.length() == 1
-                                        && jsonObject.opt(config.getcDataTagName()) != null) {
-                                    context.accumulate(tagName, jsonObject.opt(config.getcDataTagName()));
+                                if (config.getForceList().contains(tagName)) {
+                                    if (jsonObject.length() == 0) {
+                                        context.append(tagName, "");
+                                    } else if (jsonObject.length() == 1
+                                            && jsonObject.opt(config.getcDataTagName()) != null) {
+                                        context.append(tagName, jsonObject.opt(config.getcDataTagName()));
+                                    } else {
+                                        context.append(tagName, jsonObject);
+                                    }
                                 } else {
-                                    context.accumulate(tagName, jsonObject);
+                                    if (jsonObject.length() == 0) {
+                                        context.accumulate(tagName, "");
+                                    } else if (jsonObject.length() == 1
+                                            && jsonObject.opt(config.getcDataTagName()) != null) {
+                                        context.accumulate(tagName, jsonObject.opt(config.getcDataTagName()));
+                                    } else {
+                                        context.accumulate(tagName, jsonObject);
+                                    }
                                 }
+                                
                                 return false;
                             }
                         }

--- a/src/main/java/org/json/XML.java
+++ b/src/main/java/org/json/XML.java
@@ -415,7 +415,7 @@ public class XML {
                             if (parse(x, jsonObject, tagName, config)) {
                                 if (config.getForceList().contains(tagName)) {
                                     if (jsonObject.length() == 0) {
-                                        context.append(tagName, "");
+                                        context.put(tagName, new JSONArray());
                                     } else if (jsonObject.length() == 1
                                             && jsonObject.opt(config.getcDataTagName()) != null) {
                                         context.append(tagName, jsonObject.opt(config.getcDataTagName()));

--- a/src/main/java/org/json/XML.java
+++ b/src/main/java/org/json/XML.java
@@ -380,12 +380,23 @@ public class XML {
                     if (x.nextToken() != GT) {
                         throw x.syntaxError("Misshaped tag");
                     }
-                    if (nilAttributeFound) {
-                        context.accumulate(tagName, JSONObject.NULL);
-                    } else if (jsonObject.length() > 0) {
-                        context.accumulate(tagName, jsonObject);
+                    if (config.getForceList().contains(tagName)) {
+                        // Force the value to be an array
+                        if (nilAttributeFound) {
+                            context.append(tagName, JSONObject.NULL);
+                        } else if (jsonObject.length() > 0) {
+                            context.append(tagName, jsonObject);
+                        } else {
+                            context.put(tagName, new JSONArray());
+                        }
                     } else {
-                        context.accumulate(tagName, "");
+                        if (nilAttributeFound) {
+                            context.accumulate(tagName, JSONObject.NULL);
+                        } else if (jsonObject.length() > 0) {
+                            context.accumulate(tagName, jsonObject);
+                        } else {
+                            context.accumulate(tagName, "");
+                        }
                     }
                     return false;
 
@@ -414,6 +425,7 @@ public class XML {
                             // Nested element
                             if (parse(x, jsonObject, tagName, config)) {
                                 if (config.getForceList().contains(tagName)) {
+                                    // Force the value to be an array
                                     if (jsonObject.length() == 0) {
                                         context.put(tagName, new JSONArray());
                                     } else if (jsonObject.length() == 1

--- a/src/main/java/org/json/XMLParserConfiguration.java
+++ b/src/main/java/org/json/XMLParserConfiguration.java
@@ -25,7 +25,9 @@ SOFTWARE.
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -67,6 +69,12 @@ public class XMLParserConfiguration {
     private Map<String, XMLXsiTypeConverter<?>> xsiTypeMap;
 
     /**
+     * When parsing the XML into JSON, specifies the tags whose values should be converted
+     * to arrays
+     */
+    private Set<String> forceList;
+
+    /**
      * Default parser configuration. Does not keep strings (tries to implicitly convert
      * values), and the CDATA Tag Name is "content".
      */
@@ -75,6 +83,7 @@ public class XMLParserConfiguration {
         this.cDataTagName = "content";
         this.convertNilAttributeToNull = false;
         this.xsiTypeMap = Collections.emptyMap();
+        this.forceList = Collections.emptySet();
     }
 
     /**
@@ -151,13 +160,15 @@ public class XMLParserConfiguration {
      *                                  <code>false</code> to parse values with attribute xsi:nil="true" as {"xsi:nil":true}.
      * @param xsiTypeMap  <code>new HashMap<String, XMLXsiTypeConverter<?>>()</code> to parse values with attribute
      *                   xsi:type="integer" as integer,  xsi:type="string" as string
+     * @param forceList  <code>new HashSet<String>()</code> to parse the provided tags' values as arrays 
      */
     private XMLParserConfiguration (final boolean keepStrings, final String cDataTagName,
-            final boolean convertNilAttributeToNull, final Map<String, XMLXsiTypeConverter<?>> xsiTypeMap ) {
+            final boolean convertNilAttributeToNull, final Map<String, XMLXsiTypeConverter<?>> xsiTypeMap, final Set<String> forceList ) {
         this.keepStrings = keepStrings;
         this.cDataTagName = cDataTagName;
         this.convertNilAttributeToNull = convertNilAttributeToNull;
         this.xsiTypeMap = Collections.unmodifiableMap(xsiTypeMap);
+        this.forceList = Collections.unmodifiableSet(forceList);
     }
 
     /**
@@ -174,7 +185,8 @@ public class XMLParserConfiguration {
                 this.keepStrings,
                 this.cDataTagName,
                 this.convertNilAttributeToNull,
-                this.xsiTypeMap
+                this.xsiTypeMap,
+                this.forceList
         );
     }
     
@@ -281,6 +293,28 @@ public class XMLParserConfiguration {
         XMLParserConfiguration newConfig = this.clone();
         Map<String, XMLXsiTypeConverter<?>> cloneXsiTypeMap = new HashMap<String, XMLXsiTypeConverter<?>>(xsiTypeMap);
         newConfig.xsiTypeMap = Collections.unmodifiableMap(cloneXsiTypeMap);
+        return newConfig;
+    }
+
+    /**
+     * When parsing the XML into JSON, specifies that tags that will be converted to arrays
+     * in this configuration {@code Set<String>} to parse the provided tags' values as arrays 
+     * @return <code>forceList</code> unmodifiable configuration set.
+     */
+    public Set<String> getForceList() {
+        return this.forceList;
+    }
+
+    /**
+     * When parsing the XML into JSON, specifies that tags that will be converted to arrays
+     * in this configuration {@code Set<String>} to parse the provided tags' values as arrays 
+     * @param forceList  {@code new HashSet<String>()} to parse the provided tags' values as arrays 
+     * @return The existing configuration will not be modified. A new configuration is returned.
+     */
+    public XMLParserConfiguration withForceList(final Set<String> forceList) {
+        XMLParserConfiguration newConfig = this.clone();
+        Set<String> cloneForceList = new HashSet<String>(forceList);
+        newConfig.forceList = Collections.unmodifiableSet(cloneForceList);
         return newConfig;
     }
 }

--- a/src/test/java/org/json/junit/XMLConfigurationTest.java
+++ b/src/test/java/org/json/junit/XMLConfigurationTest.java
@@ -919,7 +919,8 @@ public class XMLConfigurationTest {
                 "   </address>\n"+
                 "</addresses>";
 
-        String expectedStr = "{\"addresses\":[{\"address\":{\"name\":\"Sherlock Holmes\"}}]}";
+        String expectedStr = 
+                "{\"addresses\":[{\"address\":{\"name\":\"Sherlock Holmes\"}}]}";
         
         Set<String> forceList = new HashSet<String>();
         forceList.add("addresses");
@@ -949,18 +950,18 @@ public class XMLConfigurationTest {
                 "</servers>";
 
         String expectedStr = 
-            "{"+
-            "\"servers\": ["+
-              "{"+
-                "\"server\": {"+
-                  "\"name\": \"host1\","+
-                  "\"os\": \"Linux\","+
-                  "\"interfaces\": ["+
-                   "{"+
-                     "\"interface\": {"+
-                       "\"name\": \"em0\","+
-                       "\"ip_address\": \"10.0.0.1\""+
-                      "}}]}}]}";
+                "{"+
+                    "\"servers\": ["+
+                        "{"+
+                            "\"server\": {"+
+                            "\"name\": \"host1\","+
+                            "\"os\": \"Linux\","+
+                            "\"interfaces\": ["+
+                                "{"+
+                                    "\"interface\": {"+
+                                    "\"name\": \"em0\","+
+                                    "\"ip_address\": \"10.0.0.1\""+
+                                    "}}]}}]}";
         
         Set<String> forceList = new HashSet<String>();
         forceList.add("servers");
@@ -974,7 +975,25 @@ public class XMLConfigurationTest {
 
         Util.compareActualVsExpectedJsonObjects(jsonObject, expetedJsonObject);
     }
-    
+    @Test
+    public void testEmptyForceList() {
+        String xmlStr = 
+                "<addresses></addresses>";
+
+        String expectedStr = 
+                "{\"addresses\":[]}";
+        
+        Set<String> forceList = new HashSet<String>();
+        forceList.add("addresses");
+
+        XMLParserConfiguration config = 
+                new XMLParserConfiguration()
+                        .withForceList(forceList);
+        JSONObject jsonObject = XML.toJSONObject(xmlStr, config);
+        JSONObject expetedJsonObject = new JSONObject(expectedStr);
+
+        Util.compareActualVsExpectedJsonObjects(jsonObject, expetedJsonObject);
+    }
     
     /**
      * Convenience method, given an input string and expected result,

--- a/src/test/java/org/json/junit/XMLConfigurationTest.java
+++ b/src/test/java/org/json/junit/XMLConfigurationTest.java
@@ -907,11 +907,10 @@ public class XMLConfigurationTest {
     }
 
     /**
-     * Confirm XMLParserConfiguration functionality
+     * Test forceList parameter
      */
     @Test
     public void testSimpleForceList() {
-
         String xmlStr = 
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+
                 "<addresses>\n"+
@@ -924,6 +923,48 @@ public class XMLConfigurationTest {
         
         Set<String> forceList = new HashSet<String>();
         forceList.add("addresses");
+
+        XMLParserConfiguration config = 
+                new XMLParserConfiguration()
+                        .withForceList(forceList);
+        JSONObject jsonObject = XML.toJSONObject(xmlStr, config);
+        JSONObject expetedJsonObject = new JSONObject(expectedStr);
+
+        Util.compareActualVsExpectedJsonObjects(jsonObject, expetedJsonObject);
+    }
+    @Test
+    public void testLongForceList() {
+        String xmlStr = 
+                "<servers>"+
+                    "<server>"+
+                        "<name>host1</name>"+
+                        "<os>Linux</os>"+
+                        "<interfaces>"+
+                            "<interface>"+
+                                "<name>em0</name>"+
+                                "<ip_address>10.0.0.1</ip_address>"+
+                            "</interface>"+
+                        "</interfaces>"+
+                    "</server>"+
+                "</servers>";
+
+        String expectedStr = 
+            "{"+
+            "\"servers\": ["+
+              "{"+
+                "\"server\": {"+
+                  "\"name\": \"host1\","+
+                  "\"os\": \"Linux\","+
+                  "\"interfaces\": ["+
+                   "{"+
+                     "\"interface\": {"+
+                       "\"name\": \"em0\","+
+                       "\"ip_address\": \"10.0.0.1\""+
+                      "}}]}}]}";
+        
+        Set<String> forceList = new HashSet<String>();
+        forceList.add("servers");
+        forceList.add("interfaces");
 
         XMLParserConfiguration config = 
                 new XMLParserConfiguration()

--- a/src/test/java/org/json/junit/XMLConfigurationTest.java
+++ b/src/test/java/org/json/junit/XMLConfigurationTest.java
@@ -976,9 +976,86 @@ public class XMLConfigurationTest {
         Util.compareActualVsExpectedJsonObjects(jsonObject, expetedJsonObject);
     }
     @Test
+    public void testMultipleTagForceList() {
+        String xmlStr = 
+                "<addresses>\n"+
+                "   <address>\n"+
+                "      <name>Sherlock Holmes</name>\n"+
+                "      <name>John H. Watson</name>\n"+
+                "   </address>\n"+
+                "</addresses>";
+
+        String expectedStr = 
+                "{"+
+                    "\"addresses\":["+
+                    "{"+
+                        "\"address\":["+
+                            "{"+
+                                "\"name\":["+
+                                "\"Sherlock Holmes\","+
+                                "\"John H. Watson\""+
+                                "]"+
+                            "}"+
+                        "]"+
+                    "}"+
+                    "]"+
+                "}";
+        
+        Set<String> forceList = new HashSet<String>();
+        forceList.add("addresses");
+        forceList.add("address");
+        forceList.add("name");
+
+        XMLParserConfiguration config = 
+                new XMLParserConfiguration()
+                        .withForceList(forceList);
+        JSONObject jsonObject = XML.toJSONObject(xmlStr, config);
+        JSONObject expetedJsonObject = new JSONObject(expectedStr);
+
+        Util.compareActualVsExpectedJsonObjects(jsonObject, expetedJsonObject);
+    }
+    @Test
     public void testEmptyForceList() {
         String xmlStr = 
                 "<addresses></addresses>";
+
+        String expectedStr = 
+                "{\"addresses\":[]}";
+        
+        Set<String> forceList = new HashSet<String>();
+        forceList.add("addresses");
+
+        XMLParserConfiguration config = 
+                new XMLParserConfiguration()
+                        .withForceList(forceList);
+        JSONObject jsonObject = XML.toJSONObject(xmlStr, config);
+        JSONObject expetedJsonObject = new JSONObject(expectedStr);
+
+        Util.compareActualVsExpectedJsonObjects(jsonObject, expetedJsonObject);
+    }
+    @Test
+    public void testContentForceList() {
+        String xmlStr = 
+                "<addresses>Baker Street</addresses>";
+
+        String expectedStr = 
+                "{\"addresses\":[\"Baker Street\"]}";
+        
+        Set<String> forceList = new HashSet<String>();
+        forceList.add("addresses");
+
+        XMLParserConfiguration config = 
+                new XMLParserConfiguration()
+                        .withForceList(forceList);
+        JSONObject jsonObject = XML.toJSONObject(xmlStr, config);
+        JSONObject expetedJsonObject = new JSONObject(expectedStr);
+
+        Util.compareActualVsExpectedJsonObjects(jsonObject, expetedJsonObject);
+    }
+    @Test
+    public void testEmptyTagForceList() {
+        String xmlStr = 
+                "<addresses />";
 
         String expectedStr = 
                 "{\"addresses\":[]}";

--- a/src/test/java/org/json/junit/XMLConfigurationTest.java
+++ b/src/test/java/org/json/junit/XMLConfigurationTest.java
@@ -35,6 +35,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -902,6 +904,34 @@ public class XMLConfigurationTest {
         expectedJsonArray = new JSONArray(expectedStr);
         Util.compareActualVsExpectedJsonArrays(jsonArray, expectedJsonArray);
 
+    }
+
+    /**
+     * Confirm XMLParserConfiguration functionality
+     */
+    @Test
+    public void testSimpleForceList() {
+
+        String xmlStr = 
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+
+                "<addresses>\n"+
+                "   <address>\n"+
+                "      <name>Sherlock Holmes</name>\n"+
+                "   </address>\n"+
+                "</addresses>";
+
+        String expectedStr = "{\"addresses\":[{\"address\":{\"name\":\"Sherlock Holmes\"}}]}";
+        
+        Set<String> forceList = new HashSet<String>();
+        forceList.add("addresses");
+
+        XMLParserConfiguration config = 
+                new XMLParserConfiguration()
+                        .withForceList(forceList);
+        JSONObject jsonObject = XML.toJSONObject(xmlStr, config);
+        JSONObject expetedJsonObject = new JSONObject(expectedStr);
+
+        Util.compareActualVsExpectedJsonObjects(jsonObject, expetedJsonObject);
     }
     
     


### PR DESCRIPTION
- Added a member variable named `Set<String> forceList` to `XMLParserConfiguration` with corresponding constructor/getter/setter
- After configuring `forceList` in `XMLParserConfiguration`, `XML.toJSONObject` will now set the corresponding values as arrays, regardless of their number of occurrences
- If the returning value is originally `""`, it will be replaced by `[]`
