### PR TITLE
Correction of bug when compiling/testing on Windows

### DIFF
--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -915,7 +916,7 @@ public class XMLTest {
             InputStream xmlStream = null;
             try {
                 xmlStream = XMLTest.class.getClassLoader().getResourceAsStream("Issue537.xml");
-                Reader xmlReader = new InputStreamReader(xmlStream);
+                Reader xmlReader = new InputStreamReader(xmlStream, Charset.forName("UTF-8"));
                 JSONObject actual = XML.toJSONObject(xmlReader, true);
                 InputStream jsonStream = null;
                 try {


### PR DESCRIPTION
Issue537.xml file must be read as UTF-8 (#745).
Otherwise, on Windows, the test fails - the beta character (U+03B2) gets read as the two ascii characters 206 & 178.