### PR TITLE
Issue 682 JSONString similarity

### DIFF
--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -1386,6 +1386,10 @@ public class JSONArray implements Iterable<Object> {
                 if (!JSONObject.isNumberSimilar((Number)valueThis, (Number)valueOther)) {
                 	return false;
                 }
+            } else if (valueThis instanceof JSONString && valueOther instanceof JSONString) {
+                if (!((JSONString) valueThis).toJSONString().equals(((JSONString) valueOther).toJSONString())) {
+                    return false;
+                }
             } else if (!valueThis.equals(valueOther)) {
                 return false;
             }

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -2142,6 +2142,10 @@ public class JSONObject {
                     if (!isNumberSimilar((Number)valueThis, (Number)valueOther)) {
                     	return false;
                     }
+                } else if (valueThis instanceof JSONString && valueOther instanceof JSONString) {
+                    if (!((JSONString) valueThis).toJSONString().equals(((JSONString) valueOther).toJSONString())) {
+                    	return false;
+                    }
                 } else if (!valueThis.equals(valueOther)) {
                     return false;
                 }

--- a/src/test/java/org/json/junit/JSONArrayTest.java
+++ b/src/test/java/org/json/junit/JSONArrayTest.java
@@ -26,6 +26,7 @@ SOFTWARE.
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -49,7 +50,9 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONPointerException;
+import org.json.JSONString;
 import org.json.JSONTokener;
+import org.json.junit.data.MyJsonString;
 import org.junit.Test;
 
 import com.jayway.jsonpath.Configuration;
@@ -1297,5 +1300,26 @@ public class JSONArrayTest {
         JSONArray json_input = new JSONArray(tokener);
         assertNotNull(json_input);
         fail("Excepected Exception.");
+    }
+
+    @Test
+    public void testIssue682SimilarityOfJSONString() {
+        JSONArray ja1 = new JSONArray()
+                .put(new MyJsonString())
+                .put(2);
+        JSONArray ja2 = new JSONArray()
+                .put(new MyJsonString())
+                .put(2);
+        assertTrue(ja1.similar(ja2));
+
+        JSONArray ja3 = new JSONArray()
+                .put(new JSONString() {
+                    @Override
+                    public String toJSONString() {
+                        return "\"different value\"";
+                    }
+                })
+                .put(2);
+        assertFalse(ja1.similar(ja3));
     }
 }

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -57,6 +57,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONPointerException;
+import org.json.JSONString;
 import org.json.JSONTokener;
 import org.json.XML;
 import org.json.junit.data.BrokenToString;
@@ -3397,5 +3398,26 @@ public class JSONObjectTest {
         JSONObject json_input = new JSONObject(tokener);
         assertNotNull(json_input);
         fail("Excepected Exception.");
+    }
+
+    @Test
+    public void testIssue682SimilarityOfJSONString() {
+        JSONObject jo1 = new JSONObject()
+                .put("a", new MyJsonString())
+                .put("b", 2);
+        JSONObject jo2 = new JSONObject()
+                .put("a", new MyJsonString())
+                .put("b", 2);
+        assertTrue(jo1.similar(jo2));
+
+        JSONObject jo3 = new JSONObject()
+                .put("a", new JSONString() {
+                    @Override
+                    public String toJSONString() {
+                        return "\"different value\"";
+                    }
+                })
+                .put("b", 2);
+        assertFalse(jo1.similar(jo3));
     }
 }


### PR DESCRIPTION
For Issue #682.

What problem does this code solve?
The `similar` methods of JSONObject and JSONArray did not evaluate two equivalent JSONString objects to true.

Risks
Low

Changes to the API?
No

Will this require a new release?
No

Should the documentation be updated?
No

Does it break the unit tests?
No, new unit tests were added.

Was any code refactored in this commit?
No

Review status:
**APPROVED**