### PR TITLE
Updates value error messages to be consistent.

### DIFF
--- a/src/main/java/org/json/XML.java
+++ b/src/main/java/org/json/XML.java
@@ -26,7 +26,6 @@ SOFTWARE.
 
 import java.io.Reader;
 import java.io.StringReader;
-import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Iterator;

--- a/src/test/java/org/json/junit/JSONArrayTest.java
+++ b/src/test/java/org/json/junit/JSONArrayTest.java
@@ -412,7 +412,7 @@ public class JSONArrayTest {
             assertTrue("expected getBoolean to fail", false);
         } catch (JSONException e) {
             assertEquals("Expected an exception message",
-                    "JSONArray[4] is not a boolean.",e.getMessage());
+                    "JSONArray[4] is not a boolean (class java.lang.String : hello).",e.getMessage());
         }
         try {
             jsonArray.get(-1);
@@ -426,42 +426,42 @@ public class JSONArrayTest {
             assertTrue("expected getDouble to fail", false);
         } catch (JSONException e) {
             assertEquals("Expected an exception message",
-                    "JSONArray[4] is not a double.",e.getMessage());
+                    "JSONArray[4] is not a double (class java.lang.String : hello).",e.getMessage());
         }
         try {
             jsonArray.getInt(4);
             assertTrue("expected getInt to fail", false);
         } catch (JSONException e) {
             assertEquals("Expected an exception message",
-                    "JSONArray[4] is not a int.",e.getMessage());
+                    "JSONArray[4] is not a int (class java.lang.String : hello).",e.getMessage());
         }
         try {
             jsonArray.getJSONArray(4);
             assertTrue("expected getJSONArray to fail", false);
         } catch (JSONException e) {
             assertEquals("Expected an exception message",
-                    "JSONArray[4] is not a JSONArray.",e.getMessage());
+                    "JSONArray[4] is not a JSONArray (class java.lang.String : hello).",e.getMessage());
         }
         try {
             jsonArray.getJSONObject(4);
             assertTrue("expected getJSONObject to fail", false);
         } catch (JSONException e) {
             assertEquals("Expected an exception message",
-                    "JSONArray[4] is not a JSONObject.",e.getMessage());
+                    "JSONArray[4] is not a JSONObject (class java.lang.String : hello).",e.getMessage());
         }
         try {
             jsonArray.getLong(4);
             assertTrue("expected getLong to fail", false);
         } catch (JSONException e) {
             assertEquals("Expected an exception message",
-                    "JSONArray[4] is not a long.",e.getMessage());
+                    "JSONArray[4] is not a long (class java.lang.String : hello).",e.getMessage());
         }
         try {
             jsonArray.getString(5);
             assertTrue("expected getString to fail", false);
         } catch (JSONException e) {
             assertEquals("Expected an exception message",
-                    "JSONArray[5] is not a String.",e.getMessage());
+                    "JSONArray[5] is not a String (class java.math.BigDecimal : 0.002345).",e.getMessage());
         }
     }
 

--- a/src/test/java/org/json/junit/JSONMLTest.java
+++ b/src/test/java/org/json/junit/JSONMLTest.java
@@ -158,7 +158,7 @@ public class JSONMLTest {
             assertTrue("Expecting an exception", false);
         } catch (JSONException e) {
             assertEquals("Expecting an exception message",
-                "JSONArray[0] is not a String.",
+                "JSONArray[0] is not a String (class org.json.JSONArray).",
                 e.getMessage());
         }
     }

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -1090,7 +1090,7 @@ public class JSONObjectTest {
             fail("Expected an exception");
         } catch (JSONException e) { 
             assertEquals("Expecting an exception message", 
-                    "JSONObject[\"stringKey\"] is not a Boolean.",
+                    "JSONObject[\"stringKey\"] is not a Boolean (class java.lang.String : hello world!).",
                     e.getMessage());
         }
         try {
@@ -1106,7 +1106,7 @@ public class JSONObjectTest {
             fail("Expected an exception");
         } catch (JSONException e) { 
             assertEquals("Expecting an exception message", 
-                    "JSONObject[\"trueKey\"] is not a string.",
+                    "JSONObject[\"trueKey\"] is not a string (class java.lang.Boolean : true).",
                     e.getMessage());
         }
         try {
@@ -1122,7 +1122,7 @@ public class JSONObjectTest {
             fail("Expected an exception");
         } catch (JSONException e) { 
             assertEquals("Expecting an exception message",
-                    "JSONObject[\"stringKey\"] is not a double.",
+                    "JSONObject[\"stringKey\"] is not a double (class java.lang.String : hello world!).",
                     e.getMessage());
         }
         try {
@@ -1138,7 +1138,7 @@ public class JSONObjectTest {
             fail("Expected an exception");
         } catch (JSONException e) { 
             assertEquals("Expecting an exception message",
-                    "JSONObject[\"stringKey\"] is not a float.",
+                    "JSONObject[\"stringKey\"] is not a float (class java.lang.String : hello world!).",
                     e.getMessage());
         }
         try {
@@ -1154,7 +1154,7 @@ public class JSONObjectTest {
             fail("Expected an exception");
         } catch (JSONException e) { 
             assertEquals("Expecting an exception message", 
-                    "JSONObject[\"stringKey\"] is not a int.",
+                    "JSONObject[\"stringKey\"] is not a int (class java.lang.String : hello world!).",
                     e.getMessage());
         }
         try {
@@ -1170,7 +1170,7 @@ public class JSONObjectTest {
             fail("Expected an exception");
         } catch (JSONException e) { 
             assertEquals("Expecting an exception message", 
-                    "JSONObject[\"stringKey\"] is not a long.",
+                    "JSONObject[\"stringKey\"] is not a long (class java.lang.String : hello world!).",
                     e.getMessage());
         }
         try {
@@ -1186,7 +1186,7 @@ public class JSONObjectTest {
             fail("Expected an exception");
         } catch (JSONException e) { 
             assertEquals("Expecting an exception message", 
-                    "JSONObject[\"stringKey\"] is not a JSONArray.",
+                    "JSONObject[\"stringKey\"] is not a JSONArray (class java.lang.String : hello world!).",
                     e.getMessage());
         }
         try {
@@ -1202,7 +1202,7 @@ public class JSONObjectTest {
             fail("Expected an exception");
         } catch (JSONException e) { 
             assertEquals("Expecting an exception message", 
-                    "JSONObject[\"stringKey\"] is not a JSONObject.",
+                    "JSONObject[\"stringKey\"] is not a JSONObject (class java.lang.String : hello world!).",
                     e.getMessage());
         }
     }


### PR DESCRIPTION
Fixes #649 

**What problem does this code solve?**

Updates value error messages to be consistent. Some errors would output value information, but others not.

Provide both the type and value that failed conversion. Tries not to
"toString" large value types like Arrays or Maps. For those types it
will just output the type and not a value.

**Risks**

Low

**Changes to the API?**

No

**Will this require a new release?**

Yes

**Should the documentation be updated?**

No

**Does it break the unit tests?**

Yes. Some tests that verify error messages have been updated.

**Was any code refactored in this commit?**

Private methods were removed that allowed generation of the error messages with no value information.

**Review status**
**APPROVED**