### PR TITLE
Fix XMLTest.testIndentComplicatedJsonObjectWithArrayAndWithConfig() for Windows - in the test

### DIFF
--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -1223,32 +1223,18 @@ public class XMLTest {
 
     @Test
     public void testIndentComplicatedJsonObjectWithArrayAndWithConfig(){
-        try {
-            InputStream jsonStream = null;
-            try {
-                jsonStream = XMLTest.class.getClassLoader().getResourceAsStream("Issue593.json");
-                final JSONObject object = new JSONObject(new JSONTokener(jsonStream));
-                String actualString = XML.toString(object, null, XMLParserConfiguration.KEEP_STRINGS,2);
-                InputStream xmlStream = null;
-                try {
-                    xmlStream = XMLTest.class.getClassLoader().getResourceAsStream("Issue593.xml");
-                    int bufferSize = 1024;
-                    char[] buffer = new char[bufferSize];
-                    StringBuilder expected = new StringBuilder();
-                    Reader in = new InputStreamReader(xmlStream, "UTF-8");
-                    for (int numRead; (numRead = in.read(buffer, 0, buffer.length)) > 0; ) {
-                        expected.append(buffer, 0, numRead);
-                    }
-                    assertEquals(expected.toString(), actualString.replaceAll("\\n|\\r\\n", System.getProperty("line.separator")));
-                } finally {
-                    if (xmlStream != null) {
-                        xmlStream.close();
-                    }
+        try (InputStream jsonStream = XMLTest.class.getClassLoader().getResourceAsStream("Issue593.json")) {
+            final JSONObject object = new JSONObject(new JSONTokener(jsonStream));
+            String actualString = XML.toString(object, null, XMLParserConfiguration.KEEP_STRINGS, 2);
+            try (InputStream xmlStream = XMLTest.class.getClassLoader().getResourceAsStream("Issue593.xml")) {
+                int bufferSize = 1024;
+                char[] buffer = new char[bufferSize];
+                StringBuilder expected = new StringBuilder();
+                Reader in = new InputStreamReader(xmlStream, "UTF-8");
+                for (int numRead; (numRead = in.read(buffer, 0, buffer.length)) > 0; ) {
+                    expected.append(buffer, 0, numRead);
                 }
-            } finally {
-                if (jsonStream != null) {
-                    jsonStream.close();
-                }
+                assertEquals(expected.toString(), actualString);
             }
         } catch (IOException e) {
             fail("file writer error: " +e.getMessage());


### PR DESCRIPTION
#593 and 85495facbd4a9e2e13f6ef50a35a4b35535c96b5 included some workaround for Windows machines regarding linefeeds. The test `org.json.junit.XMLTest.testIndentComplicatedJsonObjectWithArrayAndWithConfig()` is currently failing on my Windows 10 machine and also I see no reason why this workaround was needed in the first place. The file `Issue593.xml` contains only `\n` line feeds and no conversion is done while reading this file, thus `expected` only contains `\n`. Conversely the tested method `XML.toString()` only appends hardcoded `\n`.

The only setting where the conversion is needed is when someone has their `.gitattributes`/Git settings or IDE configured to autoreplace linefeeds by the system default. In that case I would say it is actually correct that the test fails because it indicates a wrong setup.