### PR TITLE
Adding ordering of items

### DIFF
--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -40,6 +40,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.Locale;
@@ -185,6 +186,18 @@ public class JSONObject {
         // retrieval based on associative access.
         // Therefore, an implementation mustn't rely on the order of the item.
         this.map = new HashMap<String, Object>();
+    }
+
+    /**
+     * Construct an empty JSONObject specifying if the items are ordered based on the order of insertion.
+     */
+    public JSONObject(boolean ordered) {
+        // If ordered, a LinkedHashMap is used instead of a HashMap. Even if the JSON standard does not mandate the ordering of properties,
+        // in some cases it is requested by the specific use case. For example the ordering of the items is requested by
+        // <a href="https://spec.graphql.org/June2018/#sec-Serialized-Map-Ordering">GraphQL specification</a>. The default implementation
+        // should use the HashMap because if the order is not requested, it is more efficient using the HashMap in terms of memory
+        // consumption and runtime cost for most operations.
+        this.map = ordered ? new LinkedHashMap<String, Object>() : new HashMap<String, Object>();
     }
 
     /**

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -3351,4 +3351,20 @@ public class JSONObjectTest {
         assertTrue("expected jsonObject.length() == 0", jsonObject.length() == 0); //Check if its length is 0
         jsonObject.getInt("key1"); //Should throws org.json.JSONException: JSONObject["asd"] not found
     }
+
+    @Test
+    public void jsonObjectOrdered() {
+      JSONObject jsonObject = new JSONObject(true);
+      for (int i = 0; i < 100; i++)
+        jsonObject.put(String.valueOf(i), i);
+
+      // validate JSON
+      assertEquals("expected 100 items",100, jsonObject.length());
+
+      int i = 0;
+      for( String key : jsonObject.keySet() ){
+        assertEquals("expected "+i+" as key",i, Integer.parseInt(key));
+        ++i;
+      }
+    }
 }


### PR DESCRIPTION
Even if the JSON standard does not mandate the ordering of properties, in some cases it is requested by the specific use case. For example, the ordering of the items is requested by <a href="https://spec.graphql.org/June2018/#sec-Serialized-Map-Ordering">GraphQL specification</a>. The default implementation should use the HashMap because if the order is not requested, it is more efficient using the HashMap in terms of memory consumption and runtime cost for most operations.

ArcadeDB project depends heavily on JSON-java project and without this feature, we are forced to use an alternative library.

At the end of the day, there is no added code, just a different implementation of Map and **only** on explicit request.

WDYT?

Thanks in advance,
Luca Garulli
(Author of ArcadeDB and OrientDB Multi-Model DBMS)
