### PR TITLE
remove-jsonparserconfig-ctor - just use withOverwriteDuplicateKey()

### DIFF
--- a/src/main/java/org/json/JSONParserConfiguration.java
+++ b/src/main/java/org/json/JSONParserConfiguration.java
@@ -13,24 +13,14 @@ public class JSONParserConfiguration extends ParserConfiguration {
      * Configuration with the default values.
      */
     public JSONParserConfiguration() {
-        this(false);
-    }
-
-    /**
-     * Configure the parser with argument overwriteDuplicateKey.
-     *
-     * @param overwriteDuplicateKey Indicate whether to overwrite duplicate key or not.<br>
-     *                              If not, the JSONParser will throw a {@link JSONException}
-     *                              when meeting duplicate keys.
-     */
-    public JSONParserConfiguration(boolean overwriteDuplicateKey) {
         super();
-        this.overwriteDuplicateKey = overwriteDuplicateKey;
+        this.overwriteDuplicateKey = false;
     }
 
     @Override
     protected JSONParserConfiguration clone() {
-        JSONParserConfiguration clone = new JSONParserConfiguration(overwriteDuplicateKey);
+        JSONParserConfiguration clone = new JSONParserConfiguration();
+        clone.overwriteDuplicateKey = overwriteDuplicateKey;
         clone.maxNestingDepth = maxNestingDepth;
         return clone;
     }

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -18,7 +18,8 @@ public class JSONParserConfigurationTest {
 
     @Test
     public void testOverwrite() {
-        JSONObject jsonObject = new JSONObject(TEST_SOURCE, new JSONParserConfiguration(true));
+        JSONObject jsonObject = new JSONObject(TEST_SOURCE,
+                new JSONParserConfiguration().withOverwriteDuplicateKey(true));
 
         assertEquals("duplicate key should be overwritten", "value2", jsonObject.getString("key"));
     }


### PR DESCRIPTION
**Description**
Remove overloaded JSONParserConfiguration ctor. Use withOverwriteDuplicateKey() instead

**Refactoring**
None

**Testing done**
unit tests