### PR TITLE
Add module-info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,13 +188,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.2.0</version>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>org.json</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,31 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.Final</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <module>
+                                <moduleInfo>
+                                    <name>org.json</name>
+                                    <exports>
+                                        org.json;
+                                    </exports>
+                                </moduleInfo>
+                            </module>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.2.0</version>


### PR DESCRIPTION
This adds a module info for the reasons described in #760.

For users of Java 6, 7, or 8 this should not make any difference. The `module-info.class` should be inert under `META-INF/versions/9/module-info.class`. 

The way I implemented it here was with moditect, which directly generates the module-info. There are pros and cons to this, but a small pro is that people should be able to at least run package with JDK 8
