### PR TITLE
fix: flakiness in org.json.junit.XMLTest#testIndentComplicatedJsonObjectWithArrayAndWithConfig

### DIFF
--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -1234,7 +1234,7 @@ public class XMLTest {
                 for (int numRead; (numRead = in.read(buffer, 0, buffer.length)) > 0; ) {
                     expected.append(buffer, 0, numRead);
                 }
-                assertEquals(expected.toString(), actualString);
+                assertTrue(XML.toJSONObject(expected.toString()).similar(XML.toJSONObject(actualString)));
             }
         } catch (IOException e) {
             fail("file writer error: " +e.getMessage());


### PR DESCRIPTION
## Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
In this test, the contents of an XML file and a JSON file is getting parsed and compared. But XML does not specify the order of the elements in the String, what means that the actual and the expected string cannot be directly compared for equality.
The flaky test was found by using the [NonDex](https://mvnrepository.com/artifact/edu.illinois/nondex-maven-plugin) tool.

https://github.com/stleary/JSON-java/blob/f346203cd663bb680cad0d5894e7c147e36f31cd/src/test/java/org/json/junit/XMLTest.java#L1237

## Solution:
<!--Changed the assert statement from a JUnit Assertion to an XML Assertion and wrapped it in a default root element. This default root element is necessary, because of the specification of well-formed XML files. -->
To fix this assertion without the import of a new XMLAssertion library, just like in other PRs discussed, the XML String gets converted to a JSON Object and afterward compared for similarity. This is needed due to the fact that XML Objects do not offer a `similarity()` method.  

https://github.com/stleary/JSON-java/blob/4dfd779b1c84e66e03e9ff13b46b238fd9dc72ea/src/test/java/org/json/junit/XMLTest.java#L1237

## Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
The test is deterministic and not flaky. This improves the quality of the test and reduces the time to search for the bug during future development, as well as the need for reruns of the pipeline. 

## Reproduce
```shell
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.json.junit.XMLTest#testIndentComplicatedJsonObjectWithArrayAndWithConfig
``` 