### PR TITLE
Add new deployment pipeline

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,4 +1,8 @@
-# For more information see: https://docs.github.com/en/actions/learn-github-actions or https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+# For more information see:
+#  * https://docs.github.com/en/actions/learn-github-actions
+#  * https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#  * https://github.com/actions/setup-java/blob/v3.13.0/docs/advanced-usage.md#Publishing-using-Apache-Maven
+#
 
 name: Deployment workflow
 
@@ -20,14 +24,18 @@ jobs:
             # Use lowest supported LTS Java version
             java-version: '8'
             distribution: 'temurin'
-            server-id: ossrh
-            server-username: MAVEN_USERNAME
-            server-password: MAVEN_PASSWORD
+            server-id: ossrh  # Value of the distributionManagement/repository/id field of the pom.xml
+            server-username: MAVEN_USERNAME # env variable for username in deploy
+            server-password: MAVEN_PASSWORD # env variable for token in deploy
+            gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import
+            gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
+    
         - name: Publish to the Maven Central Repository
           run: mvn --batch-mode deploy
           env:
             MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
             MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+            MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
         # - name: Set up Java for publishing to GitHub Packages
         #   uses: actions/setup-java@v3
         #   with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,40 @@
+# For more information see: https://docs.github.com/en/actions/learn-github-actions or https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+
+name: Deployment workflow
+
+on:
+    release:
+      types: [published]
+  
+jobs:
+    publish:
+      runs-on: ubuntu-latest
+      permissions:
+        contents: read
+        packages: write
+      steps:
+        - uses: actions/checkout@v4
+        - name: Set up Java for publishing to Maven Central Repository
+          uses: actions/setup-java@v3
+          with:
+            # Use lowest supported LTS Java version
+            java-version: '8'
+            distribution: 'temurin'
+            server-id: ossrh
+            server-username: MAVEN_USERNAME
+            server-password: MAVEN_PASSWORD
+        - name: Publish to the Maven Central Repository
+          run: mvn --batch-mode deploy
+          env:
+            MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+            MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+        # - name: Set up Java for publishing to GitHub Packages
+        #   uses: actions/setup-java@v3
+        #   with:
+        #     # Use lowest supported LTS Java version
+        #     java-version: '8'
+        #     distribution: 'temurin'
+        # - name: Publish to GitHub Packages
+        #   run: mvn --batch-mode deploy
+        #   env:
+        #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <distributionManagement>
+        <repository>
+            <id>ossrh</id>
+            <name>Central Repository OSSRH</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,6 @@
     </description>
     <url>https://github.com/douglascrockford/JSON-java</url>
 
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>9</version>
-    </parent>
-
     <scm>
         <url>https://github.com/douglascrockford/JSON-java.git</url>
         <connection>scm:git:git://github.com/douglascrockford/JSON-java.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,10 @@
             <name>Central Repository OSSRH</name>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
     </distributionManagement>
 
     <dependencies>


### PR DESCRIPTION
**What problem does this code solve?**

Adds a new pipeline that should allow automatic deployment to Maven Central when a new GitHub Release is published. This reduces the manual work involved in creating and publishing releases. If the project needs to be handed off again, this should also reduce the hand-off steps.

The pipeline was based on [GitHub documentation](https://github.com/actions/setup-java/blob/v3.13.0/docs/advanced-usage.md#Publishing-using-Apache-Maven) and [StackOverflow how to use GPG in Workflows](https://stackoverflow.com/questions/61096521/how-to-use-gpg-key-in-github-actions) and modified slightly for our use-case as defined in the [Wiki Release document](https://github.com/stleary/JSON-java/wiki/Tech:-How-to-make-a-new-JSON-java-release) and [Sonatype release documentation](https://central.sonatype.org/publish/publish-guide/).  In order for the pipeline to run successfully, The following [Secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) will need to be added to the workflow configuration in the GitHub Project. Only the project maintainer can do this configuration.

Secrets names:
* `OSSRH_USERNAME` set to your Sonatype Jira username
* `OSSRH_TOKEN` set to your Sonatype Jira password/token
* `MAVEN_GPG_PRIVATE_KEY` set to your GPG private key: `gpg --list-secret-keys --keyid-format LONG` to get the Key ID, then `gpg --export-secret-keys --armor {your_keyId}` to get the actual key that goes in the secret
* `MAVEN_GPG_PASSPHRASE` set to the passphrase needed to use your private key

**Risks**

Low. If the auto-deployment fails, manual deployment can still be done. Corrections could be made on-the-fly, or could be queued up for the next release.

**Changes to the API?**

No

**Will this require a new release?**

No

**Should the documentation be updated?**

It would be a good idea.

**Does it break the unit tests?**

No

**Was any code refactored in this commit?**

No

**Review status**

**APPROVED**

Starting 3-day comment window