### PR TITLE
optLong vs getLong inconsistencies

### DIFF
--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -2379,12 +2379,13 @@ public class JSONObject {
      * returns for this function are BigDecimal, Double, BigInteger, Long, and Integer.
      * When a Double is returned, it should always be a valid Double and not NaN or +-infinity.
      *
-     * @param val value to convert
+     * @param input value to convert
      * @return Number representation of the value.
      * @throws NumberFormatException thrown if the value is not a valid number. A public
      *      caller should catch this and wrap it in a {@link JSONException} if applicable.
      */
-    protected static Number stringToNumber(final String val) throws NumberFormatException {
+    protected static Number stringToNumber(final String input) throws NumberFormatException {
+        String val = input;
         char initial = val.charAt(0);
         if ((initial >= '0' && initial <= '9') || initial == '-') {
             // decimal representation
@@ -2411,6 +2412,8 @@ public class JSONObject {
                     }
                 }
             }
+            val = removeLeadingZerosOfNumber(input);
+            initial = val.charAt(0);
             // block items like 00 01 etc. Java number parsers treat these as Octal.
             if(initial == '0' && val.length() > 1) {
                 char at1 = val.charAt(1);
@@ -2885,5 +2888,34 @@ public class JSONObject {
         return new JSONException(
             "JavaBean object contains recursively defined member variable of key " + quote(key)
         );
+    }
+
+    /**
+     * For a prospective number, remove the leading zeros
+     * @param value prospective number
+     * @return number without leading zeros
+     */
+    private static String removeLeadingZerosOfNumber(String value){
+        char[] chars = value.toCharArray();
+        int leftMostUnsignedIndex = 0;
+        if (chars[0] == '-'){
+            leftMostUnsignedIndex = 1;
+        }
+        int firstNonZeroCharIndex = -1;
+        for (int i=leftMostUnsignedIndex;i<value.length();i++){
+            if (chars[i] != '0'){
+                firstNonZeroCharIndex = i;
+                break;
+            }
+        }
+        if (firstNonZeroCharIndex == -1){
+            return value;
+        }
+        StringBuilder result = new StringBuilder();
+        if (leftMostUnsignedIndex == 1){
+            result.append('-');
+        }
+        result.append(value.substring(firstNonZeroCharIndex));
+        return result.toString();
     }
 }

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -2416,17 +2416,16 @@ public class JSONObject {
                     try {
                         Double d = Double.valueOf(val);
                         if(d.isNaN() || d.isInfinite()) {
-                            throw new NumberFormatException("val ["+val+"] is not a valid number.");
+                            throw new NumberFormatException("val ["+input+"] is not a valid number.");
                         }
                         return d;
                     } catch (NumberFormatException ignore) {
-                        throw new NumberFormatException("val ["+val+"] is not a valid number.");
+                        throw new NumberFormatException("val ["+input+"] is not a valid number.");
                     }
                 }
             }
             val = removeLeadingZerosOfNumber(input);
             initial = val.charAt(0);
-            // block items like 00 01 etc. Java number parsers treat these as Octal.
             if(initial == '0' && val.length() > 1) {
                 char at1 = val.charAt(1);
                 if(at1 >= '0' && at1 <= '9') {
@@ -2934,10 +2933,12 @@ public class JSONObject {
         int counter = negativeFirstChar ? 1:0;
         while (counter < value.length()){
             if (value.charAt(counter) != '0'){
-                return String.format("%s%s", negativeFirstChar?'-':"",value.substring(counter));
+                if (negativeFirstChar) {return "-".concat(value.substring(counter));}
+                return value.substring(counter);
             }
             ++counter;
         }
-        return String.format("%s%s", negativeFirstChar?'-':"",'0');
+        if (negativeFirstChar) {return "-0";}
+        return "0";
     }
 }

--- a/src/test/java/org/json/junit/JSONObjectDecimalTest.java
+++ b/src/test/java/org/json/junit/JSONObjectDecimalTest.java
@@ -1,0 +1,100 @@
+package org.json.junit;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.junit.Assert.assertEquals;
+
+public class JSONObjectDecimalTest {
+
+    @Test
+    public void shouldParseDecimalNumberThatStartsWithDecimalPoint(){
+        JSONObject jsonObject = new JSONObject("{value:0.50}");
+        assertEquals("Float not recognized", 0.5f, jsonObject.getFloat("value"), 0.0f);
+        assertEquals("Float not recognized", 0.5f, jsonObject.optFloat("value"), 0.0f);
+        assertEquals("Float not recognized", 0.5f, jsonObject.optFloatObject("value"), 0.0f);
+        assertEquals("Double not recognized", 0.5d, jsonObject.optDouble("value"), 0.0f);
+        assertEquals("Double not recognized", 0.5d, jsonObject.optDoubleObject("value"), 0.0f);
+        assertEquals("Double not recognized", 0.5d, jsonObject.getDouble("value"), 0.0f);
+        assertEquals("Long not recognized", 0, jsonObject.optLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.getLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.optLongObject("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.getInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optIntegerObject("value"), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").intValue(), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").longValue(), 0);
+        assertEquals("BigDecimal not recognized", 0, BigDecimal.valueOf(.5).compareTo(jsonObject.getBigDecimal("value")));
+        assertEquals("BigInteger not recognized",0, BigInteger.valueOf(0).compareTo(jsonObject.getBigInteger("value")));
+    }
+
+
+
+    @Test
+    public void shouldParseNegativeDecimalNumberThatStartsWithDecimalPoint(){
+        JSONObject jsonObject = new JSONObject("{value:-.50}");
+        assertEquals("Float not recognized", -0.5f, jsonObject.getFloat("value"), 0.0f);
+        assertEquals("Float not recognized", -0.5f, jsonObject.optFloat("value"), 0.0f);
+        assertEquals("Float not recognized", -0.5f, jsonObject.optFloatObject("value"), 0.0f);
+        assertEquals("Double not recognized", -0.5d, jsonObject.optDouble("value"), 0.0f);
+        assertEquals("Double not recognized", -0.5d, jsonObject.optDoubleObject("value"), 0.0f);
+        assertEquals("Double not recognized", -0.5d, jsonObject.getDouble("value"), 0.0f);
+        assertEquals("Long not recognized", 0, jsonObject.optLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.getLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.optLongObject("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.getInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optIntegerObject("value"), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").intValue(), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").longValue(), 0);
+        assertEquals("BigDecimal not recognized", 0, BigDecimal.valueOf(-.5).compareTo(jsonObject.getBigDecimal("value")));
+        assertEquals("BigInteger not recognized",0, BigInteger.valueOf(0).compareTo(jsonObject.getBigInteger("value")));
+    }
+
+    @Test
+    public void shouldParseDecimalNumberThatHasZeroBeforeWithDecimalPoint(){
+        JSONObject jsonObject = new JSONObject("{value:00.050}");
+        assertEquals("Float not recognized", 0.05f, jsonObject.getFloat("value"), 0.0f);
+        assertEquals("Float not recognized", 0.05f, jsonObject.optFloat("value"), 0.0f);
+        assertEquals("Float not recognized", 0.05f, jsonObject.optFloatObject("value"), 0.0f);
+        assertEquals("Double not recognized", 0.05d, jsonObject.optDouble("value"), 0.0f);
+        assertEquals("Double not recognized", 0.05d, jsonObject.optDoubleObject("value"), 0.0f);
+        assertEquals("Double not recognized", 0.05d, jsonObject.getDouble("value"), 0.0f);
+        assertEquals("Long not recognized", 0, jsonObject.optLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.getLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.optLongObject("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.getInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optIntegerObject("value"), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").intValue(), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").longValue(), 0);
+        assertEquals("BigDecimal not recognized", 0, BigDecimal.valueOf(.05).compareTo(jsonObject.getBigDecimal("value")));
+        assertEquals("BigInteger not recognized",0, BigInteger.valueOf(0).compareTo(jsonObject.getBigInteger("value")));
+    }
+
+    @Test
+    public void shouldParseNegativeDecimalNumberThatHasZeroBeforeWithDecimalPoint(){
+        JSONObject jsonObject = new JSONObject("{value:-00.050}");
+        assertEquals("Float not recognized", -0.05f, jsonObject.getFloat("value"), 0.0f);
+        assertEquals("Float not recognized", -0.05f, jsonObject.optFloat("value"), 0.0f);
+        assertEquals("Float not recognized", -0.05f, jsonObject.optFloatObject("value"), 0.0f);
+        assertEquals("Double not recognized", -0.05d, jsonObject.optDouble("value"), 0.0f);
+        assertEquals("Double not recognized", -0.05d, jsonObject.optDoubleObject("value"), 0.0f);
+        assertEquals("Double not recognized", -0.05d, jsonObject.getDouble("value"), 0.0f);
+        assertEquals("Long not recognized", 0, jsonObject.optLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.getLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.optLongObject("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.getInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optIntegerObject("value"), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").intValue(), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").longValue(), 0);
+        assertEquals("BigDecimal not recognized", 0, BigDecimal.valueOf(-.05).compareTo(jsonObject.getBigDecimal("value")));
+        assertEquals("BigInteger not recognized",0, BigInteger.valueOf(0).compareTo(jsonObject.getBigInteger("value")));
+    }
+
+
+}

--- a/src/test/java/org/json/junit/JSONObjectNumberTest.java
+++ b/src/test/java/org/json/junit/JSONObjectNumberTest.java
@@ -23,7 +23,10 @@ public class JSONObjectNumberTest {
     @Parameters(name = "{index}: {0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-            {"{value:50}", 1},
+            {"{value:0050}", 1},
+            {"{value:0050.0000}", 1},
+            {"{value:-0050}", -1},
+            {"{value:-0050.0000}", -1},
             {"{value:50.0}", 1},
             {"{value:5e1}", 1},
             {"{value:5E1}", 1},
@@ -32,6 +35,7 @@ public class JSONObjectNumberTest {
             {"{value:-50}", -1},
             {"{value:-50.0}", -1},
             {"{value:-5e1}", -1},
+            {"{value:-0005e1}", -1},
             {"{value:-5E1}", -1},
             {"{value:-5e1}", -1},
             {"{value:'-50'}", -1}

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -1063,12 +1063,16 @@ public class JSONObjectTest {
                 "\"tooManyZeros\":00,"+
                 "\"negativeInfinite\":-Infinity,"+
                 "\"negativeNaN\":-NaN,"+
+                "\"negativeNaNWithLeadingZeros\":-00NaN,"+
                 "\"negativeFraction\":-.01,"+
                 "\"tooManyZerosFraction\":00.001,"+
                 "\"negativeHexFloat\":-0x1.fffp1,"+
                 "\"hexFloat\":0x1.0P-1074,"+
                 "\"floatIdentifier\":0.1f,"+
-                "\"doubleIdentifier\":0.1d"+
+                "\"doubleIdentifier\":0.1d,"+
+                "\"integerWithLeadingZeros\":000900,"+
+                "\"integerWithAllZeros\":00000,"+
+                "\"compositeWithLeadingZeros\":00800.90d"+
             "}";
         JSONObject jsonObject = new JSONObject(str);
         Object obj;
@@ -1085,10 +1089,17 @@ public class JSONObjectTest {
         obj = jsonObject.get("negativeNaN");
         assertTrue( "negativeNaN currently evaluates to string",
                 obj.equals("-NaN"));
+        obj = jsonObject.get("negativeNaNWithLeadingZeros");
+        assertTrue( "negativeNaNWithLeadingZeros currently evaluates to string",
+                obj.equals("-00NaN"));
         assertTrue( "negativeFraction currently evaluates to double -0.01",
                 jsonObject.get( "negativeFraction" ).equals(BigDecimal.valueOf(-0.01)));
         assertTrue( "tooManyZerosFraction currently evaluates to double 0.001",
                 jsonObject.get( "tooManyZerosFraction" ).equals(BigDecimal.valueOf(0.001)));
+        assertTrue( "tooManyZerosFraction currently evaluates to double 0.001",
+                jsonObject.getLong( "tooManyZerosFraction" )==0);
+        assertTrue( "tooManyZerosFraction currently evaluates to double 0.001",
+                jsonObject.optLong( "tooManyZerosFraction" )==0);
         assertTrue( "negativeHexFloat currently evaluates to double -3.99951171875",
                 jsonObject.get( "negativeHexFloat" ).equals(Double.valueOf(-3.99951171875)));
         assertTrue("hexFloat currently evaluates to double 4.9E-324",
@@ -1097,6 +1108,28 @@ public class JSONObjectTest {
                 jsonObject.get("floatIdentifier").equals(Double.valueOf(0.1)));
         assertTrue("doubleIdentifier currently evaluates to double 0.1",
                 jsonObject.get("doubleIdentifier").equals(Double.valueOf(0.1)));
+        assertTrue("Integer does not evaluate to 900",
+                jsonObject.get("integerWithLeadingZeros").equals(900));
+        assertTrue("Integer does not evaluate to 900",
+                jsonObject.getInt("integerWithLeadingZeros")==900);
+        assertTrue("Integer does not evaluate to 900",
+                jsonObject.optInt("integerWithLeadingZeros")==900);
+        assertTrue("Integer does not evaluate to 0",
+                jsonObject.get("integerWithAllZeros").equals("00000"));
+        assertTrue("Integer does not evaluate to 0",
+                jsonObject.getInt("integerWithAllZeros")==0);
+        assertTrue("Integer does not evaluate to 0",
+                jsonObject.optInt("integerWithAllZeros")==0);
+        assertTrue("Double does not evaluate to 800.90",
+                jsonObject.get("compositeWithLeadingZeros").equals(800.90));
+        assertTrue("Double does not evaluate to 800.90",
+                jsonObject.getDouble("compositeWithLeadingZeros")==800.9d);
+        assertTrue("Integer does not evaluate to 800",
+                jsonObject.optInt("compositeWithLeadingZeros")==800);
+        assertTrue("Long does not evaluate to 800.90",
+                jsonObject.getLong("compositeWithLeadingZeros")==800);
+        assertTrue("Long does not evaluate to 800.90",
+                jsonObject.optLong("compositeWithLeadingZeros")==800);
         Util.checkJSONObjectMaps(jsonObject);
     }
 

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -4,6 +4,7 @@ package org.json.junit;
 Public Domain.
 */
 
+import static java.lang.Double.NaN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -782,7 +783,7 @@ public class JSONObjectTest {
         jsonObject.accumulate("myArray", -23.45e7);
         // include an unsupported object for coverage
         try {
-            jsonObject.accumulate("myArray", Double.NaN);
+            jsonObject.accumulate("myArray", NaN);
             fail("Expected exception");
         } catch (JSONException ignored) {}
 
@@ -814,7 +815,7 @@ public class JSONObjectTest {
         jsonObject.append("myArray", -23.45e7);
         // include an unsupported object for coverage
         try {
-            jsonObject.append("myArray", Double.NaN);
+            jsonObject.append("myArray", NaN);
             fail("Expected exception");
         } catch (JSONException ignored) {}
 
@@ -839,7 +840,7 @@ public class JSONObjectTest {
     public void jsonObjectDoubleToString() {
         String [] expectedStrs = {"1", "1", "-23.4", "-2.345E68", "null", "null" };
         Double [] doubles = { 1.0, 00001.00000, -23.4, -23.45e67, 
-                Double.NaN, Double.NEGATIVE_INFINITY }; 
+                NaN, Double.NEGATIVE_INFINITY };
         for (int i = 0; i < expectedStrs.length; ++i) {
             String actualStr = JSONObject.doubleToString(doubles[i]);
             assertTrue("value expected ["+expectedStrs[i]+
@@ -894,11 +895,11 @@ public class JSONObjectTest {
         assertTrue("opt doubleKey should be double", 
                 jsonObject.optDouble("doubleKey") == -23.45e7);
         assertTrue("opt doubleKey with Default should be double", 
-                jsonObject.optDouble("doubleStrKey", Double.NaN) == 1);
+                jsonObject.optDouble("doubleStrKey", NaN) == 1);
         assertTrue("opt doubleKey should be Double",
                 Double.valueOf(-23.45e7).equals(jsonObject.optDoubleObject("doubleKey")));
         assertTrue("opt doubleKey with Default should be Double",
-                Double.valueOf(1).equals(jsonObject.optDoubleObject("doubleStrKey", Double.NaN)));
+                Double.valueOf(1).equals(jsonObject.optDoubleObject("doubleStrKey", NaN)));
         assertTrue("opt negZeroKey should be a Double", 
                 jsonObject.opt("negZeroKey") instanceof Double);
         assertTrue("get negZeroKey should be a Double", 
@@ -1071,9 +1072,14 @@ public class JSONObjectTest {
                 "\"hexFloat\":0x1.0P-1074,"+
                 "\"floatIdentifier\":0.1f,"+
                 "\"doubleIdentifier\":0.1d,"+
+                "\"doubleIdentifierWithMultipleLeadingZerosBeforeDecimal\":0000000.1d,"+
+                "\"negativeDoubleIdentifierWithMultipleLeadingZerosBeforeDecimal\":-0000000.1d,"+
+                "\"doubleIdentifierWithMultipleLeadingZerosAfterDecimal\":0000000.0001d,"+
+                "\"negativeDoubleIdentifierWithMultipleLeadingZerosAfterDecimal\":-0000000.0001d,"+
                 "\"integerWithLeadingZeros\":000900,"+
                 "\"integerWithAllZeros\":00000,"+
-                "\"compositeWithLeadingZeros\":00800.90d"+
+                "\"compositeWithLeadingZeros\":00800.90d,"+
+                "\"decimalPositiveWithoutNumberBeforeDecimalPoint\":.90,"+
             "}";
         JSONObject jsonObject = new JSONObject(str);
         Object obj;
@@ -1083,7 +1089,7 @@ public class JSONObjectTest {
         assertTrue("hexNumber currently evaluates to string",
                 obj.equals("-0x123"));
         assertTrue( "tooManyZeros currently evaluates to string",
-                jsonObject.get( "tooManyZeros" ).equals("00"));
+                jsonObject.get( "tooManyZeros" ).equals(0));
         obj = jsonObject.get("negativeInfinite");
         assertTrue( "negativeInfinite currently evaluates to string",
                 obj.equals("-Infinity"));
@@ -1109,6 +1115,16 @@ public class JSONObjectTest {
                 jsonObject.get("floatIdentifier").equals(Double.valueOf(0.1)));
         assertTrue("doubleIdentifier currently evaluates to double 0.1",
                 jsonObject.get("doubleIdentifier").equals(Double.valueOf(0.1)));
+        assertTrue("doubleIdentifierWithMultipleLeadingZerosBeforeDecimal currently evaluates to double 0.1",
+                jsonObject.get("doubleIdentifierWithMultipleLeadingZerosBeforeDecimal").equals(Double.valueOf(0.1)));
+        assertTrue("negativeDoubleIdentifierWithMultipleLeadingZerosBeforeDecimal currently evaluates to double -0.1",
+                jsonObject.get("negativeDoubleIdentifierWithMultipleLeadingZerosBeforeDecimal").equals(Double.valueOf(-0.1)));
+        assertTrue("doubleIdentifierWithMultipleLeadingZerosAfterDecimal currently evaluates to double 0.0001",
+                jsonObject.get("doubleIdentifierWithMultipleLeadingZerosAfterDecimal").equals(Double.valueOf(0.0001)));
+        assertTrue("doubleIdentifierWithMultipleLeadingZerosAfterDecimal currently evaluates to double 0.0001",
+                jsonObject.get("doubleIdentifierWithMultipleLeadingZerosAfterDecimal").equals(Double.valueOf(0.0001)));
+        assertTrue("negativeDoubleIdentifierWithMultipleLeadingZerosAfterDecimal currently evaluates to double -0.0001",
+                jsonObject.get("negativeDoubleIdentifierWithMultipleLeadingZerosAfterDecimal").equals(Double.valueOf(-0.0001)));
         assertTrue("Integer does not evaluate to 900",
                 jsonObject.get("integerWithLeadingZeros").equals(900));
         assertTrue("Integer does not evaluate to 900",
@@ -1116,7 +1132,7 @@ public class JSONObjectTest {
         assertTrue("Integer does not evaluate to 900",
                 jsonObject.optInt("integerWithLeadingZeros")==900);
         assertTrue("Integer does not evaluate to 0",
-                jsonObject.get("integerWithAllZeros").equals("00000"));
+                jsonObject.get("integerWithAllZeros").equals(0));
         assertTrue("Integer does not evaluate to 0",
                 jsonObject.getInt("integerWithAllZeros")==0);
         assertTrue("Integer does not evaluate to 0",
@@ -1131,6 +1147,21 @@ public class JSONObjectTest {
                 jsonObject.getLong("compositeWithLeadingZeros")==800);
         assertTrue("Long does not evaluate to 800.90",
                 jsonObject.optLong("compositeWithLeadingZeros")==800);
+        assertEquals("Get long of decimalPositiveWithoutNumberBeforeDecimalPoint does not match",
+                0.9d,jsonObject.getDouble("decimalPositiveWithoutNumberBeforeDecimalPoint"),  0.0d);
+        assertEquals("Get long of decimalPositiveWithoutNumberBeforeDecimalPoint does not match",
+                0.9d,jsonObject.optDouble("decimalPositiveWithoutNumberBeforeDecimalPoint"),  0.0d);
+        assertEquals("Get long of decimalPositiveWithoutNumberBeforeDecimalPoint does not match",
+                0.0d,jsonObject.optLong("decimalPositiveWithoutNumberBeforeDecimalPoint"),  0.0d);
+
+        assertEquals("Get long of doubleIdentifierWithMultipleLeadingZerosAfterDecimal does not match",
+                0.0001d,jsonObject.getDouble("doubleIdentifierWithMultipleLeadingZerosAfterDecimal"),  0.0d);
+        assertEquals("Get long of doubleIdentifierWithMultipleLeadingZerosAfterDecimal does not match",
+                0.0001d,jsonObject.optDouble("doubleIdentifierWithMultipleLeadingZerosAfterDecimal"),  0.0d);
+        assertEquals("Get long of doubleIdentifierWithMultipleLeadingZerosAfterDecimal does not match",
+                0.0d, jsonObject.getLong("doubleIdentifierWithMultipleLeadingZerosAfterDecimal") , 0.0d);
+        assertEquals("Get long of doubleIdentifierWithMultipleLeadingZerosAfterDecimal does not match",
+                0.0d,jsonObject.optLong("doubleIdentifierWithMultipleLeadingZerosAfterDecimal"),  0.0d);
         Util.checkJSONObjectMaps(jsonObject);
     }
 
@@ -2361,7 +2392,7 @@ public class JSONObjectTest {
         }
         try {
             // test validity of invalid double 
-            JSONObject.testValidity(Double.NaN);
+            JSONObject.testValidity(NaN);
             fail("Expected an exception");
         } catch (JSONException e) { 
             assertTrue("", true);

--- a/src/test/java/org/json/junit/JsonNumberZeroTest.java
+++ b/src/test/java/org/json/junit/JsonNumberZeroTest.java
@@ -1,0 +1,55 @@
+package org.json.junit;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.junit.Assert.assertEquals;
+
+public class JsonNumberZeroTest {
+
+    @Test
+    public void shouldParseNegativeZeroValueWithMultipleZeroDigit(){
+        JSONObject jsonObject = new JSONObject("{value:-0000}");
+        assertEquals("Float not recognized", -0f, jsonObject.getFloat("value"), 0.0f);
+        assertEquals("Float not recognized", -0f, jsonObject.optFloat("value"), 0.0f);
+        assertEquals("Float not recognized", -0f, jsonObject.optFloatObject("value"), 0.0f);
+        assertEquals("Double not recognized", -0d, jsonObject.optDouble("value"), 0.0f);
+        assertEquals("Double not recognized", -0.0d, jsonObject.optDoubleObject("value"), 0.0f);
+        assertEquals("Double not recognized", -0.0d, jsonObject.getDouble("value"), 0.0f);
+        assertEquals("Long not recognized", 0, jsonObject.optLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.getLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.optLongObject("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.getInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optIntegerObject("value"), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").intValue(), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").longValue(), 0);
+        assertEquals("BigDecimal not recognized", 0, BigDecimal.valueOf(-0).compareTo(jsonObject.getBigDecimal("value")));
+        assertEquals("BigInteger not recognized",0, BigInteger.valueOf(0).compareTo(jsonObject.getBigInteger("value")));
+    }
+
+    @Test
+    public void shouldParseZeroValueWithMultipleZeroDigit(){
+        JSONObject jsonObject = new JSONObject("{value:0000}");
+        assertEquals("Float not recognized", 0f, jsonObject.getFloat("value"), 0.0f);
+        assertEquals("Float not recognized", 0f, jsonObject.optFloat("value"), 0.0f);
+        assertEquals("Float not recognized", 0f, jsonObject.optFloatObject("value"), 0.0f);
+        assertEquals("Double not recognized", 0d, jsonObject.optDouble("value"), 0.0f);
+        assertEquals("Double not recognized", 0.0d, jsonObject.optDoubleObject("value"), 0.0f);
+        assertEquals("Double not recognized", 0.0d, jsonObject.getDouble("value"), 0.0f);
+        assertEquals("Long not recognized", 0, jsonObject.optLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.getLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.optLongObject("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.getInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optIntegerObject("value"), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").intValue(), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").longValue(), 0);
+        assertEquals("BigDecimal not recognized", 0, BigDecimal.valueOf(-0).compareTo(jsonObject.getBigDecimal("value")));
+        assertEquals("BigInteger not recognized",0, BigInteger.valueOf(0).compareTo(jsonObject.getBigInteger("value")));
+    }
+
+}


### PR DESCRIPTION
For exponential decimal conversion, number is not touched. Leading zeros removed from numeric number strings before converting to number.