### PR TITLE
Update Releases.md for JSONObject(Map): Throws NPE if key is null

### DIFF
--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -20,6 +20,7 @@ and artifactId "json". For example:
 20190722    Recent commits
 
 20180813    POM change to include Automatic-Module-Name (#431)
+            JSONObject(Map) now throws an exception if any of a map keys are null (#405)
 
 20180130    Recent commits
 


### PR DESCRIPTION
Fixes #678 

Reflecting breaking change that happened in version [20180813](https://github.com/stleary/JSON-java/releases/tag/20180813).
