### PR TITLE
Supported using custom map implementation for JSONObject

### DIFF
--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -164,7 +164,7 @@ public class JSONObject {
     /**
      * The map where the JSONObject's properties are kept.
      */
-    private final Map<String, Object> map;
+    protected final Map<String, Object> map;
 
     /**
      * It is sometimes more convenient and less ambiguous to have a
@@ -365,6 +365,17 @@ public class JSONObject {
     public JSONObject(Object bean) {
         this();
         this.populateMap(bean);
+    }
+
+    protected JSONObject(Class<? extends Map> mapImplementation) {
+        if( mapImplementation == null )
+            throw new JSONException("Map implementation is null");
+
+        try {
+            this.map = mapImplementation.getConstructor().newInstance();
+        } catch (Exception e) {
+            throw new JSONException("Error on instantiating default constructor of map implementation from class '"+mapImplementation+"'");
+        }
     }
 
     private JSONObject(Object bean, Set<Object> objectsRecord) {

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -208,16 +208,16 @@ public class JSONObject {
     }
 
     /**
-     * Construct a JSONObject from a JSONTokener.
-     *
-     * @param x
-     *            A JSONTokener object containing the source string.
-     * @throws JSONException
-     *             If there is a syntax error in the source string or a
-     *             duplicated key.
-     */
+         * Construct a JSONObject from a JSONTokener.
+         *
+         * @param x
+         *            A JSONTokener object containing the source string.
+         * @throws JSONException
+         *             If there is a syntax error in the source string or a
+         *             duplicated key.
+         */
     public JSONObject(JSONTokener x) throws JSONException {
-        this();
+        this(x.getMapImplementation());
         char c;
         String key;
 
@@ -369,12 +369,14 @@ public class JSONObject {
 
     protected JSONObject(Class<? extends Map> mapImplementation) {
         if( mapImplementation == null )
-            throw new JSONException("Map implementation is null");
-
-        try {
-            this.map = mapImplementation.getConstructor().newInstance();
-        } catch (Exception e) {
-            throw new JSONException("Error on instantiating default constructor of map implementation from class '"+mapImplementation+"'");
+            // Use the default implementation.
+            this.map = new HashMap<String,Object>();
+        else {
+            try {
+                this.map = mapImplementation.getConstructor().newInstance();
+            } catch (Exception e) {
+                throw new JSONException("Error on instantiating default constructor of map implementation from class '" + mapImplementation + "'");
+            }
         }
     }
 

--- a/src/main/java/org/json/JSONTokener.java
+++ b/src/main/java/org/json/JSONTokener.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.Map;
 
 /*
 Copyright (c) 2002 JSON.org
@@ -56,6 +57,8 @@ public class JSONTokener {
     /** the number of characters read in the previous line. */
     private long characterPreviousLine;
 
+    /** custom map implementation to use. */
+    private Class<? extends Map> mapImplementation = null;
 
     /**
      * Construct a JSONTokener from a Reader. The caller must close the Reader.
@@ -495,6 +498,15 @@ public class JSONTokener {
         }
         this.back();
         return c;
+    }
+
+    public Class<? extends Map> getMapImplementation() {
+        return mapImplementation;
+    }
+
+    public JSONTokener setMapImplementation(Class<? extends Map> mapImplementation) {
+        this.mapImplementation = mapImplementation;
+        return this;
     }
 
     /**

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -45,6 +45,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -3350,5 +3351,28 @@ public class JSONObjectTest {
         jsonObject.clear(); //Clears the JSONObject
         assertTrue("expected jsonObject.length() == 0", jsonObject.length() == 0); //Check if its length is 0
         jsonObject.getInt("key1"); //Should throws org.json.JSONException: JSONObject["asd"] not found
+    }
+
+
+    @Test
+    public void jsonObjectOrdered() {
+        class OrderedJSONObject extends JSONObject {
+            public OrderedJSONObject() {
+               super( LinkedHashMap.class );
+            }
+        }
+
+        JSONObject jsonObject = new OrderedJSONObject();
+        for (int i = 0; i < 100; i++)
+           jsonObject.put(String.valueOf(i), i);
+
+        // validate JSON
+        assertEquals("expected 100 items",100, jsonObject.length());
+
+        int i = 0;
+        for( String key : jsonObject.keySet() ){
+            assertEquals("expected "+i+" as key",i, Integer.parseInt(key));
+           ++i;
+        }
     }
 }

--- a/src/test/java/org/json/junit/JSONTokenerTest.java
+++ b/src/test/java/org/json/junit/JSONTokenerTest.java
@@ -24,23 +24,19 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.StringReader;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.Test;
+
+import java.io.*;
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Test specific to the {@link org.json.JSONTokener} class.
@@ -333,4 +329,29 @@ public class JSONTokenerTest {
         assertEquals(0, t2.next());
         assertFalse(t2.more());
    }
+
+
+    @Test
+    public void jsonObjectOrdered() {
+        class OrderedJSONObject extends JSONObject {
+            public OrderedJSONObject() {
+                super( LinkedHashMap.class );
+            }
+        }
+
+        JSONObject jsonObject = new OrderedJSONObject();
+        for (int i = 0; i < 100; i++)
+            jsonObject.put(String.valueOf(i), i);
+
+        JSONObject orderedObject = new JSONObject( new JSONTokener(jsonObject.toString()).setMapImplementation( LinkedHashMap.class ) );
+
+        // validate JSON
+        assertEquals("expected 100 items",100, orderedObject.length());
+
+        int i = 0;
+        for( String key : orderedObject.keySet() ){
+            assertEquals("expected "+i+" as key",i, Integer.parseInt(key));
+            ++i;
+        }
+    }
 }

--- a/src/test/java/org/json/junit/JSONTokenerTest.java
+++ b/src/test/java/org/json/junit/JSONTokenerTest.java
@@ -30,8 +30,14 @@ import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.Test;
 
-import java.io.*;
-import java.util.*;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
+
+import java.util.LinkedHashMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -329,7 +335,6 @@ public class JSONTokenerTest {
         assertEquals(0, t2.next());
         assertFalse(t2.more());
    }
-
 
     @Test
     public void jsonObjectOrdered() {


### PR DESCRIPTION
Supported using custom map implementation for JSONObject, like a LinkedHashMap to keep the insertion order to the map fields.

This is a more flexible implementation than https://github.com/stleary/JSON-java/pull/655.