### PR TITLE
JSONTokener(InputStream) violates rfc8259#section-8.1 (#739)

### DIFF
--- a/src/main/java/org/json/JSONTokener.java
+++ b/src/main/java/org/json/JSONTokener.java
@@ -1,6 +1,7 @@
 package org.json;
 
 import java.io.*;
+import java.nio.charset.Charset;
 
 /*
 Public Domain.
@@ -56,7 +57,7 @@ public class JSONTokener {
      * @param inputStream The source.
      */
     public JSONTokener(InputStream inputStream) {
-        this(new InputStreamReader(inputStream));
+        this(new InputStreamReader(inputStream, Charset.forName("UTF-8")));
     }
 
 
@@ -120,7 +121,7 @@ public class JSONTokener {
 
     /**
      * Checks if the end of the input has been reached.
-     *  
+     *
      * @return true if at the end of the file and we didn't step back
      */
     public boolean end() {
@@ -184,7 +185,7 @@ public class JSONTokener {
         this.previous = (char) c;
         return this.previous;
     }
-    
+
     /**
      * Get the last character read from the input or '\0' if nothing has been read yet.
      * @return the last character read from the input.


### PR DESCRIPTION
Always use UTF-8 when an InputStream is passed.

This fixes #739.