### PR TITLE
Updated new object methods

### DIFF
--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -600,6 +600,38 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
+     * Get the optional Boolean object associated with an index. It returns false
+     * if there is no value at that index, or if the value is not Boolean.TRUE
+     * or the String "true".
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The truth.
+     */
+    public Boolean optBooleanObject(int index) {
+        return this.optBooleanObject(index, false);
+    }
+
+    /**
+     * Get the optional Boolean object associated with an index. It returns the
+     * defaultValue if there is no value at that index or if it is not a Boolean
+     * or the String "true" or "false" (case insensitive).
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            A boolean default.
+     * @return The truth.
+     */
+    public Boolean optBooleanObject(int index, Boolean defaultValue) {
+        try {
+            return this.getBoolean(index);
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+
+    /**
      * Get the optional double value associated with an index. NaN is returned
      * if there is no value for the index, or if the value is not a number and
      * cannot be converted to a number.
@@ -629,6 +661,42 @@ public class JSONArray implements Iterable<Object> {
             return defaultValue;
         }
         final double doubleValue = val.doubleValue();
+        // if (Double.isNaN(doubleValue) || Double.isInfinite(doubleValue)) {
+        // return defaultValue;
+        // }
+        return doubleValue;
+    }
+
+    /**
+     * Get the optional Double object associated with an index. NaN is returned
+     * if there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The object.
+     */
+    public Double optDoubleObject(int index) {
+        return this.optDoubleObject(index, Double.NaN);
+    }
+
+    /**
+     * Get the optional double value associated with an index. The defaultValue
+     * is returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
+     *
+     * @param index
+     *            subscript
+     * @param defaultValue
+     *            The default object.
+     * @return The object.
+     */
+    public Double optDoubleObject(int index, Double defaultValue) {
+        final Number val = this.optNumber(index, null);
+        if (val == null) {
+            return defaultValue;
+        }
+        final Double doubleValue = val.doubleValue();
         // if (Double.isNaN(doubleValue) || Double.isInfinite(doubleValue)) {
         // return defaultValue;
         // }
@@ -672,6 +740,42 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
+     * Get the optional Float object associated with an index. NaN is returned
+     * if there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The object.
+     */
+    public Float optFloatObject(int index) {
+        return this.optFloatObject(index, Float.NaN);
+    }
+
+    /**
+     * Get the optional Float object associated with an index. The defaultValue
+     * is returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
+     *
+     * @param index
+     *            subscript
+     * @param defaultValue
+     *            The default object.
+     * @return The object.
+     */
+    public Float optFloatObject(int index, Float defaultValue) {
+        final Number val = this.optNumber(index, null);
+        if (val == null) {
+            return defaultValue;
+        }
+        final Float floatValue = val.floatValue();
+        // if (Float.isNaN(floatValue) || Float.isInfinite(floatValue)) {
+        // return floatValue;
+        // }
+        return floatValue;
+    }
+
+    /**
      * Get the optional int value associated with an index. Zero is returned if
      * there is no value for the index, or if the value is not a number and
      * cannot be converted to a number.
@@ -696,6 +800,38 @@ public class JSONArray implements Iterable<Object> {
      * @return The value.
      */
     public int optInt(int index, int defaultValue) {
+        final Number val = this.optNumber(index, null);
+        if (val == null) {
+            return defaultValue;
+        }
+        return val.intValue();
+    }
+
+    /**
+     * Get the optional Integer object associated with an index. Zero is returned if
+     * there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The object.
+     */
+    public Integer optIntegerObject(int index) {
+        return this.optIntegerObject(index, 0);
+    }
+
+    /**
+     * Get the optional Integer object associated with an index. The defaultValue is
+     * returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default object.
+     * @return The object.
+     */
+    public Integer optIntegerObject(int index, Integer defaultValue) {
         final Number val = this.optNumber(index, null);
         if (val == null) {
             return defaultValue;
@@ -839,6 +975,38 @@ public class JSONArray implements Iterable<Object> {
      * @return The value.
      */
     public long optLong(int index, long defaultValue) {
+        final Number val = this.optNumber(index, null);
+        if (val == null) {
+            return defaultValue;
+        }
+        return val.longValue();
+    }
+
+    /**
+     * Get the optional Long object associated with an index. Zero is returned if
+     * there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The object.
+     */
+    public Long optLongObject(int index) {
+        return this.optLongObject(index, 0L);
+    }
+
+    /**
+     * Get the optional Long object associated with an index. The defaultValue is
+     * returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default object.
+     * @return The object.
+     */
+    public Long optLongObject(int index, Long defaultValue) {
         final Number val = this.optNumber(index, null);
         if (val == null) {
             return defaultValue;

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -1132,6 +1132,45 @@ public class JSONObject {
     }
 
     /**
+     * Get an optional boolean object associated with a key. It returns false if there
+     * is no such key, or if the value is not Boolean.TRUE or the String "true".
+     *
+     * @param key
+     *            A key string.
+     * @return The truth.
+     */
+    public Boolean optBooleanObject(String key) {
+        return this.optBooleanObject(key, false);
+    }
+
+    /**
+     * Get an optional boolean object associated with a key. It returns the
+     * defaultValue if there is no such key, or if it is not a Boolean or the
+     * String "true" or "false" (case insensitive).
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
+     * @return The truth.
+     */
+    public Boolean optBooleanObject(String key, Boolean defaultValue) {
+        Object val = this.opt(key);
+        if (NULL.equals(val)) {
+            return defaultValue;
+        }
+        if (val instanceof Boolean){
+            return ((Boolean) val).booleanValue();
+        }
+        try {
+            // we'll use the get anyway because it does string conversion.
+            return this.getBoolean(key);
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+
+    /**
      * Get an optional BigDecimal associated with a key, or the defaultValue if
      * there is no such key or if its value is not a number. If the value is a
      * string, an attempt will be made to evaluate it as a number. If the value
@@ -1294,7 +1333,39 @@ public class JSONObject {
     }
 
     /**
-     * Get the optional double value associated with an index. NaN is returned
+     * Get an optional Double object associated with a key, or NaN if there is no such
+     * key or if its value is not a number. If the value is a string, an attempt
+     * will be made to evaluate it as a number.
+     *
+     * @param key
+     *            A string which is the key.
+     * @return An object which is the value.
+     */
+    public Double optDoubleObject(String key) {
+        return this.optDoubleObject(key, Double.NaN);
+    }
+
+    /**
+     * Get an optional Double object associated with a key, or the defaultValue if
+     * there is no such key or if its value is not a number. If the value is a
+     * string, an attempt will be made to evaluate it as a number.
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
+     * @return An object which is the value.
+     */
+    public Double optDoubleObject(String key, Double defaultValue) {
+        Number val = this.optNumber(key);
+        if (val == null) {
+            return defaultValue;
+        }
+        return val.doubleValue();
+    }
+
+    /**
+     * Get the optional float value associated with an index. NaN is returned
      * if there is no value for the index, or if the value is not a number and
      * cannot be converted to a number.
      *
@@ -1307,7 +1378,7 @@ public class JSONObject {
     }
 
     /**
-     * Get the optional double value associated with an index. The defaultValue
+     * Get the optional float value associated with an index. The defaultValue
      * is returned if there is no value for the index, or if the value is not a
      * number and cannot be converted to a number.
      *
@@ -1323,6 +1394,42 @@ public class JSONObject {
             return defaultValue;
         }
         final float floatValue = val.floatValue();
+        // if (Float.isNaN(floatValue) || Float.isInfinite(floatValue)) {
+        // return defaultValue;
+        // }
+        return floatValue;
+    }
+
+    /**
+     * Get the optional Float object associated with an index. NaN is returned
+     * if there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
+     *
+     * @param key
+     *            A key string.
+     * @return The object.
+     */
+    public Float optFloatObject(String key) {
+        return this.optFloatObject(key, Float.NaN);
+    }
+
+    /**
+     * Get the optional Float object associated with an index. The defaultValue
+     * is returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default object.
+     * @return The object.
+     */
+    public Float optFloatObject(String key, Float defaultValue) {
+        Number val = this.optNumber(key);
+        if (val == null) {
+            return defaultValue;
+        }
+        final Float floatValue = val.floatValue();
         // if (Float.isNaN(floatValue) || Float.isInfinite(floatValue)) {
         // return defaultValue;
         // }
@@ -1354,6 +1461,38 @@ public class JSONObject {
      * @return An object which is the value.
      */
     public int optInt(String key, int defaultValue) {
+        final Number val = this.optNumber(key, null);
+        if (val == null) {
+            return defaultValue;
+        }
+        return val.intValue();
+    }
+
+    /**
+     * Get an optional Integer object associated with a key, or zero if there is no
+     * such key or if the value is not a number. If the value is a string, an
+     * attempt will be made to evaluate it as a number.
+     *
+     * @param key
+     *            A key string.
+     * @return An object which is the value.
+     */
+    public Integer optIntegerObject(String key) {
+        return this.optIntegerObject(key, 0);
+    }
+
+    /**
+     * Get an optional Integer object associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number.
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
+     * @return An object which is the value.
+     */
+    public Integer optIntegerObject(String key, Integer defaultValue) {
         final Number val = this.optNumber(key, null);
         if (val == null) {
             return defaultValue;
@@ -1424,6 +1563,39 @@ public class JSONObject {
      * @return An object which is the value.
      */
     public long optLong(String key, long defaultValue) {
+        final Number val = this.optNumber(key, null);
+        if (val == null) {
+            return defaultValue;
+        }
+
+        return val.longValue();
+    }
+
+    /**
+     * Get an optional Long object associated with a key, or zero if there is no
+     * such key or if the value is not a number. If the value is a string, an
+     * attempt will be made to evaluate it as a number.
+     *
+     * @param key
+     *            A key string.
+     * @return An object which is the value.
+     */
+    public Long optLongObject(String key) {
+        return this.optLongObject(key, 0L);
+    }
+
+    /**
+     * Get an optional Long object associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number.
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
+     * @return An object which is the value.
+     */
+    public Long optLongObject(String key, Long defaultValue) {
         final Number val = this.optNumber(key, null);
         if (val == null) {
             return defaultValue;

--- a/src/test/java/org/json/junit/JSONArrayTest.java
+++ b/src/test/java/org/json/junit/JSONArrayTest.java
@@ -537,6 +537,13 @@ public class JSONArrayTest {
         assertTrue("Array opt boolean implicit default",
                 Boolean.FALSE == jsonArray.optBoolean(-1));
 
+         assertTrue("Array opt boolean object",
+                Boolean.TRUE.equals(jsonArray.optBooleanObject(0)));
+        assertTrue("Array opt boolean object default",
+                Boolean.FALSE.equals(jsonArray.optBooleanObject(-1, Boolean.FALSE)));
+        assertTrue("Array opt boolean object implicit default",
+                Boolean.FALSE.equals(jsonArray.optBooleanObject(-1)));
+
         assertTrue("Array opt double",
                 new Double(23.45e-4).equals(jsonArray.optDouble(5)));
         assertTrue("Array opt double default",
@@ -544,12 +551,26 @@ public class JSONArrayTest {
         assertTrue("Array opt double default implicit",
            new Double(jsonArray.optDouble(99)).isNaN());
 
+        assertTrue("Array opt double object",
+                Double.valueOf(23.45e-4).equals(jsonArray.optDoubleObject(5)));
+        assertTrue("Array opt double object default",
+                Double.valueOf(1).equals(jsonArray.optDoubleObject(0, 1D)));
+        assertTrue("Array opt double object default implicit",
+                jsonArray.optDoubleObject(99).isNaN());
+
         assertTrue("Array opt float",
                 new Float(23.45e-4).equals(jsonArray.optFloat(5)));
         assertTrue("Array opt float default",
                 new Float(1).equals(jsonArray.optFloat(0, 1)));
         assertTrue("Array opt float default implicit",
            new Float(jsonArray.optFloat(99)).isNaN());
+
+        assertTrue("Array opt float object",
+                Float.valueOf(23.45e-4F).equals(jsonArray.optFloatObject(5)));
+        assertTrue("Array opt float object default",
+                Float.valueOf(1).equals(jsonArray.optFloatObject(0, 1F)));
+        assertTrue("Array opt float object default implicit",
+                jsonArray.optFloatObject(99).isNaN());
 
         assertTrue("Array opt Number",
                 BigDecimal.valueOf(23.45e-4).equals(jsonArray.optNumber(5)));
@@ -564,6 +585,13 @@ public class JSONArrayTest {
                 new Integer(-1).equals(jsonArray.optInt(0, -1)));
         assertTrue("Array opt int default implicit",
                 0 == jsonArray.optInt(0));
+
+        assertTrue("Array opt int object",
+                Integer.valueOf(42).equals(jsonArray.optIntegerObject(7)));
+        assertTrue("Array opt int object default",
+                Integer.valueOf(-1).equals(jsonArray.optIntegerObject(0, -1)));
+        assertTrue("Array opt int object default implicit",
+                Integer.valueOf(0).equals(jsonArray.optIntegerObject(0)));
 
         JSONArray nestedJsonArray = jsonArray.optJSONArray(9);
         assertTrue("Array opt JSONArray", nestedJsonArray != null);
@@ -582,6 +610,13 @@ public class JSONArrayTest {
         assertTrue("Array opt long default implicit",
                 0 == jsonArray.optLong(-1));
 
+        assertTrue("Array opt long object",
+                Long.valueOf(0).equals(jsonArray.optLongObject(11)));
+        assertTrue("Array opt long object default",
+                Long.valueOf(-2).equals(jsonArray.optLongObject(-1, -2L)));
+        assertTrue("Array opt long object default implicit",
+                Long.valueOf(0).equals(jsonArray.optLongObject(-1)));
+
         assertTrue("Array opt string",
                 "hello".equals(jsonArray.optString(4)));
         assertTrue("Array opt string default implicit",
@@ -599,10 +634,15 @@ public class JSONArrayTest {
     public void optStringConversion(){
         JSONArray ja = new JSONArray("[\"123\",\"true\",\"false\"]");
         assertTrue("unexpected optBoolean value",ja.optBoolean(1,false)==true);
+        assertTrue("unexpected optBooleanObject value",Boolean.valueOf(true).equals(ja.optBooleanObject(1,false)));
         assertTrue("unexpected optBoolean value",ja.optBoolean(2,true)==false);
+        assertTrue("unexpected optBooleanObject value",Boolean.valueOf(false).equals(ja.optBooleanObject(2,true)));
         assertTrue("unexpected optInt value",ja.optInt(0,0)==123);
+        assertTrue("unexpected optIntegerObject value",Integer.valueOf(123).equals(ja.optIntegerObject(0,0)));
         assertTrue("unexpected optLong value",ja.optLong(0,0)==123);
+        assertTrue("unexpected optLongObject value",Long.valueOf(123).equals(ja.optLongObject(0,0L)));
         assertTrue("unexpected optDouble value",ja.optDouble(0,0.0)==123.0);
+        assertTrue("unexpected optDoubleObject value",Double.valueOf(123.0).equals(ja.optDoubleObject(0,0.0)));
         assertTrue("unexpected optBigInteger value",ja.optBigInteger(0,BigInteger.ZERO).compareTo(new BigInteger("123"))==0);
         assertTrue("unexpected optBigDecimal value",ja.optBigDecimal(0,BigDecimal.ZERO).compareTo(new BigDecimal("123"))==0);
         Util.checkJSONArrayMaps(ja);

--- a/src/test/java/org/json/junit/JSONObjectNumberTest.java
+++ b/src/test/java/org/json/junit/JSONObjectNumberTest.java
@@ -110,8 +110,18 @@ public class JSONObjectNumberTest {
     }
 
     @Test
+    public void testOptFloatObject() {
+        assertEquals((Float) value.floatValue(), object.optFloatObject("value"), 0.0f);
+    }
+
+    @Test
     public void testOptDouble() {
         assertEquals(value.doubleValue(), object.optDouble("value"), 0.0d);
+    }
+
+    @Test
+    public void testOptDoubleObject() {
+        assertEquals((Double) value.doubleValue(), object.optDoubleObject("value"), 0.0d);
     }
 
     @Test
@@ -120,7 +130,17 @@ public class JSONObjectNumberTest {
     }
 
     @Test
+    public void testOptIntegerObject() {
+        assertEquals((Integer) value.intValue(), object.optIntegerObject("value"));
+    }
+
+    @Test
     public void testOptLong() {
         assertEquals(value.longValue(), object.optLong("value"));
+    }
+
+    @Test
+    public void testOptLongObject() {
+        assertEquals((Long) value.longValue(), object.optLongObject("value"));
     }
 }

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -231,6 +231,11 @@ public class JSONObjectTest {
         assert 26315000000253009L == actualLong : "Incorrect key value. Got "
                 + actualLong + " expected " + str;
 
+        final Long actualLongObject = json.optLongObject("key");
+        assert actualLongObject != 0L : "Unable to extract Long value for string " + str;
+        assert Long.valueOf(26315000000253009L).equals(actualLongObject) : "Incorrect key value. Got "
+                + actualLongObject + " expected " + str;
+
         final String actualString = json.optString("key");
         assert str.equals(actualString) : "Incorrect key value. Got "
                 + actualString + " expected " + str;
@@ -866,9 +871,11 @@ public class JSONObjectTest {
         JSONObject jsonObject = new JSONObject(str);
         assertTrue("trueKey should be true", jsonObject.getBoolean("trueKey"));
         assertTrue("opt trueKey should be true", jsonObject.optBoolean("trueKey"));
+        assertTrue("opt trueKey should be true", jsonObject.optBooleanObject("trueKey"));
         assertTrue("falseKey should be false", !jsonObject.getBoolean("falseKey"));
         assertTrue("trueStrKey should be true", jsonObject.getBoolean("trueStrKey"));
         assertTrue("trueStrKey should be true", jsonObject.optBoolean("trueStrKey"));
+        assertTrue("trueStrKey should be true", jsonObject.optBooleanObject("trueStrKey"));
         assertTrue("falseStrKey should be false", !jsonObject.getBoolean("falseStrKey"));
         assertTrue("stringKey should be string",
             jsonObject.getString("stringKey").equals("hello world!"));
@@ -884,6 +891,10 @@ public class JSONObjectTest {
                 jsonObject.optDouble("doubleKey") == -23.45e7);
         assertTrue("opt doubleKey with Default should be double", 
                 jsonObject.optDouble("doubleStrKey", Double.NaN) == 1);
+        assertTrue("opt doubleKey should be Double",
+                Double.valueOf(-23.45e7).equals(jsonObject.optDoubleObject("doubleKey")));
+        assertTrue("opt doubleKey with Default should be Double",
+                Double.valueOf(1).equals(jsonObject.optDoubleObject("doubleStrKey", Double.NaN)));
         assertTrue("opt negZeroKey should be a Double", 
                 jsonObject.opt("negZeroKey") instanceof Double);
         assertTrue("get negZeroKey should be a Double", 
@@ -896,6 +907,10 @@ public class JSONObjectTest {
                 Double.compare(jsonObject.optDouble("negZeroKey"), -0.0d) == 0);
         assertTrue("opt negZeroStrKey with Default should be double", 
                 Double.compare(jsonObject.optDouble("negZeroStrKey"), -0.0d) == 0);
+        assertTrue("opt negZeroKey should be Double",
+                Double.valueOf(-0.0d).equals(jsonObject.optDoubleObject("negZeroKey")));
+        assertTrue("opt negZeroStrKey with Default should be Double",
+                Double.valueOf(-0.0d).equals(jsonObject.optDoubleObject("negZeroStrKey")));
         assertTrue("optNumber negZeroKey should be -0.0", 
                 Double.compare(jsonObject.optNumber("negZeroKey").doubleValue(), -0.0d) == 0);
         assertTrue("optNumber negZeroStrKey should be -0.0", 
@@ -904,10 +919,18 @@ public class JSONObjectTest {
                 jsonObject.optFloat("doubleKey") == -23.45e7f);
         assertTrue("optFloat doubleKey with Default should be float", 
                 jsonObject.optFloat("doubleStrKey", Float.NaN) == 1f);
+        assertTrue("optFloat doubleKey should be Float",
+                Float.valueOf(-23.45e7f).equals(jsonObject.optFloatObject("doubleKey")));
+        assertTrue("optFloat doubleKey with Default should be Float",
+                Float.valueOf(1f).equals(jsonObject.optFloatObject("doubleStrKey", Float.NaN)));
         assertTrue("intKey should be int", 
                 jsonObject.optInt("intKey") == 42);
         assertTrue("opt intKey should be int", 
                 jsonObject.optInt("intKey", 0) == 42);
+        assertTrue("intKey should be Integer",
+                Integer.valueOf(42).equals(jsonObject.optIntegerObject("intKey")));
+        assertTrue("opt intKey should be Integer",
+                Integer.valueOf(42).equals(jsonObject.optIntegerObject("intKey", 0)));
         assertTrue("opt intKey with default should be int", 
                 jsonObject.getInt("intKey") == 42);
         assertTrue("intStrKey should be int", 
@@ -918,6 +941,10 @@ public class JSONObjectTest {
                 jsonObject.optLong("longKey") == 1234567890123456789L);
         assertTrue("opt longKey with default should be long", 
                 jsonObject.optLong("longKey", 0) == 1234567890123456789L);
+        assertTrue("opt longKey should be Long",
+                Long.valueOf(1234567890123456789L).equals(jsonObject.optLongObject("longKey")));
+        assertTrue("opt longKey with default should be Long",
+                Long.valueOf(1234567890123456789L).equals(jsonObject.optLongObject("longKey", 0L)));
         assertTrue("longStrKey should be long", 
                 jsonObject.getLong("longStrKey") == 987654321098765432L);
         assertTrue("optNumber int should return Integer",
@@ -2465,8 +2492,12 @@ public class JSONObjectTest {
                 BigInteger.TEN.compareTo(jsonObject.optBigInteger("myKey",BigInteger.TEN ))==0);
         assertTrue("optBoolean() should return default boolean",
                  jsonObject.optBoolean("myKey", true));
+        assertTrue("optBooleanObject() should return default Boolean",
+                 jsonObject.optBooleanObject("myKey", true));
         assertTrue("optInt() should return default int",
                 42 == jsonObject.optInt("myKey", 42));
+        assertTrue("optIntegerObject() should return default Integer",
+                Integer.valueOf(42).equals(jsonObject.optIntegerObject("myKey", 42)));
         assertTrue("optEnum() should return default Enum",
                 MyEnum.VAL1.equals(jsonObject.optEnum(MyEnum.class, "myKey", MyEnum.VAL1)));
         assertTrue("optJSONArray() should return null ",
@@ -2475,10 +2506,16 @@ public class JSONObjectTest {
                 jsonObject.optJSONObject("myKey", new JSONObject("{\"testKey\":\"testValue\"}")).getString("testKey").equals("testValue"));
         assertTrue("optLong() should return default long",
                 42l == jsonObject.optLong("myKey", 42l));
+        assertTrue("optLongObject() should return default Long",
+                Long.valueOf(42l).equals(jsonObject.optLongObject("myKey", 42l)));
         assertTrue("optDouble() should return default double",
                 42.3d == jsonObject.optDouble("myKey", 42.3d));
+        assertTrue("optDoubleObject() should return default Double",
+                Double.valueOf(42.3d).equals(jsonObject.optDoubleObject("myKey", 42.3d)));
         assertTrue("optFloat() should return default float",
                 42.3f == jsonObject.optFloat("myKey", 42.3f));
+        assertTrue("optFloatObject() should return default Float",
+                Float.valueOf(42.3f).equals(jsonObject.optFloatObject("myKey", 42.3f)));
         assertTrue("optNumber() should return default Number",
                 42l == jsonObject.optNumber("myKey", Long.valueOf(42)).longValue());
         assertTrue("optString() should return default string",
@@ -2502,8 +2539,12 @@ public class JSONObjectTest {
                  BigInteger.TEN.compareTo(jsonObject.optBigInteger("myKey",BigInteger.TEN ))==0);
          assertTrue("optBoolean() should return default boolean",
                   jsonObject.optBoolean("myKey", true));
+         assertTrue("optBooleanObject() should return default Boolean",
+                  jsonObject.optBooleanObject("myKey", true));
          assertTrue("optInt() should return default int",
                  42 == jsonObject.optInt("myKey", 42));
+         assertTrue("optIntegerObject() should return default Integer",
+                 Integer.valueOf(42).equals(jsonObject.optIntegerObject("myKey", 42)));
          assertTrue("optEnum() should return default Enum",
                  MyEnum.VAL1.equals(jsonObject.optEnum(MyEnum.class, "myKey", MyEnum.VAL1)));
          assertTrue("optJSONArray() should return null ",
@@ -2512,10 +2553,16 @@ public class JSONObjectTest {
                 jsonObject.optJSONObject("myKey", new JSONObject("{\"testKey\":\"testValue\"}")).getString("testKey").equals("testValue"));
          assertTrue("optLong() should return default long",
                  42l == jsonObject.optLong("myKey", 42l));
+         assertTrue("optLongObject() should return default Long",
+                 Long.valueOf(42l).equals(jsonObject.optLongObject("myKey", 42l)));
          assertTrue("optDouble() should return default double",
                  42.3d == jsonObject.optDouble("myKey", 42.3d));
+         assertTrue("optDoubleObject() should return default Double",
+                 Double.valueOf(42.3d).equals(jsonObject.optDoubleObject("myKey", 42.3d)));
          assertTrue("optFloat() should return default float",
                  42.3f == jsonObject.optFloat("myKey", 42.3f));
+         assertTrue("optFloatObject() should return default Float",
+                 Float.valueOf(42.3f).equals(jsonObject.optFloatObject("myKey", 42.3f)));
          assertTrue("optNumber() should return default Number",
                  42l == jsonObject.optNumber("myKey", Long.valueOf(42)).longValue());
          assertTrue("optString() should return default string",
@@ -2530,11 +2577,17 @@ public class JSONObjectTest {
     public void jsonObjectOptStringConversion() {
         JSONObject jo = new JSONObject("{\"int\":\"123\",\"true\":\"true\",\"false\":\"false\"}");
         assertTrue("unexpected optBoolean value",jo.optBoolean("true",false)==true);
+        assertTrue("unexpected optBooleanObject value",Boolean.valueOf(true).equals(jo.optBooleanObject("true",false)));
         assertTrue("unexpected optBoolean value",jo.optBoolean("false",true)==false);
+        assertTrue("unexpected optBooleanObject value",Boolean.valueOf(false).equals(jo.optBooleanObject("false",true)));
         assertTrue("unexpected optInt value",jo.optInt("int",0)==123);
+        assertTrue("unexpected optIntegerObject value",Integer.valueOf(123).equals(jo.optIntegerObject("int",0)));
         assertTrue("unexpected optLong value",jo.optLong("int",0)==123l);
+        assertTrue("unexpected optLongObject value",Long.valueOf(123l).equals(jo.optLongObject("int",0L)));
         assertTrue("unexpected optDouble value",jo.optDouble("int",0.0d)==123.0d);
+        assertTrue("unexpected optDoubleObject value",Double.valueOf(123.0d).equals(jo.optDoubleObject("int",0.0d)));
         assertTrue("unexpected optFloat value",jo.optFloat("int",0.0f)==123.0f);
+        assertTrue("unexpected optFloatObject value",Float.valueOf(123.0f).equals(jo.optFloatObject("int",0.0f)));
         assertTrue("unexpected optBigInteger value",jo.optBigInteger("int",BigInteger.ZERO).compareTo(new BigInteger("123"))==0);
         assertTrue("unexpected optBigDecimal value",jo.optBigDecimal("int",BigDecimal.ZERO).compareTo(new BigDecimal("123"))==0);
         assertTrue("unexpected optBigDecimal value",jo.optBigDecimal("int",BigDecimal.ZERO).compareTo(new BigDecimal("123"))==0);
@@ -2555,23 +2608,35 @@ public class JSONObjectTest {
         assertEquals(new BigDecimal("19007199254740993.35481234487103587486413587843213584"), jo.optBigDecimal("largeNumber",null));
         assertEquals(new BigInteger("19007199254740993"), jo.optBigInteger("largeNumber",null));
         assertEquals(1.9007199254740992E16, jo.optDouble("largeNumber"),0.0);
+        assertEquals(1.9007199254740992E16, jo.optDoubleObject("largeNumber"),0.0);
         assertEquals(1.90071995E16f, jo.optFloat("largeNumber"),0.0f);
+        assertEquals(1.90071995E16f, jo.optFloatObject("largeNumber"),0.0f);
         assertEquals(19007199254740993l, jo.optLong("largeNumber"));
+        assertEquals(Long.valueOf(19007199254740993l), jo.optLongObject("largeNumber"));
         assertEquals(1874919425, jo.optInt("largeNumber"));
+        assertEquals(Integer.valueOf(1874919425), jo.optIntegerObject("largeNumber"));
 
         // conversion from a string
         assertEquals(new BigDecimal("19007199254740993.35481234487103587486413587843213584"), jo.optBigDecimal("largeNumberStr",null));
         assertEquals(new BigInteger("19007199254740993"), jo.optBigInteger("largeNumberStr",null));
         assertEquals(1.9007199254740992E16, jo.optDouble("largeNumberStr"),0.0);
+        assertEquals(1.9007199254740992E16, jo.optDoubleObject("largeNumberStr"),0.0);
         assertEquals(1.90071995E16f, jo.optFloat("largeNumberStr"),0.0f);
+        assertEquals(1.90071995E16f, jo.optFloatObject("largeNumberStr"),0.0f);
         assertEquals(19007199254740993l, jo.optLong("largeNumberStr"));
+        assertEquals(Long.valueOf(19007199254740993l), jo.optLongObject("largeNumberStr"));
         assertEquals(1874919425, jo.optInt("largeNumberStr"));
+        assertEquals(Integer.valueOf(1874919425), jo.optIntegerObject("largeNumberStr"));
 
         // the integer portion of the actual value is larger than a double can hold.
         assertNotEquals((long)Double.parseDouble("19007199254740993.35481234487103587486413587843213584"), jo.optLong("largeNumber"));
+        assertNotEquals(Long.valueOf((long)Double.parseDouble("19007199254740993.35481234487103587486413587843213584")), jo.optLongObject("largeNumber"));
         assertNotEquals((int)Double.parseDouble("19007199254740993.35481234487103587486413587843213584"), jo.optInt("largeNumber"));
+        assertNotEquals(Integer.valueOf((int)Double.parseDouble("19007199254740993.35481234487103587486413587843213584")), jo.optIntegerObject("largeNumber"));
         assertNotEquals((long)Double.parseDouble("19007199254740993.35481234487103587486413587843213584"), jo.optLong("largeNumberStr"));
+        assertNotEquals(Long.valueOf((long)Double.parseDouble("19007199254740993.35481234487103587486413587843213584")), jo.optLongObject("largeNumberStr"));
         assertNotEquals((int)Double.parseDouble("19007199254740993.35481234487103587486413587843213584"), jo.optInt("largeNumberStr"));
+        assertNotEquals(Integer.valueOf((int)Double.parseDouble("19007199254740993.35481234487103587486413587843213584")), jo.optIntegerObject("largeNumberStr"));
         assertEquals(19007199254740992l, (long)Double.parseDouble("19007199254740993.35481234487103587486413587843213584"));
         assertEquals(2147483647, (int)Double.parseDouble("19007199254740993.35481234487103587486413587843213584"));
         Util.checkJSONObjectMaps(jo);


### PR DESCRIPTION
Further to #744 & #714, I've:
- Renamed the object methods from ...Obj to ...Object.
- Added an object method for optDoubleObject (returns Double vice double).
- Added similar methods in JSONArray.
- Added test methods.

_To recap, #744 was the following:_
_- optBooleanObj (returns Boolean vice boolean)_
_- optFloatObj (returns Float vice float)_
_- optIntegerObj (returns Integer vice integer)_
_- optLongObj (returns Long vice long)_
_The reason for doing so is that, sometimes, I want (e.g.) optInt to return null if a value isn't found (i.e. I want to do optInt(theKey,null)). However, that gives a compiler error <null> cannot be converted to int, since optInt needs to return an int. Hence adding an almost identical function that returns an Integer instead._

I don't know why I couldn't update the existing PR, it wouldn't let me, hence the new one containing all the above changes in one hit.

