### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/main/java/org/json/ParserConfiguration.java
+++ b/src/main/java/org/json/ParserConfiguration.java
@@ -71,7 +71,8 @@ public class ParserConfiguration {
      *
      * @param newVal
      *      new value to use for the <code>keepStrings</code> configuration option.
-     *
+     * @param <T> the type of the configuration object
+     * 
      * @return The existing configuration will not be modified. A new configuration is returned.
      */
     public <T extends ParserConfiguration> T withKeepStrings(final boolean newVal) {
@@ -96,6 +97,8 @@ public class ParserConfiguration {
      * Using any negative value as a parameter is equivalent to setting no limit to the nesting depth,
      * which means the parses will go as deep as the maximum call stack size allows.
      * @param maxNestingDepth the maximum nesting depth allowed to the XML parser
+     * @param <T> the type of the configuration object
+     * 
      * @return The existing configuration will not be modified. A new configuration is returned.
      */
     public <T extends ParserConfiguration> T withMaxNestingDepth(int maxNestingDepth) {


### PR DESCRIPTION
Fixes the two build error messages given in Issue #800 by adding a param outline to the withKeepStrings() and withMaxNestingStrings() method documentation.