### PR TITLE
pipeline-fix-1 remove v7 build from pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         # build against supported Java LTS versions:
-        java: [ 1.7, 8, 11 ]
+        java: [ 8, 11 ]
     name: Java ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
**What problem does this code solve?**
Pipeline builds are failing - possible loss of support in 3rd party build tools for Java 7

**Risks**
Low

**Changes to the API?**
N/A No code changes

**Will this require a new release?**
No

**Should the documentation be updated?**
No

**Does it break the unit tests?**
No

**Was any code refactored in this commit?**
No

**Review status**
**APPROVED** - by myself. 
Starting 3 day comment window