### PR TITLE
Ticket #863 rewrite toString with StringBuilder for better performance

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -52,6 +52,8 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Compile Java ${{ matrix.java }}
+        env:
+          MAVEN_OPTS: -Xss4m
         run: mvn clean compile -D maven.compiler.source=${{ matrix.java }} -D maven.compiler.target=${{ matrix.java }} -D maven.test.skip=true -D maven.site.skip=true -D maven.javadoc.skip=true
       - name: Run Tests ${{ matrix.java }}
         run: |

--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -1659,11 +1659,33 @@ public class JSONArray implements Iterable<Object> {
      */
     @Override
     public String toString() {
+        StringBuilder sb = new StringBuilder();
         try {
-            return this.toString(0);
-        } catch (Exception e) {
+            write(sb);
+        } catch (JSONException e) {
             return null;
         }
+        return sb.toString();
+    }
+
+    StringBuilder write(StringBuilder sb) {
+        boolean needsComma = false;
+        int length = this.length();
+        sb.append('[');
+
+        for (int i = 0; i < length; i++) {
+            if (needsComma) {
+                sb.append(',');
+            }
+            try {
+                JSONObject.writeValue(sb, this.myArrayList.get(i));
+            } catch (Exception e) {
+                throw new JSONException("Unable to write JSONArray value at index: " + i, e);
+            }
+            needsComma = true;
+        }
+        sb.append(']');
+        return sb;
     }
 
     /**


### PR DESCRIPTION
Implementation for https://github.com/stleary/JSON-java/issues/863

Using a StringBuilder to improve the performance for the default `toString` methods without indent.

This duplicates a lot of code, as I assume you want to keep the existing public method interfaces accepting and returning a `Writer` for backwards compatibility. But is results in ~25% faster `toString` method, mostly used for serialisation.

I validated the performance with this project: https://github.com/fabienrenaud/java-json-benchmark
`./run ser --libs ORGJSON`

on my local machine result for the benchmark (thoughput measured in operations per second, higher is better):

currently latest library version 20240205:
```
Benchmark               Mode  Cnt       Score       Error  Units
Serialization.orgjson  thrpt   20  719375,045 ▒ 63677,634  ops/s
```

Improved implementation from this PR:
```
Benchmark               Mode  Cnt       Score       Error  Units
Serialization.orgjson  thrpt   20  905794,579 ▒ 23428,330  ops/s
```
