### PR TITLE
Close XML tag explicitly for empty tags with configuration.

### DIFF
--- a/src/main/java/org/json/XML.java
+++ b/src/main/java/org/json/XML.java
@@ -877,12 +877,25 @@ public class XML {
                         }
                     }
                 } else if ("".equals(value)) {
-                    sb.append(indent(indent));
-                    sb.append('<');
-                    sb.append(key);
-                    sb.append("/>");
-                    if(indentFactor > 0){
-                        sb.append("\n");
+                    if (config.isCloseEmptyTag()){
+                        sb.append(indent(indent));
+                        sb.append('<');
+                        sb.append(key);
+                        sb.append(">");
+                        sb.append("</");
+                        sb.append(key);
+                        sb.append(">");
+                        if (indentFactor > 0) {
+                            sb.append("\n");
+                        }
+                    }else {
+                        sb.append(indent(indent));
+                        sb.append('<');
+                        sb.append(key);
+                        sb.append("/>");
+                        if (indentFactor > 0) {
+                            sb.append("\n");
+                        }
                     }
 
                     // Emit a new tag <k>

--- a/src/main/java/org/json/XMLParserConfiguration.java
+++ b/src/main/java/org/json/XMLParserConfiguration.java
@@ -149,6 +149,7 @@ public class XMLParserConfiguration extends ParserConfiguration {
      *                   xsi:type="integer" as integer,  xsi:type="string" as string
      * @param forceList  <code>new HashSet<String>()</code> to parse the provided tags' values as arrays
      * @param maxNestingDepth <code>int</code> to limit the nesting depth
+     * @param closeEmptyTag <code>boolean</code> to turn on explicit end tag for tag with empty value
      */
     private XMLParserConfiguration (final boolean keepStrings, final String cDataTagName,
             final boolean convertNilAttributeToNull, final Map<String, XMLXsiTypeConverter<?>> xsiTypeMap, final Set<String> forceList,
@@ -313,6 +314,11 @@ public class XMLParserConfiguration extends ParserConfiguration {
         return super.withMaxNestingDepth(maxNestingDepth);
     }
 
+    /**
+     * To enable explicit end tag with empty value.
+     * @param closeEmptyTag
+     * @return same instance of configuration with empty tag config updated
+     */
     public XMLParserConfiguration withCloseEmptyTag(boolean closeEmptyTag){
         this.closeEmptyTag = closeEmptyTag;
         return this;

--- a/src/main/java/org/json/XMLParserConfiguration.java
+++ b/src/main/java/org/json/XMLParserConfiguration.java
@@ -44,6 +44,13 @@ public class XMLParserConfiguration extends ParserConfiguration {
     private boolean convertNilAttributeToNull;
 
     /**
+     * When creating an XML from JSON Object, an empty tag by default will self-close.
+     * If it has to be closed explicitly, with empty content between start and end tag,
+     * this flag is to be turned on.
+     */
+    private boolean closeEmptyTag;
+
+    /**
      * This will allow type conversion for values in XML if xsi:type attribute is defined
      */
     private Map<String, XMLXsiTypeConverter<?>> xsiTypeMap;
@@ -145,12 +152,13 @@ public class XMLParserConfiguration extends ParserConfiguration {
      */
     private XMLParserConfiguration (final boolean keepStrings, final String cDataTagName,
             final boolean convertNilAttributeToNull, final Map<String, XMLXsiTypeConverter<?>> xsiTypeMap, final Set<String> forceList,
-            final int maxNestingDepth) {
+            final int maxNestingDepth, final boolean closeEmptyTag) {
         super(keepStrings, maxNestingDepth);
         this.cDataTagName = cDataTagName;
         this.convertNilAttributeToNull = convertNilAttributeToNull;
         this.xsiTypeMap = Collections.unmodifiableMap(xsiTypeMap);
         this.forceList = Collections.unmodifiableSet(forceList);
+        this.closeEmptyTag = closeEmptyTag;
     }
 
     /**
@@ -169,7 +177,8 @@ public class XMLParserConfiguration extends ParserConfiguration {
                 this.convertNilAttributeToNull,
                 this.xsiTypeMap,
                 this.forceList,
-                this.maxNestingDepth
+                this.maxNestingDepth,
+                this.closeEmptyTag
         );
     }
 
@@ -302,5 +311,14 @@ public class XMLParserConfiguration extends ParserConfiguration {
     @Override
     public XMLParserConfiguration withMaxNestingDepth(int maxNestingDepth) {
         return super.withMaxNestingDepth(maxNestingDepth);
+    }
+
+    public XMLParserConfiguration withCloseEmptyTag(boolean closeEmptyTag){
+        this.closeEmptyTag = closeEmptyTag;
+        return this;
+    }
+
+    public boolean isCloseEmptyTag() {
+        return this.closeEmptyTag;
     }
 }

--- a/src/main/java/org/json/XMLParserConfiguration.java
+++ b/src/main/java/org/json/XMLParserConfiguration.java
@@ -320,8 +320,9 @@ public class XMLParserConfiguration extends ParserConfiguration {
      * @return same instance of configuration with empty tag config updated
      */
     public XMLParserConfiguration withCloseEmptyTag(boolean closeEmptyTag){
-        this.closeEmptyTag = closeEmptyTag;
-        return this;
+        XMLParserConfiguration clonedConfiguration = this.clone();
+        clonedConfiguration.closeEmptyTag = closeEmptyTag;
+        return clonedConfiguration;
     }
 
     public boolean isCloseEmptyTag() {

--- a/src/test/java/org/json/junit/XMLConfigurationTest.java
+++ b/src/test/java/org/json/junit/XMLConfigurationTest.java
@@ -557,6 +557,17 @@ public class XMLConfigurationTest {
         assertEquals(actualXML, resultXML);
     }
 
+    @Test
+    public void shouldHandleEmptyNodeValue()
+    {
+        JSONObject inputJSON = new JSONObject();
+        inputJSON.put("Emptyness", "");
+        String expectedXmlWithoutExplicitEndTag = "<Emptyness/>";
+        String expectedXmlWithExplicitEndTag = "<Emptyness></Emptyness>";
+        assertEquals(expectedXmlWithoutExplicitEndTag, XML.toString(inputJSON, null, new XMLParserConfiguration().withCloseEmptyTag(false)));
+        assertEquals(expectedXmlWithExplicitEndTag, XML.toString(inputJSON, null, new XMLParserConfiguration().withCloseEmptyTag(true)));
+    }
+
     /**
      * Investigate exactly how the "content" keyword works
      */

--- a/src/test/java/org/json/junit/XMLConfigurationTest.java
+++ b/src/test/java/org/json/junit/XMLConfigurationTest.java
@@ -4,11 +4,6 @@ package org.json.junit;
 Public Domain.
 */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
@@ -26,6 +21,8 @@ import org.json.XMLParserConfiguration;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.*;
 
 
 /**
@@ -564,8 +561,28 @@ public class XMLConfigurationTest {
         inputJSON.put("Emptyness", "");
         String expectedXmlWithoutExplicitEndTag = "<Emptyness/>";
         String expectedXmlWithExplicitEndTag = "<Emptyness></Emptyness>";
-        assertEquals(expectedXmlWithoutExplicitEndTag, XML.toString(inputJSON, null, new XMLParserConfiguration().withCloseEmptyTag(false)));
-        assertEquals(expectedXmlWithExplicitEndTag, XML.toString(inputJSON, null, new XMLParserConfiguration().withCloseEmptyTag(true)));
+        assertEquals(expectedXmlWithoutExplicitEndTag, XML.toString(inputJSON, null,
+                new XMLParserConfiguration().withCloseEmptyTag(false)));
+        assertEquals(expectedXmlWithExplicitEndTag, XML.toString(inputJSON, null,
+                new XMLParserConfiguration().withCloseEmptyTag(true)));
+    }
+
+    @Test
+    public void shouldKeepConfigurationIntactAndUpdateCloseEmptyTagChoice()
+    {
+        XMLParserConfiguration keepStrings = XMLParserConfiguration.KEEP_STRINGS;
+        XMLParserConfiguration keepStringsAndCloseEmptyTag = keepStrings.withCloseEmptyTag(true);
+        XMLParserConfiguration keepDigits = keepStringsAndCloseEmptyTag.withKeepStrings(false);
+        XMLParserConfiguration keepDigitsAndNoCloseEmptyTag = keepDigits.withCloseEmptyTag(false);
+        assertTrue(keepStrings.isKeepStrings());
+        assertFalse(keepStrings.isCloseEmptyTag());
+        assertTrue(keepStringsAndCloseEmptyTag.isKeepStrings());
+        assertTrue(keepStringsAndCloseEmptyTag.isCloseEmptyTag());
+        assertFalse(keepDigits.isKeepStrings());
+        assertTrue(keepDigits.isCloseEmptyTag());
+        assertFalse(keepDigitsAndNoCloseEmptyTag.isKeepStrings());
+        assertFalse(keepDigitsAndNoCloseEmptyTag.isCloseEmptyTag());
+
     }
 
     /**

--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -1177,6 +1177,26 @@ public class XMLTest {
 
 
     }
+
+    @Test
+    public void shouldCreateExplicitEndTagWithEmptyValueWhenConfigured(){
+        String jsonString = "{outer:{innerOne:\"\", innerTwo:\"two\"}}";
+        JSONObject jsonObject = new JSONObject(jsonString);
+        String expectedXmlString = "<encloser><outer><innerOne></innerOne><innerTwo>two</innerTwo></outer></encloser>";
+        String xmlForm = XML.toString(jsonObject,"encloser", new XMLParserConfiguration().withCloseEmptyTag(true));
+        assertEquals(expectedXmlString, xmlForm);
+    }
+
+    @Test
+    public void shouldNotCreateExplicitEndTagWithEmptyValueWhenNotConfigured(){
+        String jsonString = "{outer:{innerOne:\"\", innerTwo:\"two\"}}";
+        JSONObject jsonObject = new JSONObject(jsonString);
+        String expectedXmlString = "<encloser><outer><innerOne/><innerTwo>two</innerTwo></outer></encloser>";
+        String xmlForm = XML.toString(jsonObject,"encloser", new XMLParserConfiguration().withCloseEmptyTag(false));
+        assertEquals(expectedXmlString, xmlForm);
+    }
+
+
     @Test
     public void testIndentSimpleJsonObject(){
         String str = "{    \"employee\": {  \n" +


### PR DESCRIPTION
Added configuration option - closeEmptyTag
When this flag is set to true, all the empty tags will be closed using explicit start and end tag.