### PR TITLE
DRAFT: (JSONArray).toList() breaks format of entries

### DIFF
--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 
 
@@ -61,7 +62,7 @@ import java.util.Map;
  * @author JSON.org
  * @version 2016-08/15
  */
-public class JSONArray implements Iterable<Object> {
+public class JSONArray implements List<Object> {
 
     /**
      * The arrayList where the JSONArray's properties are kept.
@@ -229,6 +230,54 @@ public class JSONArray implements Iterable<Object> {
         return this.myArrayList.iterator();
     }
 
+    @Override
+    public Object[] toArray() {
+        return myArrayList.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] array) {
+        return myArrayList.toArray(array);
+    }
+
+    @Override
+    public boolean add(Object object) {
+        JSONObject.testValidity(object);
+        return myArrayList.add(object);
+    }
+
+    @Override
+    public boolean remove(Object object) {
+        return myArrayList.remove(object);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> collection) {
+        return myArrayList.containsAll(collection);
+    }
+
+    @Override
+    public boolean addAll(Collection<?> collection) {
+        JSONObject.testValidity(collection);
+        return myArrayList.addAll(collection);
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<?> collection) {
+        JSONObject.testValidity(collection);
+        return myArrayList.addAll(index, collection);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> collection) {
+        return myArrayList.removeAll(collection);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> collection) {
+        return myArrayList.retainAll(collection);
+    }
+
     /**
      * Get the object value associated with an index.
      *
@@ -244,6 +293,18 @@ public class JSONArray implements Iterable<Object> {
             throw new JSONException("JSONArray[" + index + "] not found.");
         }
         return object;
+    }
+
+    @Override
+    public Object set(int index, Object object) {
+        JSONObject.testValidity(object);
+        return myArrayList.set(index, object);
+    }
+
+    @Override
+    public void add(int index, Object object) {
+        JSONObject.testValidity(object);
+        myArrayList.add(index, object);
     }
 
     /**
@@ -1525,6 +1586,31 @@ public class JSONArray implements Iterable<Object> {
             : null;
     }
 
+    @Override
+    public int indexOf(Object object) {
+        return myArrayList.indexOf(object);
+    }
+
+    @Override
+    public int lastIndexOf(Object object) {
+        return myArrayList.lastIndexOf(object);
+    }
+
+    @Override
+    public ListIterator<Object> listIterator() {
+        return myArrayList.listIterator();
+    }
+
+    @Override
+    public ListIterator<Object> listIterator(int index) {
+        return myArrayList.listIterator(index);
+    }
+
+    @Override
+    public List<Object> subList(int from, int to) {
+        return myArrayList.subList(from, to);
+    }
+
     /**
      * Determine if two JSONArrays are similar.
      * They must contain similar sequences.
@@ -1762,6 +1848,11 @@ public class JSONArray implements Iterable<Object> {
         return results;
     }
 
+    @Override
+    public int size() {
+        return myArrayList.size();
+    }
+
     /**
      * Check if JSONArray is empty.
      *
@@ -1769,6 +1860,11 @@ public class JSONArray implements Iterable<Object> {
      */
     public boolean isEmpty() {
         return this.myArrayList.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object object) {
+        return myArrayList.contains(object);
     }
 
     /**

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -2487,6 +2487,12 @@ public class JSONObject {
         return string;
     }
 
+    public static <T extends Iterable<?>> void testValidity(T objects) {
+        for (Object object : objects) {
+            testValidity(object);
+        }
+    }
+
     /**
      * Throw an exception if the object is a NaN or infinite number.
      *


### PR DESCRIPTION
fix for: #737 
PR for discussion:

I suggest making the `JSONArray` class to implement the `List` because contains the functionality of a list also is powered by an `ArrayList` which is a `List`.
By making it a `List` it can be used by others like any other `List` class making it more useful.
Also automatically contains the `stream()` method that we want.

If we proceed with this approach I will add tests for the new methods.