### PR TITLE
Small test fixes.

### DIFF
--- a/src/test/java/org/json/junit/JSONArrayTest.java
+++ b/src/test/java/org/json/junit/JSONArrayTest.java
@@ -1369,7 +1369,7 @@ public class JSONArrayTest {
     @Test(expected = JSONException.class)
     public void issue654StackOverflowInputWellFormed() {
         //String input = new String(java.util.Base64.getDecoder().decode(base64Bytes));
-        final InputStream resourceAsStream = JSONObjectTest.class.getClassLoader().getResourceAsStream("Issue654WellFormedArray.json");
+        final InputStream resourceAsStream = JSONArrayTest.class.getClassLoader().getResourceAsStream("Issue654WellFormedArray.json");
         JSONTokener tokener = new JSONTokener(resourceAsStream);
         JSONArray json_input = new JSONArray(tokener);
         assertNotNull(json_input);

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -3288,6 +3288,7 @@ public class JSONObjectTest {
      * Sample test case from https://github.com/stleary/JSON-java/issues/531
      * which verifies that no regression in double/BigDecimal support is present.
      */
+    @Test
     public void testObjectToBigDecimal() {  
         double value = 1412078745.01074;  
         Reader reader = new StringReader("[{\"value\": " + value + "}]");


### PR DESCRIPTION
One test method was missing `@Test` so it was never run.

One test method used another test class as the base for finding a test resource. While this works in practice with Maven, it is not strictly right.