### PR TITLE
Fix All Compiler Warnings

### DIFF
--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -145,6 +145,9 @@ public class JSONObject {
      */
     private final Map<String, Object> map;
 
+    /**
+     * Returns the class of the underlying Map implementation used by this JSONObject.
+     */
     public Class<? extends Map> getMapType() {
         return map.getClass();
     }
@@ -342,7 +345,7 @@ public class JSONObject {
      * &#64;JSONPropertyIgnore
      * public String getName() { return this.name; }
      * </pre>
-     * <p>
+     * </p>
      *
      * @param bean
      *            An object that has getter methods that should be used to make
@@ -2197,6 +2200,22 @@ public class JSONObject {
         }
     }
 
+    /**
+     * This method takes a string and a writer object as input and returns a writer object after 
+     * writing the string to it with proper escaping of special characters.
+     * If the input string is null or empty, it writes an empty string to the writer object.
+     * Special characters like backslash, double quotes, forward slash, backspace, tab, newline, 
+     * form feed, and carriage return are escaped with a backslash.
+     * Unicode characters below ' ' (space) and between '\u0080' and '\u00a0' and between '\u2000' and 
+     * '\u2100' are escaped with a backslash and 'u' followed by their four-digit hexadecimal representation.
+     * 
+     * @param string the input string to be written to the writer object
+     * @param w the writer object to which the input string is to be written
+     * 
+     * @return the writer object after writing the input string with proper escaping of special characters
+     * 
+     * @throws IOException if an I/O error occurs while writing to the writer object
+     */
     public static Writer quote(String string, Writer w) throws IOException {
         if (string == null || string.isEmpty()) {
             w.write("\"\"");

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -147,6 +147,8 @@ public class JSONObject {
 
     /**
      * Returns the class of the underlying Map implementation used by this JSONObject.
+     * 
+     * @return The Class of the Map implementation.
      */
     public Class<? extends Map> getMapType() {
         return map.getClass();
@@ -345,7 +347,6 @@ public class JSONObject {
      * &#64;JSONPropertyIgnore
      * public String getName() { return this.name; }
      * </pre>
-     * </p>
      *
      * @param bean
      *            An object that has getter methods that should be used to make

--- a/src/main/java/org/json/JSONPointer.java
+++ b/src/main/java/org/json/JSONPointer.java
@@ -163,6 +163,11 @@ public class JSONPointer {
         //}
     }
 
+    /**
+     * Constructs a new JSONPointer instance with the given reference tokens.
+     *
+     * @param refTokens the reference tokens to use
+     */
     public JSONPointer(List<String> refTokens) {
         this.refTokens = new ArrayList<String>(refTokens);
     }

--- a/src/main/java/org/json/JSONPointerException.java
+++ b/src/main/java/org/json/JSONPointerException.java
@@ -14,10 +14,21 @@ Public Domain.
 public class JSONPointerException extends JSONException {
     private static final long serialVersionUID = 8872944667561856751L;
 
+    /**
+     * Constructs a new JSONPointerException with the specified detail message.
+     *
+     * @param message the detail message.
+     */
     public JSONPointerException(String message) {
         super(message);
     }
 
+    /**
+     * Constructs a new JSONPointerException with the specified detail message and cause.
+     *
+     * @param message the detail message (which is saved for later retrieval by the getMessage() method).
+     * @param cause the cause (which is saved for later retrieval by the getCause() method).
+     */
     public JSONPointerException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/org/json/JSONTokener.java
+++ b/src/main/java/org/json/JSONTokener.java
@@ -528,7 +528,7 @@ public class JSONTokener {
     /**
      * Close the underlying reader.
      *
-     * @throws IOException
+     * @throws IOException if the reader fails to close.
      */
     public void close() throws IOException {
         if(reader!=null){

--- a/src/main/java/org/json/JSONTokener.java
+++ b/src/main/java/org/json/JSONTokener.java
@@ -525,6 +525,11 @@ public class JSONTokener {
                 this.line + "]";
     }
 
+    /**
+     * Close the underlying reader.
+     *
+     * @throws IOException
+     */
     public void close() throws IOException {
         if(reader!=null){
             reader.close();

--- a/src/main/java/org/json/ParserConfiguration.java
+++ b/src/main/java/org/json/ParserConfiguration.java
@@ -29,11 +29,21 @@ public class ParserConfiguration {
      */
     protected int maxNestingDepth;
 
+    /**
+     * Constructs a new ParserConfiguration object with default values.
+     * By default, keepStrings is set to false and maxNestingDepth is set to the default maximum nesting depth.
+     */
     public ParserConfiguration() {
         this.keepStrings = false;
         this.maxNestingDepth = DEFAULT_MAXIMUM_NESTING_DEPTH;
     }
 
+    /**
+     * Constructs a new ParserConfiguration object with the specified parameters.
+     *
+     * @param keepStrings a boolean indicating whether strings should be guessed into JSON values
+     * @param maxNestingDepth the maximum nesting depth allowed for JSON objects
+     */
     protected ParserConfiguration(final boolean keepStrings, final int maxNestingDepth) {
         this.keepStrings = keepStrings;
         this.maxNestingDepth = maxNestingDepth;

--- a/src/main/java/org/json/ParserConfiguration.java
+++ b/src/main/java/org/json/ParserConfiguration.java
@@ -71,7 +71,8 @@ public class ParserConfiguration {
      *
      * @param newVal
      *      new value to use for the <code>keepStrings</code> configuration option.
-     *
+     * @param <T> the type of the configuration object
+     * 
      * @return The existing configuration will not be modified. A new configuration is returned.
      */
     public <T extends ParserConfiguration> T withKeepStrings(final boolean newVal) {
@@ -96,6 +97,8 @@ public class ParserConfiguration {
      * Using any negative value as a parameter is equivalent to setting no limit to the nesting depth,
      * which means the parses will go as deep as the maximum call stack size allows.
      * @param maxNestingDepth the maximum nesting depth allowed to the XML parser
+     * @param <T> the type of the configuration object
+     * 
      * @return The existing configuration will not be modified. A new configuration is returned.
      */
     public <T extends ParserConfiguration> T withMaxNestingDepth(int maxNestingDepth) {

--- a/src/main/java/org/json/XML.java
+++ b/src/main/java/org/json/XML.java
@@ -53,6 +53,9 @@ public class XML {
      */
     public static final String NULL_ATTR = "xsi:nil";
 
+    /**
+     * The XML type attribute name.
+     */
     public static final String TYPE_ATTR = "xsi:type";
 
     /**


### PR DESCRIPTION
This pull request addresses the compiler comment warnings that were previously present in the project. The warnings were identified during the ```gradle build``` task execution.

I added or changed javadoc comments to:
- JSONObject.java (getMapType(), constructor, quote())
- JSONPointer.java (constructor)
- JSONPointerException.java (both constructors)
- JSONTokener.java (close())
- ParserConfiguration.java (both basic constructors)
- XML.java (TYPE_ATTR)

Please review the changes and let me know if you have any questions or suggestions.