### PR TITLE
Issue 652 cycle detection doesnt catch cycles through collections

### DIFF
--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -142,10 +142,6 @@ public class JSONArray implements Iterable<Object> {
     public JSONArray(String source) throws JSONException {
         this(new JSONTokener(source));
     }
-    
-    public JSONArray(Collection<?> collection) {
-        this(collection, null);
-    }
 
     /**
      * Construct a JSONArray from a Collection.
@@ -153,7 +149,23 @@ public class JSONArray implements Iterable<Object> {
      * @param collection
      *            A Collection.
      */
-    public JSONArray(Collection<?> collection, Set<Object> objectsRecord) {
+    public JSONArray(Collection<?> collection) {
+        this(collection, null);
+    }
+
+    /**
+     * Construct a JSONArray from a Collection, with an objectsRecord
+     * set to identify recursively defined objects.
+     * 
+     * It's package-private because it is called exclusively by
+     * {@code JSONObject#wrap(Object, Set)}.
+     *
+     * @param collection
+     *            A Collection.
+     * @param objectsRecord
+     *            The set of already recorded objects
+     */
+    JSONArray(Collection<?> collection, Set<Object> objectsRecord) {
         if (collection == null) {
             this.myArrayList = new ArrayList<Object>();
         } else {
@@ -1598,6 +1610,18 @@ public class JSONArray implements Iterable<Object> {
         this.addAll(collection, wrap, null);
     }
     
+    /**
+     * In addition to adding a collection to the JSONArray in the manner of {@code #addAll(Collection, boolean)},
+     * propagates the objectsRecord to {@code JSONObject#wrap(Object, Set)} to identify recursively defined objects.
+     * 
+     * @param collection
+     *            A Collection.
+     * @param wrap
+     *            {@code true} to call {@link JSONObject#wrap(Object)} for each item,
+     *            {@code false} to add the items directly
+     * @param objectsRecord
+     *            The set of already recorded objects
+     */
     private void addAll(Collection<?> collection, boolean wrap, Set<Object> objectsRecord) {
         this.myArrayList.ensureCapacity(this.myArrayList.size() + collection.size());
         if (wrap) {

--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -141,6 +142,10 @@ public class JSONArray implements Iterable<Object> {
     public JSONArray(String source) throws JSONException {
         this(new JSONTokener(source));
     }
+    
+    public JSONArray(Collection<?> collection) {
+        this(collection, null);
+    }
 
     /**
      * Construct a JSONArray from a Collection.
@@ -148,12 +153,12 @@ public class JSONArray implements Iterable<Object> {
      * @param collection
      *            A Collection.
      */
-    public JSONArray(Collection<?> collection) {
+    public JSONArray(Collection<?> collection, Set<Object> objectsRecord) {
         if (collection == null) {
             this.myArrayList = new ArrayList<Object>();
         } else {
             this.myArrayList = new ArrayList<Object>(collection.size());
-            this.addAll(collection, true);
+            this.addAll(collection, true, objectsRecord);
         }
     }
 
@@ -1577,7 +1582,8 @@ public class JSONArray implements Iterable<Object> {
     public boolean isEmpty() {
         return this.myArrayList.isEmpty();
     }
-
+    
+    
     /**
      * Add a collection's elements to the JSONArray.
      *
@@ -1589,10 +1595,14 @@ public class JSONArray implements Iterable<Object> {
      *            
      */
     private void addAll(Collection<?> collection, boolean wrap) {
+        this.addAll(collection, wrap, null);
+    }
+    
+    private void addAll(Collection<?> collection, boolean wrap, Set<Object> objectsRecord) {
         this.myArrayList.ensureCapacity(this.myArrayList.size() + collection.size());
         if (wrap) {
             for (Object o: collection){
-                this.put(JSONObject.wrap(o));
+                this.put(JSONObject.wrap(o, objectsRecord));
             }
         } else {
             for (Object o: collection){

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -2466,7 +2466,20 @@ public class JSONObject {
         return wrap(object, null);
     }
 
-    public static Object wrap(Object object, Set<Object> objectsRecord) {
+    /**
+     * Wraps the object much like {@code #wrap(Object)}, but propagates an objectsRecord set
+     * to identify recursively defined objects.
+     * 
+     * It's package private because other classes in this package may need to further propagate
+     * the set.
+     * 
+     * @param object
+     *            The object to wrap
+     * @param objectsRecord
+     *            The set of already recorded objects
+     * @return The wrapped value
+     */
+    static Object wrap(Object object, Set<Object> objectsRecord) {
         try {
             if (NULL.equals(object)) {
                 return NULL;

--- a/src/test/java/org/json/junit/JSONObjectRecursiveExceptionTest.java
+++ b/src/test/java/org/json/junit/JSONObjectRecursiveExceptionTest.java
@@ -9,6 +9,7 @@ import org.hamcrest.core.StringContains;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -49,18 +50,20 @@ public class JSONObjectRecursiveExceptionTest {
         exceptionRule.expectMessage(StringContains.containsString("JavaBean object contains recursively defined member variable of key"));
     }
    
-    @Test//(expected = JSONException.class)
-    public void testRecursiveList() {
-          
+    
+    @Test
+    public void testRecursiveList() {          
         new JSONObject(new RecursiveList());
     }
     
-    @Test//(expected = JSONException.class)
+    @Ignore
+    @Test
     public void testRecursiveArray() {        
         new JSONObject(new RecursiveArray());
     }
     
-    @Test//(expected = JSONException.class)
+    @Ignore
+    @Test
     public void testRecursiveMap() {        
         new JSONObject(new RecursiveMap());
     }

--- a/src/test/java/org/json/junit/JSONObjectRecursiveExceptionTest.java
+++ b/src/test/java/org/json/junit/JSONObjectRecursiveExceptionTest.java
@@ -1,0 +1,72 @@
+package org.json.junit;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hamcrest.core.StringContains;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class JSONObjectRecursiveExceptionTest {
+    public static class RecursiveList {
+        public List<RecursiveList> getRecursiveList() {
+            return Collections.singletonList(this);
+        }
+    }
+    
+    public static class RecursiveArray {
+        public RecursiveArray[] getRecursiveArray() {
+            return new RecursiveArray[] {this};
+        }
+    }
+    
+    public static class RecursiveMap {
+        public Map<String, RecursiveMap> getRecursiveMap() {
+            Map<String, RecursiveMap> map = new HashMap<String, RecursiveMap>();
+            map.put("test", this);
+            return map;
+        }
+    }
+    
+    public static class Recursive {
+        public Recursive getSelf() {
+            return this;
+        }
+    }
+    
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+    
+    @Before
+    public void before() {
+        exceptionRule.expect(JSONException.class);
+        exceptionRule.expectMessage(StringContains.containsString("JavaBean object contains recursively defined member variable of key"));
+    }
+   
+    @Test//(expected = JSONException.class)
+    public void testRecursiveList() {
+          
+        new JSONObject(new RecursiveList());
+    }
+    
+    @Test//(expected = JSONException.class)
+    public void testRecursiveArray() {        
+        new JSONObject(new RecursiveArray());
+    }
+    
+    @Test//(expected = JSONException.class)
+    public void testRecursiveMap() {        
+        new JSONObject(new RecursiveMap());
+    }
+    
+    @Test
+    public void testRecursive() {
+        new JSONObject(new Recursive());
+    }
+}

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -71,6 +71,8 @@ public class JSONObjectTest {
      *  output to guarantee that we are always writing valid JSON. 
      */
     static final Pattern NUMBER_PATTERN = Pattern.compile("-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?");
+    
+
 
     /**
      * Tests that the similar method is working as expected.

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -71,8 +71,6 @@ public class JSONObjectTest {
      *  output to guarantee that we are always writing valid JSON. 
      */
     static final Pattern NUMBER_PATTERN = Pattern.compile("-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?");
-    
-
 
     /**
      * Tests that the similar method is working as expected.


### PR DESCRIPTION
For issue #652:

This PR detects cycles through collections. It also adds a unit test to verify that this cycle is detected.

The PR also adds three additional unit tests - one of which passes, two of which fail. The passing one verifies that cycles are detected for simple Objects - this was competed with issue #632 / PR #645.

The two failing ones attempt to verify that a cycle is detected in arrays and maps. This is currently not implemented, and a felt it was outside the scope of this issue and PR. If the tests need to pass before the code is merged, I can add an `@Ignore` annotation to the two failing tests pending another issue & PR.