### PR TITLE
do not return 'null' for toString

### DIFF
--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -2350,8 +2350,8 @@ public class JSONObject {
 
     /**
      * Make a JSON text of this JSONObject. For compactness, no whitespace is
-     * added. If this would not result in a syntactically correct JSON text,
-     * then null will be returned instead.
+     * added. This method will throw a JSONException if this object cannot
+     * produce syntactically correct JSON text.
      * <p><b>
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
@@ -2360,14 +2360,12 @@ public class JSONObject {
      *         of the object, beginning with <code>{</code>&nbsp;<small>(left
      *         brace)</small> and ending with <code>}</code>&nbsp;<small>(right
      *         brace)</small>.
+     * @throws JSONException
+     *             If the object contains an invalid number.
      */
     @Override
-    public String toString() {
-        try {
-            return this.toString(0);
-        } catch (Exception e) {
-            return null;
-        }
+    public String toString() throws JSONException {
+        return this.toString(0);
     }
 
     /**

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -215,7 +215,15 @@ public class JSONObjectTest {
         assertTrue("expected 42", textStr.contains("42"));
         Util.checkJSONObjectMaps(jsonObject);
     }
-    
+
+    @Test(expected=JSONException.class)
+    public void shouldThrowExceptionOnToStringWithDoubleInfinityMap() {
+        Map<String,Double> map = new HashMap<String,Double>();
+        map.put("infinity", Double.POSITIVE_INFINITY);
+        JSONObject o = new JSONObject(map);
+        o.toString();
+    }
+
     @Test
     public void testLongFromString(){
         String str = "26315000000253009";


### PR DESCRIPTION
Motivation:

`null` is not a valid return value for Object#toString; for example, see:

https://stackoverflow.com/questions/32378264/when-we-override-the-tostring-method-we-should-always-return-a-string-represen

Additionally, catching Exception means that any RuntimeException (which is likely a bug in the underlying code) will be supressed, making it harder to figure out what is going wrong.

Modification:

The JSONObject#toString contract requires toString to return valid JSON.

The code could return a valid JSON by returning a textural description of the JSONException as a quoted string; however, this would not make it clear than an error has occurred, and would likely be incompatible with the expected structure of the JSON (the schema).

As JSONException is a RuntimeException, the code simply allow it to propagate.

Result:

JSONObject#toString no longer returns `null` under exceptional circumstances.