### PR TITLE
move javadoc comments above the interface definition to make it visible

### DIFF
--- a/src/main/java/org/json/JSONPropertyIgnore.java
+++ b/src/main/java/org/json/JSONPropertyIgnore.java
@@ -11,13 +11,13 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-@Documented
-@Retention(RUNTIME)
-@Target({METHOD})
 /**
  * Use this annotation on a getter method to override the Bean name
  * parser for Bean -&gt; JSONObject mapping. If this annotation is
  * present at any level in the class hierarchy, then the method will
  * not be serialized from the bean into the JSONObject.
  */
+@Documented
+@Retention(RUNTIME)
+@Target({METHOD})
 public @interface JSONPropertyIgnore { }

--- a/src/main/java/org/json/JSONPropertyName.java
+++ b/src/main/java/org/json/JSONPropertyName.java
@@ -11,14 +11,14 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-@Documented
-@Retention(RUNTIME)
-@Target({METHOD})
 /**
  * Use this annotation on a getter method to override the Bean name
  * parser for Bean -&gt; JSONObject mapping. A value set to empty string <code>""</code>
  * will have the Bean parser fall back to the default field name processing.
  */
+@Documented
+@Retention(RUNTIME)
+@Target({METHOD})
 public @interface JSONPropertyName {
     /**
      * @return The name of the property as to be used in the JSON Object.


### PR DESCRIPTION
PR to fix the Javadoc not visible for both `JSONPropertyIgnore` and `JSONPropertyName` classes. 

This doesn't affect the source code execution, I've only rearranged Javadoc comments to the start of the interface definition. 

Fix #670