### PR TITLE
add a test case for an enum implementing JSONString

### DIFF
--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -2701,6 +2701,7 @@ public class JSONObject {
         if (value == null || value.equals(null)) {
             writer.write("null");
         } else if (value instanceof JSONString) {
+            // JSONString must be checked first, so it can overwrite behaviour of other types below
             Object o;
             try {
                 o = ((JSONString) value).toJSONString();

--- a/src/test/java/org/json/junit/JSONStringTest.java
+++ b/src/test/java/org/json/junit/JSONStringTest.java
@@ -319,6 +319,22 @@ public class JSONStringTest {
         }
     }
 
+    @Test
+    public void testEnumJSONString() {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("key", MyEnum.MY_ENUM);
+        assertEquals("{\"key\":\"myJsonString\"}", jsonObject.toString());
+    }
+
+    private enum MyEnum implements JSONString {
+        MY_ENUM;
+
+        @Override
+        public String toJSONString() {
+            return "\"myJsonString\"";
+        }
+    }
+
     /**
      * A JSONString that returns a valid JSON string value.
      */


### PR DESCRIPTION
This test case would fail when the instanceof check for `JSONString` in the `writeValue` method of `JSONObject` would be moved to the bottom below the check for `enum`.