### PR TITLE
Fix for #701 track for circular dependency

### DIFF
--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -3627,4 +3627,35 @@ public class JSONObjectTest {
                 .put("b", 2);
         assertFalse(jo1.similar(jo3));
     }
+
+    @Test(expected = JSONException.class)
+    public void testCircleDependencyFirstLevel() {
+        Map<Object, Object> jsonObject = new HashMap<>();
+
+        jsonObject.put("test", jsonObject);
+
+        new JSONObject(jsonObject);
+    }
+
+    @Test(expected = JSONException.class)
+    public void testCircleDependencyMultiplyLevel() {
+        Map<Object, Object> inside = new HashMap<>();
+
+        Map<Object, Object> jsonObject = new HashMap<>();
+        inside.put("test", jsonObject);
+        jsonObject.put("test", inside);
+
+        new JSONObject(jsonObject);
+    }
+
+    @Test
+    public void testDifferentKeySameInstanceNotACircleDependency() {
+        Map<Object, Object> map1 = new HashMap<>();
+        Map<Object, Object> map2 = new HashMap<>();
+
+        map1.put("test1", map2);
+        map1.put("test2", map2);
+
+        new JSONObject(map1);
+    }
 }


### PR DESCRIPTION
Fix for: #701 
The `IdentityHashMap` will be used to track the instances that are wrapped. This we don't need to wait for the `StackOverflowExcpetion` to find out about the problem of circular dependency. 

The functionality isn't new for the class the same solution is made at this constructor: `org.json.JSONObject#JSONObject(java.lang.Object, java.util.Set<java.lang.Object>)`

Please add the **hacktoberfest-accepted** label if we will proceed with the PR.