### PR TITLE
Change "douglascrockford" to "stleary" in POM URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         in Java. Perhaps someday the Java community will standardize on one. Until
         then, choose carefully.
     </description>
-    <url>https://github.com/douglascrockford/JSON-java</url>
+    <url>https://github.com/stleary/JSON-java</url>
 
     <parent>
         <groupId>org.sonatype.oss</groupId>
@@ -28,9 +28,9 @@
     </parent>
 
     <scm>
-        <url>https://github.com/douglascrockford/JSON-java.git</url>
-        <connection>scm:git:git://github.com/douglascrockford/JSON-java.git</connection>
-        <developerConnection>scm:git:git@github.com:douglascrockford/JSON-java.git</developerConnection>
+        <url>https://github.com/stleary/JSON-java.git</url>
+        <connection>scm:git:git://github.com/stleary/JSON-java.git</connection>
+        <developerConnection>scm:git:git@github.com:stleary/JSON-java.git</developerConnection>
     </scm>
 
     <licenses>


### PR DESCRIPTION
There is still an old GitHub username in URLs in pom.xml. They only work due to redirects provided by GitHub.