### PR TITLE
Fix XMLTest.testIndentComplicatedJsonObjectWithArrayAndWithConfig() for Windows - in the test

### DIFF
--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -1239,7 +1239,8 @@ public class XMLTest {
                     for (int numRead; (numRead = in.read(buffer, 0, buffer.length)) > 0; ) {
                         expected.append(buffer, 0, numRead);
                     }
-                    assertEquals(expected.toString(), actualString.replaceAll("\\n|\\r\\n", System.getProperty("line.separator")));
+                    assertEquals(expected.toString().replaceAll("\\n|\\r\\n", System.getProperty("line.separator")),
+                            actualString.replaceAll("\\n|\\r\\n", System.getProperty("line.separator")));
                 } finally {
                     if (xmlStream != null) {
                         xmlStream.close();

--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -1239,8 +1239,8 @@ public class XMLTest {
                     for (int numRead; (numRead = in.read(buffer, 0, buffer.length)) > 0; ) {
                         expected.append(buffer, 0, numRead);
                     }
-                    assertEquals(expected.toString().replaceAll("\\n|\\r\\n", System.getProperty("line.separator")),
-                            actualString.replaceAll("\\n|\\r\\n", System.getProperty("line.separator")));
+                    assertEquals(expected.toString().replaceAll("\\n|\\r\\n", System.lineSeparator()),
+                            actualString.replaceAll("\\n|\\r\\n", System.lineSeparator()));
                 } finally {
                     if (xmlStream != null) {
                         xmlStream.close();


### PR DESCRIPTION
`XMLTest.testIndentComplicatedJsonObjectWithArrayAndWithConfig` fails when run on Windows due to mismatching linebreaks (that aren't important for the test's functionality) between the actual and expected strings.

For the actual strings, linebreaks are canonized to the platform's native linebreak using `replaceAll("\\n|\\r\\n",
System.getProperty("line.separator")`. However, the expected result is read from a file, and is left with the linebreaks that were originally used to create it.

The solution is to perform the same canonization on both strings.

Closes #781