### PR TITLE
deleted redundant .toString() call in README test method Sysout

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ import org.json.JSONObject;
 public class Test {
     public static void main(String args[]){
        JSONObject jo = new JSONObject("{ \"abc\" : \"def\" }");
-       System.out.println(jo.toString());
+       System.out.println(jo);
     }
 }
 ```


### PR DESCRIPTION
Deleted the .toString() method call from the Java test demonstration in README.md, as System.out.println() automatically calls .toString() from any object parsed into it.