### PR TITLE
JSONObject parsing for self-referencing maps

### DIFF
--- a/src/main/java/org/json/AbstractConfiguration.java
+++ b/src/main/java/org/json/AbstractConfiguration.java
@@ -1,0 +1,30 @@
+package org.json;
+
+import java.util.function.Consumer;
+
+/**
+ * Describes the "with" pattern of building a configuration.
+ */
+public abstract class AbstractConfiguration {
+
+    /**
+     * This clone should always ensure a deep copy of the object.
+     *
+     * @return a new deep copied object
+     */
+    @Override
+    protected abstract Object clone();
+
+    /**
+     * Automates the "with" pattern by create a clone and apply the setter {@link Consumer} to the new instance.
+     *
+     * @param setter the setter for applying the "with" to the desiring property
+     * @return the new instance with the property being set
+     * @param <T> the configuration class
+     */
+    protected <T extends AbstractConfiguration> T with(Consumer<T> setter) {
+        T instance = (T)clone();
+        setter.accept(instance);
+        return instance;
+    }
+}

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -170,7 +170,7 @@ public class JSONObject {
         // retrieval based on associative access.
         // Therefore, an implementation mustn't rely on the order of the item.
         this.map = new HashMap<String, Object>();
-        configuration = JSONParserConfiguration.defaultInstance();
+        configuration = new JSONParserConfiguration();
     }
 
     /**
@@ -276,7 +276,7 @@ public class JSONObject {
      *            If a key in the map is <code>null</code>
      */
     public JSONObject(Map<?, ?> m) {
-        this(m, getCircularDependencySet(), JSONParserConfiguration.defaultInstance());
+        this(m, getCircularDependencySet(), new JSONParserConfiguration());
     }
 
     /**
@@ -303,7 +303,7 @@ public class JSONObject {
         map = new HashMap<>(m.size());
 
         BiConsumer<Entry<?, ?>, Object> wrapValueConsumer;
-        if (configuration.isCircularDependencyValidation()) {
+        if (configuration.isCircularDependencyValidated()) {
             wrapValueConsumer = (entry, object) -> {
                 if (objectsRecord.contains(object)) {
                     throw new JSONException("Found circular dependency.");
@@ -394,7 +394,7 @@ public class JSONObject {
      *            If a getter returned a non-finite number.
      */
     public JSONObject(Object bean) {
-        this(bean, JSONParserConfiguration.defaultInstance());
+        this(bean, new JSONParserConfiguration());
     }
 
     public JSONObject(Object bean, JSONParserConfiguration jsonParserConfiguration) {
@@ -501,7 +501,7 @@ public class JSONObject {
      */
     protected JSONObject(int initialCapacity){
         this.map = new HashMap<String, Object>(initialCapacity);
-        configuration = JSONParserConfiguration.defaultInstance();
+        configuration = new JSONParserConfiguration();
     }
 
     /**
@@ -2705,7 +2705,7 @@ public class JSONObject {
      * @return The wrapped value
      */
     public static Object wrap(Object object) {
-        return wrap(object, JSONParserConfiguration.defaultInstance());
+        return wrap(object, new JSONParserConfiguration());
     }
 
     /**

--- a/src/main/java/org/json/JSONParserConfiguration.java
+++ b/src/main/java/org/json/JSONParserConfiguration.java
@@ -1,9 +1,15 @@
 package org.json;
 
+/**
+ * Configuration class for JSON parsers.
+ */
 public class JSONParserConfiguration extends AbstractConfiguration {
 
     private boolean circularDependencyValidated;
 
+    /**
+     * Configuration with the default values.
+     */
     public JSONParserConfiguration() {
         circularDependencyValidated = true;
     }
@@ -12,10 +18,22 @@ public class JSONParserConfiguration extends AbstractConfiguration {
         this.circularDependencyValidated = circularDependencyValidated;
     }
 
+    /**
+     * Retrieves the configuration about the circular dependency check.
+     *
+     * @return if true enables the circular dependencies check, false otherwise
+     */
     public boolean isCircularDependencyValidated() {
         return circularDependencyValidated;
     }
 
+    /**
+     * Sets the flag that controls the underline functionality to check or not about circular dependencies.
+     *
+     * @param circularDependencyValidation if true enables the circular dependencies check, false otherwise.
+     *                                     Default is true
+     * @return a new instance of the configuration with the given value being set
+     */
     public JSONParserConfiguration withCircularDependencyValidation(boolean circularDependencyValidation) {
         return with(newInstance -> newInstance.circularDependencyValidated = circularDependencyValidation);
     }

--- a/src/main/java/org/json/JSONParserConfiguration.java
+++ b/src/main/java/org/json/JSONParserConfiguration.java
@@ -1,0 +1,44 @@
+package org.json;
+
+public class JSONParserConfiguration {
+    private final boolean circularDependencyValidation;
+
+    private JSONParserConfiguration() {
+        circularDependencyValidation = false;
+    }
+
+    private JSONParserConfiguration(boolean circularDependencyValidation) {
+        this.circularDependencyValidation = circularDependencyValidation;
+    }
+
+    public static JSONParserConfiguration defaultInstance() {
+        return new JSONParserConfiguration();
+    }
+
+    public static JSONParserConfiguration.Builder newInstance() {
+        return new Builder();
+    }
+
+    public boolean isCircularDependencyValidation() {
+        return circularDependencyValidation;
+    }
+
+    public static class Builder {
+        private boolean circularDependencyValidation;
+
+        public boolean isCircularDependencyValidation() {
+            return circularDependencyValidation;
+        }
+
+        public Builder setCircularDependencyValidation(boolean circularDependencyValidation) {
+            this.circularDependencyValidation = circularDependencyValidation;
+            return this;
+        }
+
+        public JSONParserConfiguration build() {
+            return new JSONParserConfiguration(
+                circularDependencyValidation
+            );
+        }
+    }
+}

--- a/src/main/java/org/json/JSONParserConfiguration.java
+++ b/src/main/java/org/json/JSONParserConfiguration.java
@@ -1,44 +1,27 @@
 package org.json;
 
-public class JSONParserConfiguration {
-    private final boolean circularDependencyValidation;
+public class JSONParserConfiguration extends AbstractConfiguration {
 
-    private JSONParserConfiguration() {
-        circularDependencyValidation = false;
+    private boolean circularDependencyValidated;
+
+    public JSONParserConfiguration() {
+        circularDependencyValidated = true;
     }
 
-    private JSONParserConfiguration(boolean circularDependencyValidation) {
-        this.circularDependencyValidation = circularDependencyValidation;
+    private JSONParserConfiguration(boolean circularDependencyValidated) {
+        this.circularDependencyValidated = circularDependencyValidated;
     }
 
-    public static JSONParserConfiguration defaultInstance() {
-        return new JSONParserConfiguration();
+    public boolean isCircularDependencyValidated() {
+        return circularDependencyValidated;
     }
 
-    public static JSONParserConfiguration.Builder newInstance() {
-        return new Builder();
+    public JSONParserConfiguration withCircularDependencyValidation(boolean circularDependencyValidation) {
+        return with(newInstance -> newInstance.circularDependencyValidated = circularDependencyValidation);
     }
 
-    public boolean isCircularDependencyValidation() {
-        return circularDependencyValidation;
-    }
-
-    public static class Builder {
-        private boolean circularDependencyValidation;
-
-        public boolean isCircularDependencyValidation() {
-            return circularDependencyValidation;
-        }
-
-        public Builder setCircularDependencyValidation(boolean circularDependencyValidation) {
-            this.circularDependencyValidation = circularDependencyValidation;
-            return this;
-        }
-
-        public JSONParserConfiguration build() {
-            return new JSONParserConfiguration(
-                circularDependencyValidation
-            );
-        }
+    @Override
+    protected Object clone() {
+        return new JSONParserConfiguration(circularDependencyValidated);
     }
 }

--- a/src/main/java/org/json/ParserConfiguration.java
+++ b/src/main/java/org/json/ParserConfiguration.java
@@ -7,7 +7,7 @@ Public Domain.
  * Configuration base object for parsers. The configuration is immutable.
  */
 @SuppressWarnings({""})
-public class ParserConfiguration {
+public class ParserConfiguration extends AbstractConfiguration {
     /**
      * Used to indicate there's no defined limit to the maximum nesting depth when parsing a document.
      */
@@ -75,9 +75,7 @@ public class ParserConfiguration {
      * @return The existing configuration will not be modified. A new configuration is returned.
      */
     public <T extends ParserConfiguration> T withKeepStrings(final boolean newVal) {
-        T newConfig = (T)this.clone();
-        newConfig.keepStrings = newVal;
-        return newConfig;
+        return with(newInstance -> newInstance.keepStrings = newVal);
     }
 
     /**
@@ -99,14 +97,6 @@ public class ParserConfiguration {
      * @return The existing configuration will not be modified. A new configuration is returned.
      */
     public <T extends ParserConfiguration> T withMaxNestingDepth(int maxNestingDepth) {
-        T newConfig = (T)this.clone();
-
-        if (maxNestingDepth > UNDEFINED_MAXIMUM_NESTING_DEPTH) {
-            newConfig.maxNestingDepth = maxNestingDepth;
-        } else {
-            newConfig.maxNestingDepth = UNDEFINED_MAXIMUM_NESTING_DEPTH;
-        }
-
-        return newConfig;
+        return with(newInstance -> newInstance.maxNestingDepth = Math.max(maxNestingDepth, UNDEFINED_MAXIMUM_NESTING_DEPTH));
     }
 }

--- a/src/main/java/org/json/XMLParserConfiguration.java
+++ b/src/main/java/org/json/XMLParserConfiguration.java
@@ -209,9 +209,7 @@ public class XMLParserConfiguration extends ParserConfiguration {
      * @return The existing configuration will not be modified. A new configuration is returned.
      */
     public XMLParserConfiguration withcDataTagName(final String newVal) {
-        XMLParserConfiguration newConfig = this.clone();
-        newConfig.cDataTagName = newVal;
-        return newConfig;
+        return with(newInstance -> newInstance.cDataTagName = newVal);
     }
 
     /**
@@ -236,9 +234,7 @@ public class XMLParserConfiguration extends ParserConfiguration {
      * @return The existing configuration will not be modified. A new configuration is returned.
      */
     public XMLParserConfiguration withConvertNilAttributeToNull(final boolean newVal) {
-        XMLParserConfiguration newConfig = this.clone();
-        newConfig.convertNilAttributeToNull = newVal;
-        return newConfig;
+        return with(newInstance -> newInstance.convertNilAttributeToNull = newVal);
     }
 
     /**
@@ -262,10 +258,7 @@ public class XMLParserConfiguration extends ParserConfiguration {
      * @return The existing configuration will not be modified. A new configuration is returned.
      */
     public XMLParserConfiguration withXsiTypeMap(final Map<String, XMLXsiTypeConverter<?>> xsiTypeMap) {
-        XMLParserConfiguration newConfig = this.clone();
-        Map<String, XMLXsiTypeConverter<?>> cloneXsiTypeMap = new HashMap<String, XMLXsiTypeConverter<?>>(xsiTypeMap);
-        newConfig.xsiTypeMap = Collections.unmodifiableMap(cloneXsiTypeMap);
-        return newConfig;
+        return with(newInstance -> newInstance.xsiTypeMap = Collections.unmodifiableMap(new HashMap<>(xsiTypeMap)));
     }
 
     /**
@@ -284,10 +277,7 @@ public class XMLParserConfiguration extends ParserConfiguration {
      * @return The existing configuration will not be modified. A new configuration is returned.
      */
     public XMLParserConfiguration withForceList(final Set<String> forceList) {
-        XMLParserConfiguration newConfig = this.clone();
-        Set<String> cloneForceList = new HashSet<String>(forceList);
-        newConfig.forceList = Collections.unmodifiableSet(cloneForceList);
-        return newConfig;
+        return with(newInstance -> newInstance.forceList = Collections.unmodifiableSet(new HashSet<>(forceList)));
     }
 
     /**

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -3721,7 +3721,7 @@ public class JSONObjectTest {
 
         jsonObject.put("test", jsonObject);
 
-        new JSONObject(jsonObject, JSONParserConfiguration.newInstance().setCircularDependencyValidation(true).build());
+        new JSONObject(jsonObject, new JSONParserConfiguration());
     }
 
     @Test(expected = StackOverflowError.class)
@@ -3732,7 +3732,7 @@ public class JSONObjectTest {
         inside.put("test", jsonObject);
         jsonObject.put("test", inside);
 
-        new JSONObject(jsonObject);
+        new JSONObject(jsonObject, new JSONParserConfiguration().withCircularDependencyValidation(false));
     }
 
     @Test(expected = JSONException.class)
@@ -3743,7 +3743,7 @@ public class JSONObjectTest {
         inside.put("test", jsonObject);
         jsonObject.put("test", inside);
 
-        new JSONObject(jsonObject, JSONParserConfiguration.newInstance().setCircularDependencyValidation(true).build());
+        new JSONObject(jsonObject, new JSONParserConfiguration());
     }
 
     @Test

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -33,6 +33,7 @@ import org.json.JSONPointerException;
 import org.json.JSONString;
 import org.json.JSONTokener;
 import org.json.XML;
+import org.json.JSONParserConfiguration;
 import org.json.junit.data.BrokenToString;
 import org.json.junit.data.ExceptionalBean;
 import org.json.junit.data.Fraction;
@@ -3634,11 +3635,11 @@ public class JSONObjectTest {
 
         jsonObject.put("test", jsonObject);
 
-        new JSONObject(jsonObject);
+        new JSONObject(jsonObject, JSONParserConfiguration.newInstance().setCircularDependencyValidation(true).build());
     }
 
-    @Test(expected = JSONException.class)
-    public void testCircleDependencyMultiplyLevel() {
+    @Test(expected = StackOverflowError.class)
+    public void testCircleDependencyMultiplyLevel_notConfigured_expectedStackOverflow() {
         Map<Object, Object> inside = new HashMap<>();
 
         Map<Object, Object> jsonObject = new HashMap<>();
@@ -3646,6 +3647,17 @@ public class JSONObjectTest {
         jsonObject.put("test", inside);
 
         new JSONObject(jsonObject);
+    }
+
+    @Test(expected = JSONException.class)
+    public void testCircleDependencyMultiplyLevel_configured_expectedJSONException() {
+        Map<Object, Object> inside = new HashMap<>();
+
+        Map<Object, Object> jsonObject = new HashMap<>();
+        inside.put("test", jsonObject);
+        jsonObject.put("test", inside);
+
+        new JSONObject(jsonObject, JSONParserConfiguration.newInstance().setCircularDependencyValidation(true).build());
     }
 
     @Test

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -3627,4 +3627,35 @@ public class JSONObjectTest {
                 .put("b", 2);
         assertFalse(jo1.similar(jo3));
     }
+
+    @Test(expected = JSONException.class)
+    public void testCircleDependencyFirstLevel() {
+        Map<Object, Object> jsonObject = new HashMap<>();
+
+        jsonObject.put("test", jsonObject);
+
+        new JSONObject(jsonObject);
+    }
+
+    @Test(expected = JSONException.class)
+    public void testCircleDependencyMultiplyLevel() {
+        Map<Object, Object> inside = new HashMap<>();
+
+        Map<Object, Object> jsonObject = new HashMap<>();
+        inside.put("test", jsonObject);
+        jsonObject.put("test", inside);
+
+        new JSONObject(jsonObject);
+    }
+
+    @Test
+    public void testDifferentKeySameInstanceNotACircleDependency() {
+        Map<Object, Object> map1 = new HashMap<>();
+        Map<Object, Object> map2 = new HashMap<>();
+
+        map1.put("test1", map2);
+        map1.put("test2", map2);
+
+        new JSONObject(map1);
+    }
 }


### PR DESCRIPTION
Fix for #701

A new configuration class was added for the JSON parser.

- The configuration class can easily accept future additions at configuration without any change at the `JSONObject` class. 
- The default functionality of the `JSONObject` class is controlled from the `JSONParserConfiguration` class. This way we can give the possibility for someone to enable the circular dependency check or if we change mid we can make the default functionality to be the check to be one. This change will not affect any other class other than `JSONParserConfiguration`.
- An already existing case using the circular dependency functionality (not for the `Map`) here: `org.json.JSONObject#populateMap`  so I left it as is. If we want to change it and respect the new configuration for the check I can make it easily.