### PR TITLE
JSON parsing should detect embedded `\0` values

### DIFF
--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -253,12 +253,11 @@ public class JSONObject {
             switch (x.nextClean()) {
             case ';':
             case ',':
-                c = x.nextClean();
-                if (c == 0) {
-                    throw x.syntaxError("A JSONObject text must end with '}'");
-                }
-                if (c == '}') {
+                if (x.nextClean() == '}') {
                     return;
+                }
+                if (x.end()) {
+                    throw x.syntaxError("A JSONObject text must end with '}'");
                 }
                 x.back();
                 break;

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -253,7 +253,11 @@ public class JSONObject {
             switch (x.nextClean()) {
             case ';':
             case ',':
-                if (x.nextClean() == '}') {
+                c = x.nextClean();
+                if (c == 0) {
+                    throw x.syntaxError("A JSONObject text must end with '}'");
+                }
+                if (c == '}') {
                     return;
                 }
                 x.back();

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -2226,6 +2226,15 @@ public class JSONObjectTest {
                     e.getMessage());
         }
         try {
+            // \0 after ,
+            String str = "{\"myKey\":true, \0\"myOtherKey\":false}";
+            assertNull("Expected an exception",new JSONObject(str));
+        } catch (JSONException e) {
+          assertEquals("Expecting an exception message",
+              "A JSONObject text must end with '}' at 15 [character 16 line 1]",
+              e.getMessage());
+        }
+        try {
             // append to wrong key
             String str = "{\"myKey\":true, \"myOtherKey\":false}";
             JSONObject jsonObject = new JSONObject(str);

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -2230,9 +2230,9 @@ public class JSONObjectTest {
             String str = "{\"myKey\":true, \0\"myOtherKey\":false}";
             assertNull("Expected an exception",new JSONObject(str));
         } catch (JSONException e) {
-          assertEquals("Expecting an exception message",
-              "A JSONObject text must end with '}' at 15 [character 16 line 1]",
-              e.getMessage());
+            assertEquals("Expecting an exception message",
+                    "A JSONObject text must end with '}' at 15 [character 16 line 1]",
+                    e.getMessage());
         }
         try {
             // append to wrong key


### PR DESCRIPTION
A better solution might be to use -1 instead 0 to represent EOF everywhere, which of course means changing `char` variables to `int`. The solution here is enough to solve the immediate problem, though.

Fixes #758.