### PR TITLE
checking .length() is faster than .equals("")

### DIFF
--- a/src/main/java/org/json/Cookie.java
+++ b/src/main/java/org/json/Cookie.java
@@ -96,7 +96,7 @@ public class Cookie {
         
         name = unescape(x.nextTo('=').trim());
         //per RFC6265, if the name is blank, the cookie should be ignored.
-        if("".equals(name)) {
+        if(name.length() == 0) {
             throw new JSONException("Cookies must have a 'name'");
         }
         jo.put("name", name);
@@ -124,7 +124,7 @@ public class Cookie {
                 x.next();
             }
             // only store non-blank attributes
-            if(!"".equals(name) && !"".equals(value)) {
+            if(name.length() != 0 && !(value instanceof String && ((String)value).length() ==0)) {
                 jo.put(name, value);
             }
         }

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -2295,7 +2295,7 @@ public class JSONObject {
     // Changes to this method must be copied to the corresponding method in
     // the XML class to keep full support for Android
     public static Object stringToValue(String string) {
-        if ("".equals(string)) {
+        if (string.length() == 0) {
             return string;
         }
 

--- a/src/main/java/org/json/JSONTokener.java
+++ b/src/main/java/org/json/JSONTokener.java
@@ -467,7 +467,7 @@ public class JSONTokener {
         }
 
         string = sb.toString().trim();
-        if ("".equals(string)) {
+        if (string.length() == 0) {
             throw this.syntaxError("Missing value");
         }
         return JSONObject.stringToValue(string);

--- a/src/main/java/org/json/XML.java
+++ b/src/main/java/org/json/XML.java
@@ -835,7 +835,7 @@ public class XML {
                             sb.append(toString(val, key, config));
                         }
                     }
-                } else if ("".equals(value)) {
+                } else if (value instanceof String && ((String) value).length() == 0) {
                     sb.append('<');
                     sb.append(key);
                     sb.append("/>");

--- a/src/main/java/org/json/XML.java
+++ b/src/main/java/org/json/XML.java
@@ -479,7 +479,7 @@ public class XML {
     // the one in JSONObject. Changes made here should be reflected there.
     // This method should not make calls out of the XML object.
     public static Object stringToValue(String string) {
-        if ("".equals(string)) {
+        if (string.length() == 0) {
             return string;
         }
 


### PR DESCRIPTION
Very minor change, when checking if a string has no characters or not then string.length() == 0 is always faster than string.equals("")
This only effects the stringToValue method