### PR TITLE
Updates the pipeline to validate that packaging a jar works properly

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,5 +1,5 @@
 # This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+# For more information see: https://docs.github.com/en/actions/learn-github-actions or https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
 
 name: Java CI with Maven
 
@@ -47,3 +47,5 @@ jobs:
         with:
           name: Test Report ${{ matrix.java }}
           path: target/site/
+      - name: Package Jar ${{ matrix.java }}
+        run: mvn clean package -Dmaven.compiler.source=${{ matrix.java }} -Dmaven.compiler.target=${{ matrix.java }} -Dmaven.test.skip=true -Dmaven.site.skip=true

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -37,15 +37,21 @@ jobs:
           mvn site -DgenerateReports=false -Dmaven.compiler.source=${{ matrix.java }} -Dmaven.compiler.target=${{ matrix.java }}
       - name: Upload Test Results ${{ matrix.java }}
         if: ${{ always() }}
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: Test Results ${{ matrix.java }}
           path: target/surefire-reports/
       - name: Upload Test Report ${{ matrix.java }}
         if: ${{ always() }}
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: Test Report ${{ matrix.java }}
           path: target/site/
       - name: Package Jar ${{ matrix.java }}
         run: mvn clean package -Dmaven.compiler.source=${{ matrix.java }} -Dmaven.compiler.target=${{ matrix.java }} -Dmaven.test.skip=true -Dmaven.site.skip=true
+      - name: Upload Package Results ${{ matrix.java }}
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: Package Jar ${{ matrix.java }}
+          path: target/*.jar

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # ignore eclipse project files
 .project
 .classpath
+# ignore vscode files
+.vscode
 # ignore Intellij Idea project files
 .idea
 *.iml

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ JSON in Java [package org.json]
 ===============================
 
 [![Maven Central](https://img.shields.io/maven-central/v/org.json/json.svg)](https://mvnrepository.com/artifact/org.json/json)
+[![Java CI with Maven](https://github.com/stleary/JSON-java/actions/workflows/pipeline.yml/badge.svg)](https://github.com/stleary/JSON-java/actions/workflows/pipeline.yml)
+[![CodeQL](https://github.com/stleary/JSON-java/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/stleary/JSON-java/actions/workflows/codeql-analysis.yml)
 
 **[Click here if you just want the latest release jar file.](https://search.maven.org/remotecontent?filepath=org/json/json/20231013/json-20231013.jar)**
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Project goals include:
 * No external dependencies
 * Fast execution and low memory footprint
 * Maintain backward compatibility
-* Designed and tested to use on Java versions 1.6 - 1.11
+* Designed and tested to use on Java versions 1.8 - 17
 
 The files in this package implement JSON encoders and decoders. The package can also convert between JSON and XML, HTTP headers, Cookies, and CDL.
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -159,16 +159,34 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.Final</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <module>
+                                <moduleInfo>
+                                    <name>org.json</name>
+                                    <exports>
+                                        org.json;
+                                    </exports>
+                                </moduleInfo>
+                            </module>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.3.0</version>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>org.json</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -172,12 +172,11 @@
                         <configuration>
                             <jvmVersion>9</jvmVersion>
                             <module>
-                                <moduleInfo>
-                                    <name>org.json</name>
-                                    <exports>
-                                        org.json;
-                                    </exports>
-                                </moduleInfo>
+                                <moduleInfoSource>
+                                    module org.json {
+                                        exports org.json;
+                                    }
+                                </moduleInfoSource>
                             </module>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Fixes #796 

See also #793, #761 and #760

**What problem does this code solve?**

Re-adds proper support for Modules on Java 9+. PR #761 was not tested with builds using JDK 8 and the changes only worked when using JDK 9+.

* Validate that the `mvn package` step completes during the pipeline
* fix issue with package step failing when run on jvm8
* Update the README.md to have correct supported versions
* Adds package artifacts to Action results. see the [Actions -> Artifacs](https://github.com/stleary/JSON-java/actions/runs/6538228155) section for compiled JARs

A Follow-on PR that enables [distribution through GitHub Actions](https://docs.github.com/en/actions/publishing-packages/publishing-java-packages-with-maven) would be worthwhile.

**Risks**

Low. Changes add new steps to the GitHub actions to ensure that packaging works properly going forward and will only affect the JAR creation

**Changes to the API?**

None

**Will this require a new release?**

Yes

**Should the documentation be updated?**

No, but slight changes were made to the README to:
1. Include workflow status badges
2. Correct the supported Java versions

**Does it break the unit tests?**

No. New GitHub actions were added to ensure that similar changes will not break release management going forward.

**Was any code refactored in this commit?**

No.

**Review status**

**APPROVED**

Starting 3-day comment window