### PR TITLE
stleary#838 - Fix enum serialization in JSONObject

### DIFF
--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -2653,7 +2653,7 @@ public class JSONObject {
         } else if (value instanceof Boolean) {
             writer.write(value.toString());
         } else if (value instanceof Enum<?>) {
-            writer.write(quote(((Enum<?>)value).name()));
+            writer.write(quote(value.toString()));
         } else if (value instanceof JSONObject) {
             ((JSONObject) value).write(writer, indentFactor, indent);
         } else if (value instanceof JSONArray) {


### PR DESCRIPTION
Resolves an issue where JSONObject.toString() used Enum.name() instead of Enum.toString() when serializing enum values. Updated the relevant code in JSONObject to use the overridden toString() method for enum values.