### PR TITLE
Ensure java 6 compatable

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,6 +10,34 @@ on:
     branches: [ master ]
 
 jobs:
+  # old-school build and jar method. No tests run or compiled.
+  build-1_6: 
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # build for java 1.6, however don't run any tests
+        java: [ 1.6 ]
+    name: Java ${{ matrix.java }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Compile Java ${{ matrix.java }}
+        run: |
+          mkdir -p target/classes
+          javac -version
+          javac -d target/classes/ src/main/java/org/json/*.java
+      - name: Create java ${{ matrix.java }} JAR
+        run: |
+          jar cvf target/org.json.jar -C target/classes .
+      - name: Upload JAR ${{ matrix.java }}
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: Create java ${{ matrix.java }} JAR
+          path: target/*.jar
   build:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
**What problem does this code solve?**

Adds back in the build/jar for java6 to help ensure binary source compatibility. This leaves the actual deployment as a Java 8 compatibility.

Sample build run: https://github.com/johnjaylward/JSON-java/actions/runs/6617867256

As part of the java6 build, I made sure to output the current version of the java compiler:

![image](https://github.com/stleary/JSON-java/assets/383703/3effb9c7-71fe-45bc-8214-e34943144d2a)


**Does the code still compile with Java6?**

Yes, that's what this PR is made to ensure.

**Risks**

To compile Java 1.6 on GitHub, it requires using the deprecated action "setup-java@v1". `v2` and greater of the action do not support java6. It's unknown when GitHub will end support for this action completely. Once then do, builds will break and we will need to "cross compile" from a newer version of the JDK down to 1.6, which is not guaranteed to ensure full 1.6 compatibility.

**Changes to the API?**

No

**Will this require a new release?**

No

**Should the documentation be updated?**

No

**Does it break the unit tests?**

No. However, no testing is done against JDK 6. Only compilation and packing is performed. The JDK jar that is uploaded to the build artifacts is also not compatible with JDK 9+ as no module information is provided

**Was any code refactored in this commit?**

No

**Review status**

NOT YET REVIEWED