### PR TITLE
StrictMode Implementation for JSONArray

### DIFF
--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -109,7 +109,11 @@ public class JSONArray implements Iterable<Object> {
                     this.myArrayList.add(JSONObject.NULL);
                 } else {
                     x.back();
-                    this.myArrayList.add(x.nextValue());
+                    if (jsonParserConfiguration.isStrictMode()) {
+                        this.myArrayList.add(x.nextValue(true));
+                    } else {
+                        this.myArrayList.add(x.nextValue());
+                    }
                 }
                 switch (x.nextClean()) {
                     case 0:
@@ -1693,7 +1697,8 @@ public class JSONArray implements Iterable<Object> {
      * @throws JSONException        If not an array or if an array value is non-finite number.
      * @throws NullPointerException Thrown if the array parameter is null.
      */
-    private void addAll(Object array, boolean wrap, int recursionDepth, JSONParserConfiguration jsonParserConfiguration)
+    private void addAll(Object array, boolean wrap, int recursionDepth, JSONParserConfiguration
+        jsonParserConfiguration)
         throws JSONException {
         if (array.getClass().isArray()) {
             int length = Array.getLength(array);

--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -85,10 +85,12 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Construct a JSONArray from a JSONTokener.
+     * Constructs a JSONArray from a JSONTokener and a JSONParserConfiguration.
+     * JSONParserConfiguration contains strictMode turned off (false) by default.
      *
-     * @param x A JSONTokener
-     * @throws JSONException If there is a syntax error.
+     * @param x                       A JSONTokener instance from which the JSONArray is constructed.
+     * @param jsonParserConfiguration A JSONParserConfiguration instance that controls the behavior of the parser.
+     * @throws JSONException If a syntax error occurs during the construction of the JSONArray.
      */
     public JSONArray(JSONTokener x, JSONParserConfiguration jsonParserConfiguration) throws JSONException {
         this();
@@ -103,7 +105,7 @@ public class JSONArray implements Iterable<Object> {
         }
         if (nextChar != ']') {
             x.back();
-            for (;;) {
+            for (; ; ) {
                 if (x.nextClean() == ',') {
                     x.back();
                     this.myArrayList.add(JSONObject.NULL);

--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -18,11 +18,10 @@ import java.util.Map;
 
 
 /**
- * A JSONArray is an ordered sequence of values. Its external text form is a
- * string wrapped in square brackets with commas separating the values. The
- * internal form is an object having <code>get</code> and <code>opt</code>
- * methods for accessing the values by index, and <code>put</code> methods for
- * adding or replacing values. The values can be any of these types:
+ * A JSONArray is an ordered sequence of values. Its external text form is a string wrapped in square brackets with
+ * commas separating the values. The internal form is an object having <code>get</code> and <code>opt</code> methods for
+ * accessing the values by index, and <code>put</code> methods for adding or replacing values. The values can be any of
+ * these types:
  * <code>Boolean</code>, <code>JSONArray</code>, <code>JSONObject</code>,
  * <code>Number</code>, <code>String</code>, or the
  * <code>JSONObject.NULL object</code>.
@@ -30,19 +29,17 @@ import java.util.Map;
  * The constructor can convert a JSON text into a Java object. The
  * <code>toString</code> method converts to JSON text.
  * <p>
- * A <code>get</code> method returns a value if one can be found, and throws an
- * exception if one cannot be found. An <code>opt</code> method returns a
- * default value instead of throwing an exception, and so is useful for
- * obtaining optional values.
+ * A <code>get</code> method returns a value if one can be found, and throws an exception if one cannot be found. An
+ * <code>opt</code> method returns a default value instead of throwing an exception, and so is useful for obtaining
+ * optional values.
  * <p>
- * The generic <code>get()</code> and <code>opt()</code> methods return an
- * object which you can cast or query for type. There are also typed
+ * The generic <code>get()</code> and <code>opt()</code> methods return an object which you can cast or query for type.
+ * There are also typed
  * <code>get</code> and <code>opt</code> methods that do type checking and type
  * coercion for you.
  * <p>
- * The texts produced by the <code>toString</code> methods strictly conform to
- * JSON syntax rules. The constructors are more forgiving in the texts they will
- * accept:
+ * The texts produced by the <code>toString</code> methods strictly conform to JSON syntax rules. The constructors are
+ * more forgiving in the texts they will accept:
  * <ul>
  * <li>An extra <code>,</code>&nbsp;<small>(comma)</small> may appear just
  * before the closing bracket.</li>
@@ -76,19 +73,29 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Construct a JSONArray from a JSONTokener.
+     * Constructs a JSONArray from a JSONTokener.
+     * <p>
+     * This constructor reads the JSONTokener to parse a JSON array. It uses the default JSONParserConfiguration.
      *
-     * @param x
-     *            A JSONTokener
-     * @throws JSONException
-     *             If there is a syntax error.
+     * @param x A JSONTokener
+     * @throws JSONException If there is a syntax error.
      */
     public JSONArray(JSONTokener x) throws JSONException {
+        this(x, new JSONParserConfiguration());
+    }
+
+    /**
+     * Construct a JSONArray from a JSONTokener.
+     *
+     * @param x A JSONTokener
+     * @throws JSONException If there is a syntax error.
+     */
+    public JSONArray(JSONTokener x, JSONParserConfiguration jsonParserConfiguration) throws JSONException {
         this();
         if (x.nextClean() != '[') {
             throw x.syntaxError("A JSONArray text must start with '['");
         }
-        
+
         char nextChar = x.nextClean();
         if (nextChar == 0) {
             // array is unclosed. No ']' found, instead EOF
@@ -105,24 +112,31 @@ public class JSONArray implements Iterable<Object> {
                     this.myArrayList.add(x.nextValue());
                 }
                 switch (x.nextClean()) {
-                case 0:
-                    // array is unclosed. No ']' found, instead EOF
-                    throw x.syntaxError("Expected a ',' or ']'");
-                case ',':
-                    nextChar = x.nextClean();
-                    if (nextChar == 0) {
+                    case 0:
                         // array is unclosed. No ']' found, instead EOF
                         throw x.syntaxError("Expected a ',' or ']'");
-                    }
-                    if (nextChar == ']') {
+                    case ',':
+                        nextChar = x.nextClean();
+                        if (nextChar == 0) {
+                            // array is unclosed. No ']' found, instead EOF
+                            throw x.syntaxError("Expected a ',' or ']'");
+                        }
+                        if (nextChar == ']') {
+                            return;
+                        }
+                        x.back();
+                        break;
+                    case ']':
+                        if (jsonParserConfiguration.isStrictMode()) {
+                            nextChar = x.nextClean();
+                            if (nextChar != 0) {
+                                throw x.syntaxError("invalid character found after end of array: " + nextChar);
+                            }
+                        }
+
                         return;
-                    }
-                    x.back();
-                    break;
-                case ']':
-                    return;
-                default:
-                    throw x.syntaxError("Expected a ',' or ']'");
+                    default:
+                        throw x.syntaxError("Expected a ',' or ']'");
                 }
             }
         }
@@ -131,34 +145,32 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Construct a JSONArray from a source JSON text.
      *
-     * @param source
-     *            A string that begins with <code>[</code>&nbsp;<small>(left
-     *            bracket)</small> and ends with <code>]</code>
-     *            &nbsp;<small>(right bracket)</small>.
-     * @throws JSONException
-     *             If there is a syntax error.
+     * @param source A string that begins with <code>[</code>&nbsp;<small>(left bracket)</small> and ends with
+     *               <code>]</code> &nbsp;<small>(right bracket)</small>.
+     * @throws JSONException If there is a syntax error.
      */
     public JSONArray(String source) throws JSONException {
-        this(new JSONTokener(source));
+        this(new JSONTokener(source), new JSONParserConfiguration());
+    }
+
+    public JSONArray(String source, JSONParserConfiguration jsonParserConfiguration) throws JSONException {
+        this(new JSONTokener(source), jsonParserConfiguration);
     }
 
     /**
      * Construct a JSONArray from a Collection.
      *
-     * @param collection
-     *            A Collection.
+     * @param collection A Collection.
      */
     public JSONArray(Collection<?> collection) {
-      this(collection, 0, new JSONParserConfiguration());
+        this(collection, 0, new JSONParserConfiguration());
     }
 
     /**
      * Construct a JSONArray from a Collection.
      *
-     * @param collection
-     *            A Collection.
-     * @param jsonParserConfiguration
-     *            Configuration object for the JSON parser
+     * @param collection              A Collection.
+     * @param jsonParserConfiguration Configuration object for the JSON parser
      */
     public JSONArray(Collection<?> collection, JSONParserConfiguration jsonParserConfiguration) {
         this(collection, 0, jsonParserConfiguration);
@@ -167,16 +179,14 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Construct a JSONArray from a collection with recursion depth.
      *
-     * @param collection
-     *             A Collection.
-     * @param recursionDepth
-     *             Variable for tracking the count of nested object creations.
-     * @param jsonParserConfiguration
-     *             Configuration object for the JSON parser
+     * @param collection              A Collection.
+     * @param recursionDepth          Variable for tracking the count of nested object creations.
+     * @param jsonParserConfiguration Configuration object for the JSON parser
      */
     JSONArray(Collection<?> collection, int recursionDepth, JSONParserConfiguration jsonParserConfiguration) {
         if (recursionDepth > jsonParserConfiguration.getMaxNestingDepth()) {
-          throw new JSONException("JSONArray has reached recursion depth limit of " + jsonParserConfiguration.getMaxNestingDepth());
+            throw new JSONException(
+                "JSONArray has reached recursion depth limit of " + jsonParserConfiguration.getMaxNestingDepth());
         }
         if (collection == null) {
             this.myArrayList = new ArrayList<Object>();
@@ -189,8 +199,7 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Construct a JSONArray from an Iterable. This is a shallow copy.
      *
-     * @param iter
-     *            A Iterable collection.
+     * @param iter A Iterable collection.
      */
     public JSONArray(Iterable<?> iter) {
         this();
@@ -203,8 +212,7 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Construct a JSONArray from another JSONArray. This is a shallow copy.
      *
-     * @param array
-     *            A array.
+     * @param array A array.
      */
     public JSONArray(JSONArray array) {
         if (array == null) {
@@ -219,20 +227,15 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Construct a JSONArray from an array.
      *
-     * @param array
-     *            Array. If the parameter passed is null, or not an array, an
-     *            exception will be thrown.
-     *
-     * @throws JSONException
-     *            If not an array or if an array value is non-finite number.
-     * @throws NullPointerException
-     *            Thrown if the array parameter is null.
+     * @param array Array. If the parameter passed is null, or not an array, an exception will be thrown.
+     * @throws JSONException        If not an array or if an array value is non-finite number.
+     * @throws NullPointerException Thrown if the array parameter is null.
      */
     public JSONArray(Object array) throws JSONException {
         this();
         if (!array.getClass().isArray()) {
             throw new JSONException(
-                    "JSONArray initial value should be a string or collection or array.");
+                "JSONArray initial value should be a string or collection or array.");
         }
         this.addAll(array, true, 0);
     }
@@ -240,17 +243,15 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Construct a JSONArray with the specified initial capacity.
      *
-     * @param initialCapacity
-     *            the initial capacity of the JSONArray.
-     * @throws JSONException
-     *             If the initial capacity is negative.
+     * @param initialCapacity the initial capacity of the JSONArray.
+     * @throws JSONException If the initial capacity is negative.
      */
     public JSONArray(int initialCapacity) throws JSONException {
-    	if (initialCapacity < 0) {
+        if (initialCapacity < 0) {
             throw new JSONException(
-                    "JSONArray initial capacity cannot be negative.");
-    	}
-    	this.myArrayList = new ArrayList<Object>(initialCapacity);
+                "JSONArray initial capacity cannot be negative.");
+        }
+        this.myArrayList = new ArrayList<Object>(initialCapacity);
     }
 
     @Override
@@ -261,11 +262,9 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the object value associated with an index.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return An object value.
-     * @throws JSONException
-     *             If there is no value for the index.
+     * @throws JSONException If there is no value for the index.
      */
     public Object get(int index) throws JSONException {
         Object object = this.opt(index);
@@ -276,25 +275,21 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the boolean value associated with an index. The string values "true"
-     * and "false" are converted to boolean.
+     * Get the boolean value associated with an index. The string values "true" and "false" are converted to boolean.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return The truth.
-     * @throws JSONException
-     *             If there is no value for the index or if the value is not
-     *             convertible to boolean.
+     * @throws JSONException If there is no value for the index or if the value is not convertible to boolean.
      */
     public boolean getBoolean(int index) throws JSONException {
         Object object = this.get(index);
         if (object.equals(Boolean.FALSE)
-                || (object instanceof String && ((String) object)
-                        .equalsIgnoreCase("false"))) {
+            || (object instanceof String && ((String) object)
+            .equalsIgnoreCase("false"))) {
             return false;
         } else if (object.equals(Boolean.TRUE)
-                || (object instanceof String && ((String) object)
-                        .equalsIgnoreCase("true"))) {
+            || (object instanceof String && ((String) object)
+            .equalsIgnoreCase("true"))) {
             return true;
         }
         throw wrongValueFormatException(index, "boolean", object, null);
@@ -303,17 +298,14 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the double value associated with an index.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return The value.
-     * @throws JSONException
-     *             If the key is not found or if the value cannot be converted
-     *             to a number.
+     * @throws JSONException If the key is not found or if the value cannot be converted to a number.
      */
     public double getDouble(int index) throws JSONException {
         final Object object = this.get(index);
-        if(object instanceof Number) {
-            return ((Number)object).doubleValue();
+        if (object instanceof Number) {
+            return ((Number) object).doubleValue();
         }
         try {
             return Double.parseDouble(object.toString());
@@ -325,17 +317,15 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the float value associated with a key.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a Number
-     *             object and cannot be converted to a number.
+     * @throws JSONException if the key is not found or if the value is not a Number object and cannot be converted to a
+     *                       number.
      */
     public float getFloat(int index) throws JSONException {
         final Object object = this.get(index);
-        if(object instanceof Number) {
-            return ((Number)object).floatValue();
+        if (object instanceof Number) {
+            return ((Number) object).floatValue();
         }
         try {
             return Float.parseFloat(object.toString());
@@ -347,18 +337,16 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the Number value associated with a key.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a Number
-     *             object and cannot be converted to a number.
+     * @throws JSONException if the key is not found or if the value is not a Number object and cannot be converted to a
+     *                       number.
      */
     public Number getNumber(int index) throws JSONException {
         Object object = this.get(index);
         try {
             if (object instanceof Number) {
-                return (Number)object;
+                return (Number) object;
             }
             return JSONObject.stringToNumber(object.toString());
         } catch (Exception e) {
@@ -368,47 +356,38 @@ public class JSONArray implements Iterable<Object> {
 
     /**
      * Get the enum value associated with an index.
-     * 
-     * @param <E>
-     *            Enum Type
-     * @param clazz
-     *            The type of enum to retrieve.
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     *
+     * @param <E>   Enum Type
+     * @param clazz The type of enum to retrieve.
+     * @param index The index must be between 0 and length() - 1.
      * @return The enum value at the index location
-     * @throws JSONException
-     *            if the key is not found or if the value cannot be converted
-     *            to an enum.
+     * @throws JSONException if the key is not found or if the value cannot be converted to an enum.
      */
     public <E extends Enum<E>> E getEnum(Class<E> clazz, int index) throws JSONException {
         E val = optEnum(clazz, index);
-        if(val==null) {
+        if (val == null) {
             // JSONException should really take a throwable argument.
             // If it did, I would re-implement this with the Enum.valueOf
             // method and place any thrown exception in the JSONException
             throw wrongValueFormatException(index, "enum of type "
-                    + JSONObject.quote(clazz.getSimpleName()), opt(index), null);
+                + JSONObject.quote(clazz.getSimpleName()), opt(index), null);
         }
         return val;
     }
 
     /**
-     * Get the BigDecimal value associated with an index. If the value is float
-     * or double, the {@link BigDecimal#BigDecimal(double)} constructor
-     * will be used. See notes on the constructor for conversion issues that
-     * may arise.
+     * Get the BigDecimal value associated with an index. If the value is float or double, the
+     * {@link BigDecimal#BigDecimal(double)} constructor will be used. See notes on the constructor for conversion
+     * issues that may arise.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return The value.
-     * @throws JSONException
-     *             If the key is not found or if the value cannot be converted
-     *             to a BigDecimal.
+     * @throws JSONException If the key is not found or if the value cannot be converted to a BigDecimal.
      */
-    public BigDecimal getBigDecimal (int index) throws JSONException {
+    public BigDecimal getBigDecimal(int index) throws JSONException {
         Object object = this.get(index);
         BigDecimal val = JSONObject.objectToBigDecimal(object, null);
-        if(val == null) {
+        if (val == null) {
             throw wrongValueFormatException(index, "BigDecimal", object, null);
         }
         return val;
@@ -417,17 +396,14 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the BigInteger value associated with an index.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return The value.
-     * @throws JSONException
-     *             If the key is not found or if the value cannot be converted
-     *             to a BigInteger.
+     * @throws JSONException If the key is not found or if the value cannot be converted to a BigInteger.
      */
-    public BigInteger getBigInteger (int index) throws JSONException {
+    public BigInteger getBigInteger(int index) throws JSONException {
         Object object = this.get(index);
         BigInteger val = JSONObject.objectToBigInteger(object, null);
-        if(val == null) {
+        if (val == null) {
             throw wrongValueFormatException(index, "BigInteger", object, null);
         }
         return val;
@@ -436,16 +412,14 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the int value associated with an index.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return The value.
-     * @throws JSONException
-     *             If the key is not found or if the value is not a number.
+     * @throws JSONException If the key is not found or if the value is not a number.
      */
     public int getInt(int index) throws JSONException {
         final Object object = this.get(index);
-        if(object instanceof Number) {
-            return ((Number)object).intValue();
+        if (object instanceof Number) {
+            return ((Number) object).intValue();
         }
         try {
             return Integer.parseInt(object.toString());
@@ -457,12 +431,9 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the JSONArray associated with an index.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return A JSONArray value.
-     * @throws JSONException
-     *             If there is no value for the index. or if the value is not a
-     *             JSONArray
+     * @throws JSONException If there is no value for the index. or if the value is not a JSONArray
      */
     public JSONArray getJSONArray(int index) throws JSONException {
         Object object = this.get(index);
@@ -475,12 +446,9 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the JSONObject associated with an index.
      *
-     * @param index
-     *            subscript
+     * @param index subscript
      * @return A JSONObject value.
-     * @throws JSONException
-     *             If there is no value for the index or if the value is not a
-     *             JSONObject
+     * @throws JSONException If there is no value for the index or if the value is not a JSONObject
      */
     public JSONObject getJSONObject(int index) throws JSONException {
         Object object = this.get(index);
@@ -493,17 +461,14 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the long value associated with an index.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return The value.
-     * @throws JSONException
-     *             If the key is not found or if the value cannot be converted
-     *             to a number.
+     * @throws JSONException If the key is not found or if the value cannot be converted to a number.
      */
     public long getLong(int index) throws JSONException {
         final Object object = this.get(index);
-        if(object instanceof Number) {
-            return ((Number)object).longValue();
+        if (object instanceof Number) {
+            return ((Number) object).longValue();
         }
         try {
             return Long.parseLong(object.toString());
@@ -515,11 +480,9 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the string associated with an index.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return A string value.
-     * @throws JSONException
-     *             If there is no string value for the index.
+     * @throws JSONException If there is no string value for the index.
      */
     public String getString(int index) throws JSONException {
         Object object = this.get(index);
@@ -532,8 +495,7 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Determine if the value is <code>null</code>.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return true if the value at the index is <code>null</code>, or if there is no value.
      */
     public boolean isNull(int index) {
@@ -545,24 +507,22 @@ public class JSONArray implements Iterable<Object> {
      * <code>separator</code> string is inserted between each element. Warning:
      * This method assumes that the data structure is acyclical.
      *
-     * @param separator
-     *            A string that will be inserted between the elements.
+     * @param separator A string that will be inserted between the elements.
      * @return a string.
-     * @throws JSONException
-     *             If the array contains an invalid number.
+     * @throws JSONException If the array contains an invalid number.
      */
     public String join(String separator) throws JSONException {
         int len = this.length();
         if (len == 0) {
             return "";
         }
-        
+
         StringBuilder sb = new StringBuilder(
-                   JSONObject.valueToString(this.myArrayList.get(0)));
+            JSONObject.valueToString(this.myArrayList.get(0)));
 
         for (int i = 1; i < len; i++) {
             sb.append(separator)
-              .append(JSONObject.valueToString(this.myArrayList.get(i)));
+                .append(JSONObject.valueToString(this.myArrayList.get(i)));
         }
         return sb.toString();
     }
@@ -577,8 +537,7 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Removes all of the elements from this JSONArray.
-     * The JSONArray will be empty after this call returns.
+     * Removes all of the elements from this JSONArray. The JSONArray will be empty after this call returns.
      */
     public void clear() {
         this.myArrayList.clear();
@@ -587,22 +546,19 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the optional object value associated with an index.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1. If not, null is returned.
+     * @param index The index must be between 0 and length() - 1. If not, null is returned.
      * @return An object value, or null if there is no object at that index.
      */
     public Object opt(int index) {
         return (index < 0 || index >= this.length()) ? null : this.myArrayList
-                .get(index);
+            .get(index);
     }
 
     /**
-     * Get the optional boolean value associated with an index. It returns false
-     * if there is no value at that index, or if the value is not Boolean.TRUE
-     * or the String "true".
+     * Get the optional boolean value associated with an index. It returns false if there is no value at that index, or
+     * if the value is not Boolean.TRUE or the String "true".
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return The truth.
      */
     public boolean optBoolean(int index) {
@@ -610,14 +566,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional boolean value associated with an index. It returns the
-     * defaultValue if there is no value at that index or if it is not a Boolean
-     * or the String "true" or "false" (case insensitive).
+     * Get the optional boolean value associated with an index. It returns the defaultValue if there is no value at that
+     * index or if it is not a Boolean or the String "true" or "false" (case insensitive).
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            A boolean default.
+     * @param index        The index must be between 0 and length() - 1.
+     * @param defaultValue A boolean default.
      * @return The truth.
      */
     public boolean optBoolean(int index, boolean defaultValue) {
@@ -629,12 +582,10 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional Boolean object associated with an index. It returns false
-     * if there is no value at that index, or if the value is not Boolean.TRUE
-     * or the String "true".
+     * Get the optional Boolean object associated with an index. It returns false if there is no value at that index, or
+     * if the value is not Boolean.TRUE or the String "true".
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return The truth.
      */
     public Boolean optBooleanObject(int index) {
@@ -642,14 +593,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional Boolean object associated with an index. It returns the
-     * defaultValue if there is no value at that index or if it is not a Boolean
-     * or the String "true" or "false" (case insensitive).
+     * Get the optional Boolean object associated with an index. It returns the defaultValue if there is no value at
+     * that index or if it is not a Boolean or the String "true" or "false" (case insensitive).
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            A boolean default.
+     * @param index        The index must be between 0 and length() - 1.
+     * @param defaultValue A boolean default.
      * @return The truth.
      */
     public Boolean optBooleanObject(int index, Boolean defaultValue) {
@@ -661,12 +609,10 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional double value associated with an index. NaN is returned
-     * if there is no value for the index, or if the value is not a number and
-     * cannot be converted to a number.
+     * Get the optional double value associated with an index. NaN is returned if there is no value for the index, or if
+     * the value is not a number and cannot be converted to a number.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return The value.
      */
     public double optDouble(int index) {
@@ -674,14 +620,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional double value associated with an index. The defaultValue
-     * is returned if there is no value for the index, or if the value is not a
-     * number and cannot be converted to a number.
+     * Get the optional double value associated with an index. The defaultValue is returned if there is no value for the
+     * index, or if the value is not a number and cannot be converted to a number.
      *
-     * @param index
-     *            subscript
-     * @param defaultValue
-     *            The default value.
+     * @param index        subscript
+     * @param defaultValue The default value.
      * @return The value.
      */
     public double optDouble(int index, double defaultValue) {
@@ -697,12 +640,10 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional Double object associated with an index. NaN is returned
-     * if there is no value for the index, or if the value is not a number and
-     * cannot be converted to a number.
+     * Get the optional Double object associated with an index. NaN is returned if there is no value for the index, or
+     * if the value is not a number and cannot be converted to a number.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return The object.
      */
     public Double optDoubleObject(int index) {
@@ -710,14 +651,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional double value associated with an index. The defaultValue
-     * is returned if there is no value for the index, or if the value is not a
-     * number and cannot be converted to a number.
+     * Get the optional double value associated with an index. The defaultValue is returned if there is no value for the
+     * index, or if the value is not a number and cannot be converted to a number.
      *
-     * @param index
-     *            subscript
-     * @param defaultValue
-     *            The default object.
+     * @param index        subscript
+     * @param defaultValue The default object.
      * @return The object.
      */
     public Double optDoubleObject(int index, Double defaultValue) {
@@ -733,12 +671,10 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional float value associated with an index. NaN is returned
-     * if there is no value for the index, or if the value is not a number and
-     * cannot be converted to a number.
+     * Get the optional float value associated with an index. NaN is returned if there is no value for the index, or if
+     * the value is not a number and cannot be converted to a number.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return The value.
      */
     public float optFloat(int index) {
@@ -746,14 +682,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional float value associated with an index. The defaultValue
-     * is returned if there is no value for the index, or if the value is not a
-     * number and cannot be converted to a number.
+     * Get the optional float value associated with an index. The defaultValue is returned if there is no value for the
+     * index, or if the value is not a number and cannot be converted to a number.
      *
-     * @param index
-     *            subscript
-     * @param defaultValue
-     *            The default value.
+     * @param index        subscript
+     * @param defaultValue The default value.
      * @return The value.
      */
     public float optFloat(int index, float defaultValue) {
@@ -769,12 +702,10 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional Float object associated with an index. NaN is returned
-     * if there is no value for the index, or if the value is not a number and
-     * cannot be converted to a number.
+     * Get the optional Float object associated with an index. NaN is returned if there is no value for the index, or if
+     * the value is not a number and cannot be converted to a number.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return The object.
      */
     public Float optFloatObject(int index) {
@@ -782,14 +713,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional Float object associated with an index. The defaultValue
-     * is returned if there is no value for the index, or if the value is not a
-     * number and cannot be converted to a number.
+     * Get the optional Float object associated with an index. The defaultValue is returned if there is no value for the
+     * index, or if the value is not a number and cannot be converted to a number.
      *
-     * @param index
-     *            subscript
-     * @param defaultValue
-     *            The default object.
+     * @param index        subscript
+     * @param defaultValue The default object.
      * @return The object.
      */
     public Float optFloatObject(int index, Float defaultValue) {
@@ -805,12 +733,10 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional int value associated with an index. Zero is returned if
-     * there is no value for the index, or if the value is not a number and
-     * cannot be converted to a number.
+     * Get the optional int value associated with an index. Zero is returned if there is no value for the index, or if
+     * the value is not a number and cannot be converted to a number.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return The value.
      */
     public int optInt(int index) {
@@ -818,14 +744,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional int value associated with an index. The defaultValue is
-     * returned if there is no value for the index, or if the value is not a
-     * number and cannot be converted to a number.
+     * Get the optional int value associated with an index. The defaultValue is returned if there is no value for the
+     * index, or if the value is not a number and cannot be converted to a number.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default value.
+     * @param index        The index must be between 0 and length() - 1.
+     * @param defaultValue The default value.
      * @return The value.
      */
     public int optInt(int index, int defaultValue) {
@@ -837,12 +760,10 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional Integer object associated with an index. Zero is returned if
-     * there is no value for the index, or if the value is not a number and
-     * cannot be converted to a number.
+     * Get the optional Integer object associated with an index. Zero is returned if there is no value for the index, or
+     * if the value is not a number and cannot be converted to a number.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return The object.
      */
     public Integer optIntegerObject(int index) {
@@ -850,14 +771,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional Integer object associated with an index. The defaultValue is
-     * returned if there is no value for the index, or if the value is not a
-     * number and cannot be converted to a number.
+     * Get the optional Integer object associated with an index. The defaultValue is returned if there is no value for
+     * the index, or if the value is not a number and cannot be converted to a number.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default object.
+     * @param index        The index must be between 0 and length() - 1.
+     * @param defaultValue The default object.
      * @return The object.
      */
     public Integer optIntegerObject(int index, Integer defaultValue) {
@@ -870,13 +788,10 @@ public class JSONArray implements Iterable<Object> {
 
     /**
      * Get the enum value associated with a key.
-     * 
-     * @param <E>
-     *            Enum Type
-     * @param clazz
-     *            The type of enum to retrieve.
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     *
+     * @param <E>   Enum Type
+     * @param clazz The type of enum to retrieve.
+     * @param index The index must be between 0 and length() - 1.
      * @return The enum value at the index location or null if not found
      */
     public <E extends Enum<E>> E optEnum(Class<E> clazz, int index) {
@@ -885,17 +800,13 @@ public class JSONArray implements Iterable<Object> {
 
     /**
      * Get the enum value associated with a key.
-     * 
-     * @param <E>
-     *            Enum Type
-     * @param clazz
-     *            The type of enum to retrieve.
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default in case the value is not found
-     * @return The enum value at the index location or defaultValue if
-     *            the value is not found or cannot be assigned to clazz
+     *
+     * @param <E>          Enum Type
+     * @param clazz        The type of enum to retrieve.
+     * @param index        The index must be between 0 and length() - 1.
+     * @param defaultValue The default in case the value is not found
+     * @return The enum value at the index location or defaultValue if the value is not found or cannot be assigned to
+     * clazz
      */
     public <E extends Enum<E>> E optEnum(Class<E> clazz, int index, E defaultValue) {
         try {
@@ -918,14 +829,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional BigInteger value associated with an index. The 
-     * defaultValue is returned if there is no value for the index, or if the 
-     * value is not a number and cannot be converted to a number.
+     * Get the optional BigInteger value associated with an index. The defaultValue is returned if there is no value for
+     * the index, or if the value is not a number and cannot be converted to a number.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default value.
+     * @param index        The index must be between 0 and length() - 1.
+     * @param defaultValue The default value.
      * @return The value.
      */
     public BigInteger optBigInteger(int index, BigInteger defaultValue) {
@@ -934,17 +842,13 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional BigDecimal value associated with an index. The 
-     * defaultValue is returned if there is no value for the index, or if the 
-     * value is not a number and cannot be converted to a number. If the value
-     * is float or double, the {@link BigDecimal#BigDecimal(double)}
-     * constructor will be used. See notes on the constructor for conversion
+     * Get the optional BigDecimal value associated with an index. The defaultValue is returned if there is no value for
+     * the index, or if the value is not a number and cannot be converted to a number. If the value is float or double,
+     * the {@link BigDecimal#BigDecimal(double)} constructor will be used. See notes on the constructor for conversion
      * issues that may arise.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default value.
+     * @param index        The index must be between 0 and length() - 1.
+     * @param defaultValue The default value.
      * @return The value.
      */
     public BigDecimal optBigDecimal(int index, BigDecimal defaultValue) {
@@ -953,11 +857,10 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional JSONArray associated with an index. Null is returned if
-     * there is no value at that index or if the value is not a JSONArray.
+     * Get the optional JSONArray associated with an index. Null is returned if there is no value at that index or if
+     * the value is not a JSONArray.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return A JSONArray value.
      */
     public JSONArray optJSONArray(int index) {
@@ -965,13 +868,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional JSONArray associated with an index. The defaultValue is returned if
-     * there is no value at that index or if the value is not a JSONArray.
+     * Get the optional JSONArray associated with an index. The defaultValue is returned if there is no value at that
+     * index or if the value is not a JSONArray.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default.
+     * @param index        The index must be between 0 and length() - 1.
+     * @param defaultValue The default.
      * @return A JSONArray value.
      */
     public JSONArray optJSONArray(int index, JSONArray defaultValue) {
@@ -980,11 +881,10 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional JSONObject associated with an index. Null is returned if
-     * there is no value at that index or if the value is not a JSONObject.
+     * Get the optional JSONObject associated with an index. Null is returned if there is no value at that index or if
+     * the value is not a JSONObject.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return A JSONObject value.
      */
     public JSONObject optJSONObject(int index) {
@@ -992,13 +892,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional JSONObject associated with an index. The defaultValue is returned if
-     * there is no value at that index or if the value is not a JSONObject.
+     * Get the optional JSONObject associated with an index. The defaultValue is returned if there is no value at that
+     * index or if the value is not a JSONObject.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default.
+     * @param index        The index must be between 0 and length() - 1.
+     * @param defaultValue The default.
      * @return A JSONObject value.
      */
     public JSONObject optJSONObject(int index, JSONObject defaultValue) {
@@ -1007,12 +905,10 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional long value associated with an index. Zero is returned if
-     * there is no value for the index, or if the value is not a number and
-     * cannot be converted to a number.
+     * Get the optional long value associated with an index. Zero is returned if there is no value for the index, or if
+     * the value is not a number and cannot be converted to a number.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return The value.
      */
     public long optLong(int index) {
@@ -1020,14 +916,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional long value associated with an index. The defaultValue is
-     * returned if there is no value for the index, or if the value is not a
-     * number and cannot be converted to a number.
+     * Get the optional long value associated with an index. The defaultValue is returned if there is no value for the
+     * index, or if the value is not a number and cannot be converted to a number.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default value.
+     * @param index        The index must be between 0 and length() - 1.
+     * @param defaultValue The default value.
      * @return The value.
      */
     public long optLong(int index, long defaultValue) {
@@ -1039,12 +932,10 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional Long object associated with an index. Zero is returned if
-     * there is no value for the index, or if the value is not a number and
-     * cannot be converted to a number.
+     * Get the optional Long object associated with an index. Zero is returned if there is no value for the index, or if
+     * the value is not a number and cannot be converted to a number.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return The object.
      */
     public Long optLongObject(int index) {
@@ -1052,14 +943,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional Long object associated with an index. The defaultValue is
-     * returned if there is no value for the index, or if the value is not a
-     * number and cannot be converted to a number.
+     * Get the optional Long object associated with an index. The defaultValue is returned if there is no value for the
+     * index, or if the value is not a number and cannot be converted to a number.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default object.
+     * @param index        The index must be between 0 and length() - 1.
+     * @param defaultValue The default object.
      * @return The object.
      */
     public Long optLongObject(int index, Long defaultValue) {
@@ -1071,13 +959,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get an optional {@link Number} value associated with a key, or <code>null</code>
-     * if there is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number ({@link BigDecimal}). This method
-     * would be used in cases where type coercion of the number value is unwanted.
+     * Get an optional {@link Number} value associated with a key, or <code>null</code> if there is no such key or if
+     * the value is not a number. If the value is a string, an attempt will be made to evaluate it as a number
+     * ({@link BigDecimal}). This method would be used in cases where type coercion of the number value is unwanted.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return An object which is the value.
      */
     public Number optNumber(int index) {
@@ -1085,15 +971,12 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get an optional {@link Number} value associated with a key, or the default if there
-     * is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number ({@link BigDecimal}). This method
-     * would be used in cases where type coercion of the number value is unwanted.
+     * Get an optional {@link Number} value associated with a key, or the default if there is no such key or if the
+     * value is not a number. If the value is a string, an attempt will be made to evaluate it as a number
+     * ({@link BigDecimal}). This method would be used in cases where type coercion of the number value is unwanted.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default.
+     * @param index        The index must be between 0 and length() - 1.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public Number optNumber(int index, Number defaultValue) {
@@ -1101,10 +984,10 @@ public class JSONArray implements Iterable<Object> {
         if (JSONObject.NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof Number){
+        if (val instanceof Number) {
             return (Number) val;
         }
-        
+
         if (val instanceof String) {
             try {
                 return JSONObject.stringToNumber((String) val);
@@ -1116,12 +999,10 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional string value associated with an index. It returns an
-     * empty string if there is no value at that index. If the value is not a
-     * string and is not null, then it is converted to a string.
+     * Get the optional string value associated with an index. It returns an empty string if there is no value at that
+     * index. If the value is not a string and is not null, then it is converted to a string.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
+     * @param index The index must be between 0 and length() - 1.
      * @return A String value.
      */
     public String optString(int index) {
@@ -1129,26 +1010,22 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional string associated with an index. The defaultValue is
-     * returned if the key is not found.
+     * Get the optional string associated with an index. The defaultValue is returned if the key is not found.
      *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default value.
+     * @param index        The index must be between 0 and length() - 1.
+     * @param defaultValue The default value.
      * @return A String value.
      */
     public String optString(int index, String defaultValue) {
         Object object = this.opt(index);
         return JSONObject.NULL.equals(object) ? defaultValue : object
-                .toString();
+            .toString();
     }
 
     /**
      * Append a boolean value. This increases the array's length by one.
      *
-     * @param value
-     *            A boolean value.
+     * @param value A boolean value.
      * @return this.
      */
     public JSONArray put(boolean value) {
@@ -1156,14 +1033,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Put a value in the JSONArray, where the value will be a JSONArray which
-     * is produced from a Collection.
+     * Put a value in the JSONArray, where the value will be a JSONArray which is produced from a Collection.
      *
-     * @param value
-     *            A Collection value.
+     * @param value A Collection value.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
+     * @throws JSONException If the value is non-finite number.
      */
     public JSONArray put(Collection<?> value) {
         return this.put(new JSONArray(value));
@@ -1172,24 +1046,20 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Append a double value. This increases the array's length by one.
      *
-     * @param value
-     *            A double value.
+     * @param value A double value.
      * @return this.
-     * @throws JSONException
-     *             if the value is not finite.
+     * @throws JSONException if the value is not finite.
      */
     public JSONArray put(double value) throws JSONException {
         return this.put(Double.valueOf(value));
     }
-    
+
     /**
      * Append a float value. This increases the array's length by one.
      *
-     * @param value
-     *            A float value.
+     * @param value A float value.
      * @return this.
-     * @throws JSONException
-     *             if the value is not finite.
+     * @throws JSONException if the value is not finite.
      */
     public JSONArray put(float value) throws JSONException {
         return this.put(Float.valueOf(value));
@@ -1198,8 +1068,7 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Append an int value. This increases the array's length by one.
      *
-     * @param value
-     *            An int value.
+     * @param value An int value.
      * @return this.
      */
     public JSONArray put(int value) {
@@ -1209,8 +1078,7 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Append an long value. This increases the array's length by one.
      *
-     * @param value
-     *            A long value.
+     * @param value A long value.
      * @return this.
      */
     public JSONArray put(long value) {
@@ -1218,16 +1086,12 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Put a value in the JSONArray, where the value will be a JSONObject which
-     * is produced from a Map.
+     * Put a value in the JSONArray, where the value will be a JSONObject which is produced from a Map.
      *
-     * @param value
-     *            A Map value.
+     * @param value A Map value.
      * @return this.
-     * @throws JSONException
-     *            If a value in the map is non-finite number.
-     * @throws NullPointerException
-     *            If a key in the map is <code>null</code>
+     * @throws JSONException        If a value in the map is non-finite number.
+     * @throws NullPointerException If a key in the map is <code>null</code>
      */
     public JSONArray put(Map<?, ?> value) {
         return this.put(new JSONObject(value));
@@ -1236,13 +1100,10 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Append an object value. This increases the array's length by one.
      *
-     * @param value
-     *            An object value. The value should be a Boolean, Double,
-     *            Integer, JSONArray, JSONObject, Long, or String, or the
-     *            JSONObject.NULL object.
+     * @param value An object value. The value should be a Boolean, Double, Integer, JSONArray, JSONObject, Long, or
+     *              String, or the JSONObject.NULL object.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
+     * @throws JSONException If the value is non-finite number.
      */
     public JSONArray put(Object value) {
         JSONObject.testValidity(value);
@@ -1251,121 +1112,90 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Put or replace a boolean value in the JSONArray. If the index is greater
-     * than the length of the JSONArray, then null elements will be added as
-     * necessary to pad it out.
+     * Put or replace a boolean value in the JSONArray. If the index is greater than the length of the JSONArray, then
+     * null elements will be added as necessary to pad it out.
      *
-     * @param index
-     *            The subscript.
-     * @param value
-     *            A boolean value.
+     * @param index The subscript.
+     * @param value A boolean value.
      * @return this.
-     * @throws JSONException
-     *             If the index is negative.
+     * @throws JSONException If the index is negative.
      */
     public JSONArray put(int index, boolean value) throws JSONException {
         return this.put(index, value ? Boolean.TRUE : Boolean.FALSE);
     }
 
     /**
-     * Put a value in the JSONArray, where the value will be a JSONArray which
-     * is produced from a Collection.
+     * Put a value in the JSONArray, where the value will be a JSONArray which is produced from a Collection.
      *
-     * @param index
-     *            The subscript.
-     * @param value
-     *            A Collection value.
+     * @param index The subscript.
+     * @param value A Collection value.
      * @return this.
-     * @throws JSONException
-     *             If the index is negative or if the value is non-finite.
+     * @throws JSONException If the index is negative or if the value is non-finite.
      */
     public JSONArray put(int index, Collection<?> value) throws JSONException {
         return this.put(index, new JSONArray(value));
     }
 
     /**
-     * Put or replace a double value. If the index is greater than the length of
-     * the JSONArray, then null elements will be added as necessary to pad it
-     * out.
+     * Put or replace a double value. If the index is greater than the length of the JSONArray, then null elements will
+     * be added as necessary to pad it out.
      *
-     * @param index
-     *            The subscript.
-     * @param value
-     *            A double value.
+     * @param index The subscript.
+     * @param value A double value.
      * @return this.
-     * @throws JSONException
-     *             If the index is negative or if the value is non-finite.
+     * @throws JSONException If the index is negative or if the value is non-finite.
      */
     public JSONArray put(int index, double value) throws JSONException {
         return this.put(index, Double.valueOf(value));
     }
 
     /**
-     * Put or replace a float value. If the index is greater than the length of
-     * the JSONArray, then null elements will be added as necessary to pad it
-     * out.
+     * Put or replace a float value. If the index is greater than the length of the JSONArray, then null elements will
+     * be added as necessary to pad it out.
      *
-     * @param index
-     *            The subscript.
-     * @param value
-     *            A float value.
+     * @param index The subscript.
+     * @param value A float value.
      * @return this.
-     * @throws JSONException
-     *             If the index is negative or if the value is non-finite.
+     * @throws JSONException If the index is negative or if the value is non-finite.
      */
     public JSONArray put(int index, float value) throws JSONException {
         return this.put(index, Float.valueOf(value));
     }
 
     /**
-     * Put or replace an int value. If the index is greater than the length of
-     * the JSONArray, then null elements will be added as necessary to pad it
-     * out.
+     * Put or replace an int value. If the index is greater than the length of the JSONArray, then null elements will be
+     * added as necessary to pad it out.
      *
-     * @param index
-     *            The subscript.
-     * @param value
-     *            An int value.
+     * @param index The subscript.
+     * @param value An int value.
      * @return this.
-     * @throws JSONException
-     *             If the index is negative.
+     * @throws JSONException If the index is negative.
      */
     public JSONArray put(int index, int value) throws JSONException {
         return this.put(index, Integer.valueOf(value));
     }
 
     /**
-     * Put or replace a long value. If the index is greater than the length of
-     * the JSONArray, then null elements will be added as necessary to pad it
-     * out.
+     * Put or replace a long value. If the index is greater than the length of the JSONArray, then null elements will be
+     * added as necessary to pad it out.
      *
-     * @param index
-     *            The subscript.
-     * @param value
-     *            A long value.
+     * @param index The subscript.
+     * @param value A long value.
      * @return this.
-     * @throws JSONException
-     *             If the index is negative.
+     * @throws JSONException If the index is negative.
      */
     public JSONArray put(int index, long value) throws JSONException {
         return this.put(index, Long.valueOf(value));
     }
 
     /**
-     * Put a value in the JSONArray, where the value will be a JSONObject that
-     * is produced from a Map.
+     * Put a value in the JSONArray, where the value will be a JSONObject that is produced from a Map.
      *
-     * @param index
-     *            The subscript.
-     * @param value
-     *            The Map value.
-     * @return
-     *             reference to self
-     * @throws JSONException
-     *             If the index is negative or if the value is an invalid
-     *             number.
-     * @throws NullPointerException
-     *             If a key in the map is <code>null</code>
+     * @param index The subscript.
+     * @param value The Map value.
+     * @return reference to self
+     * @throws JSONException        If the index is negative or if the value is an invalid number.
+     * @throws NullPointerException If a key in the map is <code>null</code>
      */
     public JSONArray put(int index, Map<?, ?> value) throws JSONException {
         this.put(index, new JSONObject(value, new JSONParserConfiguration()));
@@ -1373,40 +1203,29 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Put a value in the JSONArray, where the value will be a JSONObject that
-     * is produced from a Map.
+     * Put a value in the JSONArray, where the value will be a JSONObject that is produced from a Map.
      *
-     * @param index
-     *          The subscript
-     * @param value
-     *          The Map value.
-     * @param jsonParserConfiguration
-     *          Configuration object for the JSON parser
+     * @param index                   The subscript
+     * @param value                   The Map value.
+     * @param jsonParserConfiguration Configuration object for the JSON parser
      * @return reference to self
-     * @throws JSONException
-     *          If the index is negative or if the value is an invalid
-     *          number.
+     * @throws JSONException If the index is negative or if the value is an invalid number.
      */
-    public JSONArray put(int index, Map<?, ?> value, JSONParserConfiguration jsonParserConfiguration) throws JSONException {
+    public JSONArray put(int index, Map<?, ?> value, JSONParserConfiguration jsonParserConfiguration)
+        throws JSONException {
         this.put(index, new JSONObject(value, jsonParserConfiguration));
         return this;
     }
 
     /**
-     * Put or replace an object value in the JSONArray. If the index is greater
-     * than the length of the JSONArray, then null elements will be added as
-     * necessary to pad it out.
+     * Put or replace an object value in the JSONArray. If the index is greater than the length of the JSONArray, then
+     * null elements will be added as necessary to pad it out.
      *
-     * @param index
-     *            The subscript.
-     * @param value
-     *            The value to put into the array. The value should be a
-     *            Boolean, Double, Integer, JSONArray, JSONObject, Long, or
-     *            String, or the JSONObject.NULL object.
+     * @param index The subscript.
+     * @param value The value to put into the array. The value should be a Boolean, Double, Integer, JSONArray,
+     *              JSONObject, Long, or String, or the JSONObject.NULL object.
      * @return this.
-     * @throws JSONException
-     *             If the index is negative or if the value is an invalid
-     *             number.
+     * @throws JSONException If the index is negative or if the value is an invalid number.
      */
     public JSONArray put(int index, Object value) throws JSONException {
         if (index < 0) {
@@ -1417,7 +1236,7 @@ public class JSONArray implements Iterable<Object> {
             this.myArrayList.set(index, value);
             return this;
         }
-        if(index == this.length()){
+        if (index == this.length()) {
             // simple append
             return this.put(value);
         }
@@ -1434,21 +1253,19 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Put a collection's elements in to the JSONArray.
      *
-     * @param collection
-     *            A Collection.
-     * @return this. 
+     * @param collection A Collection.
+     * @return this.
      */
     public JSONArray putAll(Collection<?> collection) {
         this.addAll(collection, false);
         return this;
     }
-    
+
     /**
      * Put an Iterable's elements in to the JSONArray.
      *
-     * @param iter
-     *            An Iterable.
-     * @return this. 
+     * @param iter An Iterable.
+     * @return this.
      */
     public JSONArray putAll(Iterable<?> iter) {
         this.addAll(iter, false);
@@ -1458,9 +1275,8 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Put a JSONArray's elements in to the JSONArray.
      *
-     * @param array
-     *            A JSONArray.
-     * @return this. 
+     * @param array A JSONArray.
+     * @return this.
      */
     public JSONArray putAll(JSONArray array) {
         // directly copy the elements from the source array to this one
@@ -1472,36 +1288,30 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Put an array's elements in to the JSONArray.
      *
-     * @param array
-     *            Array. If the parameter passed is null, or not an array or Iterable, an
-     *            exception will be thrown.
-     * @return this. 
-     *
-     * @throws JSONException
-     *            If not an array, JSONArray, Iterable or if an value is non-finite number.
-     * @throws NullPointerException
-     *            Thrown if the array parameter is null.
+     * @param array Array. If the parameter passed is null, or not an array or Iterable, an exception will be thrown.
+     * @return this.
+     * @throws JSONException        If not an array, JSONArray, Iterable or if an value is non-finite number.
+     * @throws NullPointerException Thrown if the array parameter is null.
      */
     public JSONArray putAll(Object array) throws JSONException {
         this.addAll(array, false);
         return this;
     }
-    
+
     /**
-     * Creates a JSONPointer using an initialization string and tries to 
-     * match it to an item within this JSONArray. For example, given a
-     * JSONArray initialized with this document:
+     * Creates a JSONPointer using an initialization string and tries to match it to an item within this JSONArray. For
+     * example, given a JSONArray initialized with this document:
      * <pre>
      * [
      *     {"b":"c"}
      * ]
      * </pre>
-     * and this JSONPointer string: 
+     * and this JSONPointer string:
      * <pre>
      * "/0/b"
      * </pre>
-     * Then this method will return the String "c"
-     * A JSONPointerException may be thrown from code called by this method.
+     * Then this method will return the String "c" A JSONPointerException may be thrown from code called by this
+     * method.
      *
      * @param jsonPointer string that can be used to create a JSONPointer
      * @return the item matched by the JSONPointer, otherwise null
@@ -1509,22 +1319,21 @@ public class JSONArray implements Iterable<Object> {
     public Object query(String jsonPointer) {
         return query(new JSONPointer(jsonPointer));
     }
-    
+
     /**
-     * Uses a user initialized JSONPointer  and tries to 
-     * match it to an item within this JSONArray. For example, given a
+     * Uses a user initialized JSONPointer  and tries to match it to an item within this JSONArray. For example, given a
      * JSONArray initialized with this document:
      * <pre>
      * [
      *     {"b":"c"}
      * ]
      * </pre>
-     * and this JSONPointer: 
+     * and this JSONPointer:
      * <pre>
      * "/0/b"
      * </pre>
-     * Then this method will return the String "c"
-     * A JSONPointerException may be thrown from code called by this method.
+     * Then this method will return the String "c" A JSONPointerException may be thrown from code called by this
+     * method.
      *
      * @param jsonPointer string that can be used to create a JSONPointer
      * @return the item matched by the JSONPointer, otherwise null
@@ -1532,23 +1341,23 @@ public class JSONArray implements Iterable<Object> {
     public Object query(JSONPointer jsonPointer) {
         return jsonPointer.queryFrom(this);
     }
-    
+
     /**
-     * Queries and returns a value from this object using {@code jsonPointer}, or
-     * returns null if the query fails due to a missing key.
-     * 
+     * Queries and returns a value from this object using {@code jsonPointer}, or returns null if the query fails due to
+     * a missing key.
+     *
      * @param jsonPointer the string representation of the JSON pointer
      * @return the queried value or {@code null}
      * @throws IllegalArgumentException if {@code jsonPointer} has invalid syntax
      */
     public Object optQuery(String jsonPointer) {
-    	return optQuery(new JSONPointer(jsonPointer));
+        return optQuery(new JSONPointer(jsonPointer));
     }
-    
+
     /**
-     * Queries and returns a value from this object using {@code jsonPointer}, or
-     * returns null if the query fails due to a missing key.
-     * 
+     * Queries and returns a value from this object using {@code jsonPointer}, or returns null if the query fails due to
+     * a missing key.
+     *
      * @param jsonPointer The JSON pointer
      * @return the queried value or {@code null}
      * @throws IllegalArgumentException if {@code jsonPointer} has invalid syntax
@@ -1564,10 +1373,8 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Remove an index and close the hole.
      *
-     * @param index
-     *            The index of the element to be removed.
-     * @return The value that was associated with the index, or null if there
-     *         was no value.
+     * @param index The index of the element to be removed.
+     * @return The value that was associated with the index, or null if there was no value.
      */
     public Object remove(int index) {
         return index >= 0 && index < this.length()
@@ -1576,8 +1383,7 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Determine if two JSONArrays are similar.
-     * They must contain similar sequences.
+     * Determine if two JSONArrays are similar. They must contain similar sequences.
      *
      * @param other The other JSONArray
      * @return true if they are equal
@@ -1587,29 +1393,29 @@ public class JSONArray implements Iterable<Object> {
             return false;
         }
         int len = this.length();
-        if (len != ((JSONArray)other).length()) {
+        if (len != ((JSONArray) other).length()) {
             return false;
         }
         for (int i = 0; i < len; i += 1) {
             Object valueThis = this.myArrayList.get(i);
-            Object valueOther = ((JSONArray)other).myArrayList.get(i);
-            if(valueThis == valueOther) {
-            	continue;
+            Object valueOther = ((JSONArray) other).myArrayList.get(i);
+            if (valueThis == valueOther) {
+                continue;
             }
-            if(valueThis == null) {
-            	return false;
+            if (valueThis == null) {
+                return false;
             }
             if (valueThis instanceof JSONObject) {
-                if (!((JSONObject)valueThis).similar(valueOther)) {
+                if (!((JSONObject) valueThis).similar(valueOther)) {
                     return false;
                 }
             } else if (valueThis instanceof JSONArray) {
-                if (!((JSONArray)valueThis).similar(valueOther)) {
+                if (!((JSONArray) valueThis).similar(valueOther)) {
                     return false;
                 }
             } else if (valueThis instanceof Number && valueOther instanceof Number) {
-                if (!JSONObject.isNumberSimilar((Number)valueThis, (Number)valueOther)) {
-                	return false;
+                if (!JSONObject.isNumberSimilar((Number) valueThis, (Number) valueOther)) {
+                    return false;
                 }
             } else if (valueThis instanceof JSONString && valueOther instanceof JSONString) {
                 if (!((JSONString) valueThis).toJSONString().equals(((JSONString) valueOther).toJSONString())) {
@@ -1623,16 +1429,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Produce a JSONObject by combining a JSONArray of names with the values of
-     * this JSONArray.
+     * Produce a JSONObject by combining a JSONArray of names with the values of this JSONArray.
      *
-     * @param names
-     *            A JSONArray containing a list of key strings. These will be
-     *            paired with the values.
-     * @return A JSONObject, or null if there are no names or if this JSONArray
-     *         has no values.
-     * @throws JSONException
-     *             If any of the names are null.
+     * @param names A JSONArray containing a list of key strings. These will be paired with the values.
+     * @return A JSONObject, or null if there are no names or if this JSONArray has no values.
+     * @throws JSONException If any of the names are null.
      */
     public JSONObject toJSONObject(JSONArray names) throws JSONException {
         if (names == null || names.isEmpty() || this.isEmpty()) {
@@ -1646,16 +1447,14 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Make a JSON text of this JSONArray. For compactness, no unnecessary
-     * whitespace is added. If it is not possible to produce a syntactically
-     * correct JSON text then null will be returned instead. This could occur if
-     * the array contains an invalid number.
+     * Make a JSON text of this JSONArray. For compactness, no unnecessary whitespace is added. If it is not possible to
+     * produce a syntactically correct JSON text then null will be returned instead. This could occur if the array
+     * contains an invalid number.
      * <p><b>
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
      *
-     * @return a printable, displayable, transmittable representation of the
-     *         array.
+     * @return a printable, displayable, transmittable representation of the array.
      */
     @Override
     public String toString() {
@@ -1668,58 +1467,11 @@ public class JSONArray implements Iterable<Object> {
 
     /**
      * Make a pretty-printed JSON text of this JSONArray.
-     * 
+     *
      * <p>If <pre> {@code indentFactor > 0}</pre> and the {@link JSONArray} has only
      * one element, then the array will be output on a single line:
      * <pre>{@code [1]}</pre>
-     * 
-     * <p>If an array has 2 or more elements, then it will be output across
-     * multiple lines: <pre>{@code
-     * [
-     * 1,
-     * "value 2",
-     * 3
-     * ]
-     * }</pre>
-     * <p><b>
-     * Warning: This method assumes that the data structure is acyclical.
-     * </b>
-     * 
-     * @param indentFactor
-     *            The number of spaces to add to each level of indentation.
-     * @return a printable, displayable, transmittable representation of the
-     *         object, beginning with <code>[</code>&nbsp;<small>(left
-     *         bracket)</small> and ending with <code>]</code>
-     *         &nbsp;<small>(right bracket)</small>.
-     * @throws JSONException if a called function fails
-     */
-    @SuppressWarnings("resource")
-    public String toString(int indentFactor) throws JSONException {
-        StringWriter sw = new StringWriter();
-        return this.write(sw, indentFactor, 0).toString();
-    }
-
-    /**
-     * Write the contents of the JSONArray as JSON text to a writer. For
-     * compactness, no whitespace is added.
-     * <p><b>
-     * Warning: This method assumes that the data structure is acyclical.
-     *</b>
-     * @param writer the writer object
-     * @return The writer.
-     * @throws JSONException if a called function fails
-     */
-    public Writer write(Writer writer) throws JSONException {
-        return this.write(writer, 0, 0);
-    }
-
-    /**
-     * Write the contents of the JSONArray as JSON text to a writer.
-     * 
-     * <p>If <pre>{@code indentFactor > 0}</pre> and the {@link JSONArray} has only
-     * one element, then the array will be output on a single line:
-     * <pre>{@code [1]}</pre>
-     * 
+     *
      * <p>If an array has 2 or more elements, then it will be output across
      * multiple lines: <pre>{@code
      * [
@@ -1732,18 +1484,60 @@ public class JSONArray implements Iterable<Object> {
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
      *
-     * @param writer
-     *            Writes the serialized JSON
-     * @param indentFactor
-     *            The number of spaces to add to each level of indentation.
-     * @param indent
-     *            The indentation of the top level.
+     * @param indentFactor The number of spaces to add to each level of indentation.
+     * @return a printable, displayable, transmittable representation of the object, beginning with
+     * <code>[</code>&nbsp;<small>(left bracket)</small> and ending with <code>]</code> &nbsp;<small>(right
+     * bracket)</small>.
+     * @throws JSONException if a called function fails
+     */
+    @SuppressWarnings("resource")
+    public String toString(int indentFactor) throws JSONException {
+        StringWriter sw = new StringWriter();
+        return this.write(sw, indentFactor, 0).toString();
+    }
+
+    /**
+     * Write the contents of the JSONArray as JSON text to a writer. For compactness, no whitespace is added.
+     * <p><b>
+     * Warning: This method assumes that the data structure is acyclical.
+     * </b>
+     *
+     * @param writer the writer object
+     * @return The writer.
+     * @throws JSONException if a called function fails
+     */
+    public Writer write(Writer writer) throws JSONException {
+        return this.write(writer, 0, 0);
+    }
+
+    /**
+     * Write the contents of the JSONArray as JSON text to a writer.
+     *
+     * <p>If <pre>{@code indentFactor > 0}</pre> and the {@link JSONArray} has only
+     * one element, then the array will be output on a single line:
+     * <pre>{@code [1]}</pre>
+     *
+     * <p>If an array has 2 or more elements, then it will be output across
+     * multiple lines: <pre>{@code
+     * [
+     * 1,
+     * "value 2",
+     * 3
+     * ]
+     * }</pre>
+     * <p><b>
+     * Warning: This method assumes that the data structure is acyclical.
+     * </b>
+     *
+     * @param writer       Writes the serialized JSON
+     * @param indentFactor The number of spaces to add to each level of indentation.
+     * @param indent       The indentation of the top level.
      * @return The writer.
      * @throws JSONException if a called function fails or unable to write
      */
     @SuppressWarnings("resource")
     public Writer write(Writer writer, int indentFactor, int indent)
-            throws JSONException {
+        throws JSONException {
         try {
             boolean needsComma = false;
             int length = this.length();
@@ -1752,7 +1546,7 @@ public class JSONArray implements Iterable<Object> {
             if (length == 1) {
                 try {
                     JSONObject.writeValue(writer, this.myArrayList.get(0),
-                            indentFactor, indent);
+                        indentFactor, indent);
                 } catch (Exception e) {
                     throw new JSONException("Unable to write JSONArray value at index: 0", e);
                 }
@@ -1769,7 +1563,7 @@ public class JSONArray implements Iterable<Object> {
                     JSONObject.indent(writer, newIndent);
                     try {
                         JSONObject.writeValue(writer, this.myArrayList.get(i),
-                                indentFactor, newIndent);
+                            indentFactor, newIndent);
                     } catch (Exception e) {
                         throw new JSONException("Unable to write JSONArray value at index: " + i, e);
                     }
@@ -1788,9 +1582,8 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Returns a java.util.List containing all of the elements in this array.
-     * If an element in the array is a JSONArray or JSONObject it will also
-     * be converted to a List and a Map respectively.
+     * Returns a java.util.List containing all of the elements in this array. If an element in the array is a JSONArray
+     * or JSONObject it will also be converted to a List and a Map respectively.
      * <p>
      * Warning: This method assumes that the data structure is acyclical.
      *
@@ -1824,22 +1617,20 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Add a collection's elements to the JSONArray.
      *
-     * @param collection
-     *            A Collection.
-     * @param wrap
-     *            {@code true} to call {@link JSONObject#wrap(Object)} for each item,
-     *            {@code false} to add the items directly
-     * @param recursionDepth
-     *            Variable for tracking the count of nested object creations.
+     * @param collection     A Collection.
+     * @param wrap           {@code true} to call {@link JSONObject#wrap(Object)} for each item, {@code false} to add
+     *                       the items directly
+     * @param recursionDepth Variable for tracking the count of nested object creations.
      */
-    private void addAll(Collection<?> collection, boolean wrap, int recursionDepth, JSONParserConfiguration jsonParserConfiguration) {
+    private void addAll(Collection<?> collection, boolean wrap, int recursionDepth,
+        JSONParserConfiguration jsonParserConfiguration) {
         this.myArrayList.ensureCapacity(this.myArrayList.size() + collection.size());
         if (wrap) {
-            for (Object o: collection){
+            for (Object o : collection) {
                 this.put(JSONObject.wrap(o, recursionDepth + 1, jsonParserConfiguration));
             }
         } else {
-            for (Object o: collection){
+            for (Object o : collection) {
                 this.put(o);
             }
         }
@@ -1848,19 +1639,17 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Add an Iterable's elements to the JSONArray.
      *
-     * @param iter
-     *            An Iterable.
-     * @param wrap
-     *            {@code true} to call {@link JSONObject#wrap(Object)} for each item,
-     *            {@code false} to add the items directly
+     * @param iter An Iterable.
+     * @param wrap {@code true} to call {@link JSONObject#wrap(Object)} for each item, {@code false} to add the items
+     *             directly
      */
     private void addAll(Iterable<?> iter, boolean wrap) {
         if (wrap) {
-            for (Object o: iter){
+            for (Object o : iter) {
                 this.put(JSONObject.wrap(o));
             }
         } else {
-            for (Object o: iter){
+            for (Object o : iter) {
                 this.put(o);
             }
         }
@@ -1869,56 +1658,43 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Add an array's elements to the JSONArray.
      *
-     * @param array
-     *          Array. If the parameter passed is null, or not an array,
-     *          JSONArray, Collection, or Iterable, an exception will be
-     *          thrown.
-     * @param wrap
-     *          {@code true} to call {@link JSONObject#wrap(Object)} for each item,
-     *          {@code false} to add the items directly
-     * @throws JSONException
-     *          If not an array or if an array value is non-finite number.
+     * @param array Array. If the parameter passed is null, or not an array, JSONArray, Collection, or Iterable, an
+     *              exception will be thrown.
+     * @param wrap  {@code true} to call {@link JSONObject#wrap(Object)} for each item, {@code false} to add the items
+     *              directly
+     * @throws JSONException If not an array or if an array value is non-finite number.
      */
     private void addAll(Object array, boolean wrap) throws JSONException {
-      this.addAll(array, wrap, 0);
+        this.addAll(array, wrap, 0);
     }
 
     /**
      * Add an array's elements to the JSONArray.
      *
-     * @param array
-     *            Array. If the parameter passed is null, or not an array,
-     *            JSONArray, Collection, or Iterable, an exception will be
-     *            thrown.
-     * @param wrap
-     *          {@code true} to call {@link JSONObject#wrap(Object)} for each item,
-     *          {@code false} to add the items directly
-     * @param recursionDepth
-     *          Variable for tracking the count of nested object creations.
+     * @param array          Array. If the parameter passed is null, or not an array, JSONArray, Collection, or
+     *                       Iterable, an exception will be thrown.
+     * @param wrap           {@code true} to call {@link JSONObject#wrap(Object)} for each item, {@code false} to add
+     *                       the items directly
+     * @param recursionDepth Variable for tracking the count of nested object creations.
      */
     private void addAll(Object array, boolean wrap, int recursionDepth) {
         addAll(array, wrap, recursionDepth, new JSONParserConfiguration());
     }
+
     /**
-     * Add an array's elements to the JSONArray.
-     *`
-     * @param array
-     *            Array. If the parameter passed is null, or not an array,
-     *            JSONArray, Collection, or Iterable, an exception will be
-     *            thrown.
-     * @param wrap
-     *            {@code true} to call {@link JSONObject#wrap(Object)} for each item,
-     *            {@code false} to add the items directly
-     * @param recursionDepth
-     *            Variable for tracking the count of nested object creations.
-     * @param jsonParserConfiguration
-     *            Variable to pass parser custom configuration for json parsing.
-     * @throws JSONException
-     *            If not an array or if an array value is non-finite number.
-     * @throws NullPointerException
-     *            Thrown if the array parameter is null.
+     * Add an array's elements to the JSONArray. `
+     *
+     * @param array                   Array. If the parameter passed is null, or not an array, JSONArray, Collection, or
+     *                                Iterable, an exception will be thrown.
+     * @param wrap                    {@code true} to call {@link JSONObject#wrap(Object)} for each item, {@code false}
+     *                                to add the items directly
+     * @param recursionDepth          Variable for tracking the count of nested object creations.
+     * @param jsonParserConfiguration Variable to pass parser custom configuration for json parsing.
+     * @throws JSONException        If not an array or if an array value is non-finite number.
+     * @throws NullPointerException Thrown if the array parameter is null.
      */
-    private void addAll(Object array, boolean wrap, int recursionDepth, JSONParserConfiguration jsonParserConfiguration) throws JSONException {
+    private void addAll(Object array, boolean wrap, int recursionDepth, JSONParserConfiguration jsonParserConfiguration)
+        throws JSONException {
         if (array.getClass().isArray()) {
             int length = Array.getLength(array);
             this.myArrayList.ensureCapacity(this.myArrayList.size() + length);
@@ -1935,43 +1711,44 @@ public class JSONArray implements Iterable<Object> {
             // use the built in array list `addAll` as all object
             // wrapping should have been completed in the original
             // JSONArray
-            this.myArrayList.addAll(((JSONArray)array).myArrayList);
+            this.myArrayList.addAll(((JSONArray) array).myArrayList);
         } else if (array instanceof Collection) {
-            this.addAll((Collection<?>)array, wrap, recursionDepth);
+            this.addAll((Collection<?>) array, wrap, recursionDepth);
         } else if (array instanceof Iterable) {
-            this.addAll((Iterable<?>)array, wrap);
+            this.addAll((Iterable<?>) array, wrap);
         } else {
             throw new JSONException(
-                    "JSONArray initial value should be a string or collection or array.");
+                "JSONArray initial value should be a string or collection or array.");
         }
     }
-    
+
     /**
      * Create a new JSONException in a common format for incorrect conversions.
-     * @param idx index of the item
+     *
+     * @param idx       index of the item
      * @param valueType the type of value being coerced to
-     * @param cause optional cause of the coercion failure
+     * @param cause     optional cause of the coercion failure
      * @return JSONException that can be thrown.
      */
     private static JSONException wrongValueFormatException(
-            int idx,
-            String valueType,
-            Object value,
-            Throwable cause) {
-        if(value == null) {
+        int idx,
+        String valueType,
+        Object value,
+        Throwable cause) {
+        if (value == null) {
             return new JSONException(
-                    "JSONArray[" + idx + "] is not a " + valueType + " (null)."
-                    , cause);
+                "JSONArray[" + idx + "] is not a " + valueType + " (null)."
+                , cause);
         }
         // don't try to toString collections or known object types that could be large.
-        if(value instanceof Map || value instanceof Iterable || value instanceof JSONObject) {
+        if (value instanceof Map || value instanceof Iterable || value instanceof JSONObject) {
             return new JSONException(
-                    "JSONArray[" + idx + "] is not a " + valueType + " (" + value.getClass() + ")."
-                    , cause);
+                "JSONArray[" + idx + "] is not a " + valueType + " (" + value.getClass() + ")."
+                , cause);
         }
         return new JSONException(
-                "JSONArray[" + idx + "] is not a " + valueType + " (" + value.getClass() + " : " + value + ")."
-                , cause);
+            "JSONArray[" + idx + "] is not a " + valueType + " (" + value.getClass() + " : " + value + ")."
+            , cause);
     }
 
 }

--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -18,10 +18,11 @@ import java.util.Map;
 
 
 /**
- * A JSONArray is an ordered sequence of values. Its external text form is a string wrapped in square brackets with
- * commas separating the values. The internal form is an object having <code>get</code> and <code>opt</code> methods for
- * accessing the values by index, and <code>put</code> methods for adding or replacing values. The values can be any of
- * these types:
+ * A JSONArray is an ordered sequence of values. Its external text form is a
+ * string wrapped in square brackets with commas separating the values. The
+ * internal form is an object having <code>get</code> and <code>opt</code>
+ * methods for accessing the values by index, and <code>put</code> methods for
+ * adding or replacing values. The values can be any of these types:
  * <code>Boolean</code>, <code>JSONArray</code>, <code>JSONObject</code>,
  * <code>Number</code>, <code>String</code>, or the
  * <code>JSONObject.NULL object</code>.
@@ -29,17 +30,19 @@ import java.util.Map;
  * The constructor can convert a JSON text into a Java object. The
  * <code>toString</code> method converts to JSON text.
  * <p>
- * A <code>get</code> method returns a value if one can be found, and throws an exception if one cannot be found. An
- * <code>opt</code> method returns a default value instead of throwing an exception, and so is useful for obtaining
- * optional values.
+ * A <code>get</code> method returns a value if one can be found, and throws an
+ * exception if one cannot be found. An <code>opt</code> method returns a
+ * default value instead of throwing an exception, and so is useful for
+ * obtaining optional values.
  * <p>
- * The generic <code>get()</code> and <code>opt()</code> methods return an object which you can cast or query for type.
- * There are also typed
+ * The generic <code>get()</code> and <code>opt()</code> methods return an
+ * object which you can cast or query for type. There are also typed
  * <code>get</code> and <code>opt</code> methods that do type checking and type
  * coercion for you.
  * <p>
- * The texts produced by the <code>toString</code> methods strictly conform to JSON syntax rules. The constructors are
- * more forgiving in the texts they will accept:
+ * The texts produced by the <code>toString</code> methods strictly conform to
+ * JSON syntax rules. The constructors are more forgiving in the texts they will
+ * accept:
  * <ul>
  * <li>An extra <code>,</code>&nbsp;<small>(comma)</small> may appear just
  * before the closing bracket.</li>
@@ -105,7 +108,7 @@ public class JSONArray implements Iterable<Object> {
         }
         if (nextChar != ']') {
             x.back();
-            for (; ; ) {
+            for (;;) {
                 if (x.nextClean() == ',') {
                     x.back();
                     this.myArrayList.add(JSONObject.NULL);
@@ -151,14 +154,25 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Construct a JSONArray from a source JSON text.
      *
-     * @param source A string that begins with <code>[</code>&nbsp;<small>(left bracket)</small> and ends with
-     *               <code>]</code> &nbsp;<small>(right bracket)</small>.
-     * @throws JSONException If there is a syntax error.
+     * @param source
+     *            A string that begins with <code>[</code>&nbsp;<small>(left
+     *            bracket)</small> and ends with <code>]</code>
+     *            &nbsp;<small>(right bracket)</small>.
+     * @throws JSONException
+     *             If there is a syntax error.
      */
     public JSONArray(String source) throws JSONException {
         this(new JSONTokener(source), new JSONParserConfiguration());
     }
 
+    /**
+     * Constructs a JSONArray from a source JSON text and a JSONParserConfiguration.
+     *
+     * @param source                  A string that begins with <code>[</code>&nbsp;<small>(left bracket)</small> and
+     *                                ends with <code>]</code> &nbsp;<small>(right bracket)</small>.
+     * @param jsonParserConfiguration A JSONParserConfiguration instance that controls the behavior of the parser.
+     * @throws JSONException If there is a syntax error.
+     */
     public JSONArray(String source, JSONParserConfiguration jsonParserConfiguration) throws JSONException {
         this(new JSONTokener(source), jsonParserConfiguration);
     }
@@ -166,17 +180,20 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Construct a JSONArray from a Collection.
      *
-     * @param collection A Collection.
+     * @param collection
+     *            A Collection.
      */
     public JSONArray(Collection<?> collection) {
-        this(collection, 0, new JSONParserConfiguration());
+      this(collection, 0, new JSONParserConfiguration());
     }
 
     /**
      * Construct a JSONArray from a Collection.
      *
-     * @param collection              A Collection.
-     * @param jsonParserConfiguration Configuration object for the JSON parser
+     * @param collection
+     *            A Collection.
+     * @param jsonParserConfiguration
+     *            Configuration object for the JSON parser
      */
     public JSONArray(Collection<?> collection, JSONParserConfiguration jsonParserConfiguration) {
         this(collection, 0, jsonParserConfiguration);
@@ -185,14 +202,16 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Construct a JSONArray from a collection with recursion depth.
      *
-     * @param collection              A Collection.
-     * @param recursionDepth          Variable for tracking the count of nested object creations.
-     * @param jsonParserConfiguration Configuration object for the JSON parser
+     * @param collection
+     *             A Collection.
+     * @param recursionDepth
+     *             Variable for tracking the count of nested object creations.
+     * @param jsonParserConfiguration
+     *             Configuration object for the JSON parser
      */
     JSONArray(Collection<?> collection, int recursionDepth, JSONParserConfiguration jsonParserConfiguration) {
         if (recursionDepth > jsonParserConfiguration.getMaxNestingDepth()) {
-            throw new JSONException(
-                "JSONArray has reached recursion depth limit of " + jsonParserConfiguration.getMaxNestingDepth());
+          throw new JSONException("JSONArray has reached recursion depth limit of " + jsonParserConfiguration.getMaxNestingDepth());
         }
         if (collection == null) {
             this.myArrayList = new ArrayList<Object>();
@@ -205,7 +224,8 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Construct a JSONArray from an Iterable. This is a shallow copy.
      *
-     * @param iter A Iterable collection.
+     * @param iter
+     *            A Iterable collection.
      */
     public JSONArray(Iterable<?> iter) {
         this();
@@ -218,7 +238,8 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Construct a JSONArray from another JSONArray. This is a shallow copy.
      *
-     * @param array A array.
+     * @param array
+     *            A array.
      */
     public JSONArray(JSONArray array) {
         if (array == null) {
@@ -233,15 +254,20 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Construct a JSONArray from an array.
      *
-     * @param array Array. If the parameter passed is null, or not an array, an exception will be thrown.
-     * @throws JSONException        If not an array or if an array value is non-finite number.
-     * @throws NullPointerException Thrown if the array parameter is null.
+     * @param array
+     *            Array. If the parameter passed is null, or not an array, an
+     *            exception will be thrown.
+     *
+     * @throws JSONException
+     *            If not an array or if an array value is non-finite number.
+     * @throws NullPointerException
+     *            Thrown if the array parameter is null.
      */
     public JSONArray(Object array) throws JSONException {
         this();
         if (!array.getClass().isArray()) {
             throw new JSONException(
-                "JSONArray initial value should be a string or collection or array.");
+                    "JSONArray initial value should be a string or collection or array.");
         }
         this.addAll(array, true, 0);
     }
@@ -249,15 +275,17 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Construct a JSONArray with the specified initial capacity.
      *
-     * @param initialCapacity the initial capacity of the JSONArray.
-     * @throws JSONException If the initial capacity is negative.
+     * @param initialCapacity
+     *            the initial capacity of the JSONArray.
+     * @throws JSONException
+     *             If the initial capacity is negative.
      */
     public JSONArray(int initialCapacity) throws JSONException {
-        if (initialCapacity < 0) {
+    	if (initialCapacity < 0) {
             throw new JSONException(
-                "JSONArray initial capacity cannot be negative.");
-        }
-        this.myArrayList = new ArrayList<Object>(initialCapacity);
+                    "JSONArray initial capacity cannot be negative.");
+    	}
+    	this.myArrayList = new ArrayList<Object>(initialCapacity);
     }
 
     @Override
@@ -268,9 +296,11 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the object value associated with an index.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return An object value.
-     * @throws JSONException If there is no value for the index.
+     * @throws JSONException
+     *             If there is no value for the index.
      */
     public Object get(int index) throws JSONException {
         Object object = this.opt(index);
@@ -281,21 +311,25 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the boolean value associated with an index. The string values "true" and "false" are converted to boolean.
+     * Get the boolean value associated with an index. The string values "true"
+     * and "false" are converted to boolean.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The truth.
-     * @throws JSONException If there is no value for the index or if the value is not convertible to boolean.
+     * @throws JSONException
+     *             If there is no value for the index or if the value is not
+     *             convertible to boolean.
      */
     public boolean getBoolean(int index) throws JSONException {
         Object object = this.get(index);
         if (object.equals(Boolean.FALSE)
-            || (object instanceof String && ((String) object)
-            .equalsIgnoreCase("false"))) {
+                || (object instanceof String && ((String) object)
+                        .equalsIgnoreCase("false"))) {
             return false;
         } else if (object.equals(Boolean.TRUE)
-            || (object instanceof String && ((String) object)
-            .equalsIgnoreCase("true"))) {
+                || (object instanceof String && ((String) object)
+                        .equalsIgnoreCase("true"))) {
             return true;
         }
         throw wrongValueFormatException(index, "boolean", object, null);
@@ -304,14 +338,17 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the double value associated with an index.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The value.
-     * @throws JSONException If the key is not found or if the value cannot be converted to a number.
+     * @throws JSONException
+     *             If the key is not found or if the value cannot be converted
+     *             to a number.
      */
     public double getDouble(int index) throws JSONException {
         final Object object = this.get(index);
-        if (object instanceof Number) {
-            return ((Number) object).doubleValue();
+        if(object instanceof Number) {
+            return ((Number)object).doubleValue();
         }
         try {
             return Double.parseDouble(object.toString());
@@ -323,15 +360,17 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the float value associated with a key.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The numeric value.
-     * @throws JSONException if the key is not found or if the value is not a Number object and cannot be converted to a
-     *                       number.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a Number
+     *             object and cannot be converted to a number.
      */
     public float getFloat(int index) throws JSONException {
         final Object object = this.get(index);
-        if (object instanceof Number) {
-            return ((Number) object).floatValue();
+        if(object instanceof Number) {
+            return ((Number)object).floatValue();
         }
         try {
             return Float.parseFloat(object.toString());
@@ -343,16 +382,18 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the Number value associated with a key.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The numeric value.
-     * @throws JSONException if the key is not found or if the value is not a Number object and cannot be converted to a
-     *                       number.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a Number
+     *             object and cannot be converted to a number.
      */
     public Number getNumber(int index) throws JSONException {
         Object object = this.get(index);
         try {
             if (object instanceof Number) {
-                return (Number) object;
+                return (Number)object;
             }
             return JSONObject.stringToNumber(object.toString());
         } catch (Exception e) {
@@ -363,37 +404,46 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the enum value associated with an index.
      *
-     * @param <E>   Enum Type
-     * @param clazz The type of enum to retrieve.
-     * @param index The index must be between 0 and length() - 1.
+     * @param <E>
+     *            Enum Type
+     * @param clazz
+     *            The type of enum to retrieve.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The enum value at the index location
-     * @throws JSONException if the key is not found or if the value cannot be converted to an enum.
+     * @throws JSONException
+     *            if the key is not found or if the value cannot be converted
+     *            to an enum.
      */
     public <E extends Enum<E>> E getEnum(Class<E> clazz, int index) throws JSONException {
         E val = optEnum(clazz, index);
-        if (val == null) {
+        if(val==null) {
             // JSONException should really take a throwable argument.
             // If it did, I would re-implement this with the Enum.valueOf
             // method and place any thrown exception in the JSONException
             throw wrongValueFormatException(index, "enum of type "
-                + JSONObject.quote(clazz.getSimpleName()), opt(index), null);
+                    + JSONObject.quote(clazz.getSimpleName()), opt(index), null);
         }
         return val;
     }
 
     /**
-     * Get the BigDecimal value associated with an index. If the value is float or double, the
-     * {@link BigDecimal#BigDecimal(double)} constructor will be used. See notes on the constructor for conversion
-     * issues that may arise.
+     * Get the BigDecimal value associated with an index. If the value is float
+     * or double, the {@link BigDecimal#BigDecimal(double)} constructor
+     * will be used. See notes on the constructor for conversion issues that
+     * may arise.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The value.
-     * @throws JSONException If the key is not found or if the value cannot be converted to a BigDecimal.
+     * @throws JSONException
+     *             If the key is not found or if the value cannot be converted
+     *             to a BigDecimal.
      */
-    public BigDecimal getBigDecimal(int index) throws JSONException {
+    public BigDecimal getBigDecimal (int index) throws JSONException {
         Object object = this.get(index);
         BigDecimal val = JSONObject.objectToBigDecimal(object, null);
-        if (val == null) {
+        if(val == null) {
             throw wrongValueFormatException(index, "BigDecimal", object, null);
         }
         return val;
@@ -402,14 +452,17 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the BigInteger value associated with an index.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The value.
-     * @throws JSONException If the key is not found or if the value cannot be converted to a BigInteger.
+     * @throws JSONException
+     *             If the key is not found or if the value cannot be converted
+     *             to a BigInteger.
      */
-    public BigInteger getBigInteger(int index) throws JSONException {
+    public BigInteger getBigInteger (int index) throws JSONException {
         Object object = this.get(index);
         BigInteger val = JSONObject.objectToBigInteger(object, null);
-        if (val == null) {
+        if(val == null) {
             throw wrongValueFormatException(index, "BigInteger", object, null);
         }
         return val;
@@ -418,14 +471,16 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the int value associated with an index.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The value.
-     * @throws JSONException If the key is not found or if the value is not a number.
+     * @throws JSONException
+     *             If the key is not found or if the value is not a number.
      */
     public int getInt(int index) throws JSONException {
         final Object object = this.get(index);
-        if (object instanceof Number) {
-            return ((Number) object).intValue();
+        if(object instanceof Number) {
+            return ((Number)object).intValue();
         }
         try {
             return Integer.parseInt(object.toString());
@@ -437,9 +492,12 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the JSONArray associated with an index.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return A JSONArray value.
-     * @throws JSONException If there is no value for the index. or if the value is not a JSONArray
+     * @throws JSONException
+     *             If there is no value for the index. or if the value is not a
+     *             JSONArray
      */
     public JSONArray getJSONArray(int index) throws JSONException {
         Object object = this.get(index);
@@ -452,9 +510,12 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the JSONObject associated with an index.
      *
-     * @param index subscript
+     * @param index
+     *            subscript
      * @return A JSONObject value.
-     * @throws JSONException If there is no value for the index or if the value is not a JSONObject
+     * @throws JSONException
+     *             If there is no value for the index or if the value is not a
+     *             JSONObject
      */
     public JSONObject getJSONObject(int index) throws JSONException {
         Object object = this.get(index);
@@ -467,14 +528,17 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the long value associated with an index.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The value.
-     * @throws JSONException If the key is not found or if the value cannot be converted to a number.
+     * @throws JSONException
+     *             If the key is not found or if the value cannot be converted
+     *             to a number.
      */
     public long getLong(int index) throws JSONException {
         final Object object = this.get(index);
-        if (object instanceof Number) {
-            return ((Number) object).longValue();
+        if(object instanceof Number) {
+            return ((Number)object).longValue();
         }
         try {
             return Long.parseLong(object.toString());
@@ -486,9 +550,11 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the string associated with an index.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return A string value.
-     * @throws JSONException If there is no string value for the index.
+     * @throws JSONException
+     *             If there is no string value for the index.
      */
     public String getString(int index) throws JSONException {
         Object object = this.get(index);
@@ -501,7 +567,8 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Determine if the value is <code>null</code>.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return true if the value at the index is <code>null</code>, or if there is no value.
      */
     public boolean isNull(int index) {
@@ -513,9 +580,11 @@ public class JSONArray implements Iterable<Object> {
      * <code>separator</code> string is inserted between each element. Warning:
      * This method assumes that the data structure is acyclical.
      *
-     * @param separator A string that will be inserted between the elements.
+     * @param separator
+     *            A string that will be inserted between the elements.
      * @return a string.
-     * @throws JSONException If the array contains an invalid number.
+     * @throws JSONException
+     *             If the array contains an invalid number.
      */
     public String join(String separator) throws JSONException {
         int len = this.length();
@@ -524,11 +593,11 @@ public class JSONArray implements Iterable<Object> {
         }
 
         StringBuilder sb = new StringBuilder(
-            JSONObject.valueToString(this.myArrayList.get(0)));
+                   JSONObject.valueToString(this.myArrayList.get(0)));
 
         for (int i = 1; i < len; i++) {
             sb.append(separator)
-                .append(JSONObject.valueToString(this.myArrayList.get(i)));
+              .append(JSONObject.valueToString(this.myArrayList.get(i)));
         }
         return sb.toString();
     }
@@ -543,7 +612,8 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Removes all of the elements from this JSONArray. The JSONArray will be empty after this call returns.
+     * Removes all of the elements from this JSONArray.
+     * The JSONArray will be empty after this call returns.
      */
     public void clear() {
         this.myArrayList.clear();
@@ -552,19 +622,22 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the optional object value associated with an index.
      *
-     * @param index The index must be between 0 and length() - 1. If not, null is returned.
+     * @param index
+     *            The index must be between 0 and length() - 1. If not, null is returned.
      * @return An object value, or null if there is no object at that index.
      */
     public Object opt(int index) {
         return (index < 0 || index >= this.length()) ? null : this.myArrayList
-            .get(index);
+                .get(index);
     }
 
     /**
-     * Get the optional boolean value associated with an index. It returns false if there is no value at that index, or
-     * if the value is not Boolean.TRUE or the String "true".
+     * Get the optional boolean value associated with an index. It returns false
+     * if there is no value at that index, or if the value is not Boolean.TRUE
+     * or the String "true".
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The truth.
      */
     public boolean optBoolean(int index) {
@@ -572,11 +645,14 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional boolean value associated with an index. It returns the defaultValue if there is no value at that
-     * index or if it is not a Boolean or the String "true" or "false" (case insensitive).
+     * Get the optional boolean value associated with an index. It returns the
+     * defaultValue if there is no value at that index or if it is not a Boolean
+     * or the String "true" or "false" (case insensitive).
      *
-     * @param index        The index must be between 0 and length() - 1.
-     * @param defaultValue A boolean default.
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            A boolean default.
      * @return The truth.
      */
     public boolean optBoolean(int index, boolean defaultValue) {
@@ -588,10 +664,12 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional Boolean object associated with an index. It returns false if there is no value at that index, or
-     * if the value is not Boolean.TRUE or the String "true".
+     * Get the optional Boolean object associated with an index. It returns false
+     * if there is no value at that index, or if the value is not Boolean.TRUE
+     * or the String "true".
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The truth.
      */
     public Boolean optBooleanObject(int index) {
@@ -599,11 +677,14 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional Boolean object associated with an index. It returns the defaultValue if there is no value at
-     * that index or if it is not a Boolean or the String "true" or "false" (case insensitive).
+     * Get the optional Boolean object associated with an index. It returns the
+     * defaultValue if there is no value at that index or if it is not a Boolean
+     * or the String "true" or "false" (case insensitive).
      *
-     * @param index        The index must be between 0 and length() - 1.
-     * @param defaultValue A boolean default.
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            A boolean default.
      * @return The truth.
      */
     public Boolean optBooleanObject(int index, Boolean defaultValue) {
@@ -615,10 +696,12 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional double value associated with an index. NaN is returned if there is no value for the index, or if
-     * the value is not a number and cannot be converted to a number.
+     * Get the optional double value associated with an index. NaN is returned
+     * if there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The value.
      */
     public double optDouble(int index) {
@@ -626,11 +709,14 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional double value associated with an index. The defaultValue is returned if there is no value for the
-     * index, or if the value is not a number and cannot be converted to a number.
+     * Get the optional double value associated with an index. The defaultValue
+     * is returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
      *
-     * @param index        subscript
-     * @param defaultValue The default value.
+     * @param index
+     *            subscript
+     * @param defaultValue
+     *            The default value.
      * @return The value.
      */
     public double optDouble(int index, double defaultValue) {
@@ -646,10 +732,12 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional Double object associated with an index. NaN is returned if there is no value for the index, or
-     * if the value is not a number and cannot be converted to a number.
+     * Get the optional Double object associated with an index. NaN is returned
+     * if there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The object.
      */
     public Double optDoubleObject(int index) {
@@ -657,11 +745,14 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional double value associated with an index. The defaultValue is returned if there is no value for the
-     * index, or if the value is not a number and cannot be converted to a number.
+     * Get the optional double value associated with an index. The defaultValue
+     * is returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
      *
-     * @param index        subscript
-     * @param defaultValue The default object.
+     * @param index
+     *            subscript
+     * @param defaultValue
+     *            The default object.
      * @return The object.
      */
     public Double optDoubleObject(int index, Double defaultValue) {
@@ -677,10 +768,12 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional float value associated with an index. NaN is returned if there is no value for the index, or if
-     * the value is not a number and cannot be converted to a number.
+     * Get the optional float value associated with an index. NaN is returned
+     * if there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The value.
      */
     public float optFloat(int index) {
@@ -688,11 +781,14 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional float value associated with an index. The defaultValue is returned if there is no value for the
-     * index, or if the value is not a number and cannot be converted to a number.
+     * Get the optional float value associated with an index. The defaultValue
+     * is returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
      *
-     * @param index        subscript
-     * @param defaultValue The default value.
+     * @param index
+     *            subscript
+     * @param defaultValue
+     *            The default value.
      * @return The value.
      */
     public float optFloat(int index, float defaultValue) {
@@ -708,10 +804,12 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional Float object associated with an index. NaN is returned if there is no value for the index, or if
-     * the value is not a number and cannot be converted to a number.
+     * Get the optional Float object associated with an index. NaN is returned
+     * if there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The object.
      */
     public Float optFloatObject(int index) {
@@ -719,11 +817,14 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional Float object associated with an index. The defaultValue is returned if there is no value for the
-     * index, or if the value is not a number and cannot be converted to a number.
+     * Get the optional Float object associated with an index. The defaultValue
+     * is returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
      *
-     * @param index        subscript
-     * @param defaultValue The default object.
+     * @param index
+     *            subscript
+     * @param defaultValue
+     *            The default object.
      * @return The object.
      */
     public Float optFloatObject(int index, Float defaultValue) {
@@ -739,10 +840,12 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional int value associated with an index. Zero is returned if there is no value for the index, or if
-     * the value is not a number and cannot be converted to a number.
+     * Get the optional int value associated with an index. Zero is returned if
+     * there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The value.
      */
     public int optInt(int index) {
@@ -750,11 +853,14 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional int value associated with an index. The defaultValue is returned if there is no value for the
-     * index, or if the value is not a number and cannot be converted to a number.
+     * Get the optional int value associated with an index. The defaultValue is
+     * returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
      *
-     * @param index        The index must be between 0 and length() - 1.
-     * @param defaultValue The default value.
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default value.
      * @return The value.
      */
     public int optInt(int index, int defaultValue) {
@@ -766,10 +872,12 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional Integer object associated with an index. Zero is returned if there is no value for the index, or
-     * if the value is not a number and cannot be converted to a number.
+     * Get the optional Integer object associated with an index. Zero is returned if
+     * there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The object.
      */
     public Integer optIntegerObject(int index) {
@@ -777,11 +885,14 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional Integer object associated with an index. The defaultValue is returned if there is no value for
-     * the index, or if the value is not a number and cannot be converted to a number.
+     * Get the optional Integer object associated with an index. The defaultValue is
+     * returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
      *
-     * @param index        The index must be between 0 and length() - 1.
-     * @param defaultValue The default object.
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default object.
      * @return The object.
      */
     public Integer optIntegerObject(int index, Integer defaultValue) {
@@ -795,9 +906,12 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the enum value associated with a key.
      *
-     * @param <E>   Enum Type
-     * @param clazz The type of enum to retrieve.
-     * @param index The index must be between 0 and length() - 1.
+     * @param <E>
+     *            Enum Type
+     * @param clazz
+     *            The type of enum to retrieve.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The enum value at the index location or null if not found
      */
     public <E extends Enum<E>> E optEnum(Class<E> clazz, int index) {
@@ -807,12 +921,16 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Get the enum value associated with a key.
      *
-     * @param <E>          Enum Type
-     * @param clazz        The type of enum to retrieve.
-     * @param index        The index must be between 0 and length() - 1.
-     * @param defaultValue The default in case the value is not found
-     * @return The enum value at the index location or defaultValue if the value is not found or cannot be assigned to
-     * clazz
+     * @param <E>
+     *            Enum Type
+     * @param clazz
+     *            The type of enum to retrieve.
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default in case the value is not found
+     * @return The enum value at the index location or defaultValue if
+     *            the value is not found or cannot be assigned to clazz
      */
     public <E extends Enum<E>> E optEnum(Class<E> clazz, int index, E defaultValue) {
         try {
@@ -835,11 +953,14 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional BigInteger value associated with an index. The defaultValue is returned if there is no value for
-     * the index, or if the value is not a number and cannot be converted to a number.
+     * Get the optional BigInteger value associated with an index. The
+     * defaultValue is returned if there is no value for the index, or if the
+     * value is not a number and cannot be converted to a number.
      *
-     * @param index        The index must be between 0 and length() - 1.
-     * @param defaultValue The default value.
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default value.
      * @return The value.
      */
     public BigInteger optBigInteger(int index, BigInteger defaultValue) {
@@ -848,13 +969,17 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional BigDecimal value associated with an index. The defaultValue is returned if there is no value for
-     * the index, or if the value is not a number and cannot be converted to a number. If the value is float or double,
-     * the {@link BigDecimal#BigDecimal(double)} constructor will be used. See notes on the constructor for conversion
+     * Get the optional BigDecimal value associated with an index. The
+     * defaultValue is returned if there is no value for the index, or if the
+     * value is not a number and cannot be converted to a number. If the value
+     * is float or double, the {@link BigDecimal#BigDecimal(double)}
+     * constructor will be used. See notes on the constructor for conversion
      * issues that may arise.
      *
-     * @param index        The index must be between 0 and length() - 1.
-     * @param defaultValue The default value.
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default value.
      * @return The value.
      */
     public BigDecimal optBigDecimal(int index, BigDecimal defaultValue) {
@@ -863,10 +988,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional JSONArray associated with an index. Null is returned if there is no value at that index or if
-     * the value is not a JSONArray.
+     * Get the optional JSONArray associated with an index. Null is returned if
+     * there is no value at that index or if the value is not a JSONArray.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return A JSONArray value.
      */
     public JSONArray optJSONArray(int index) {
@@ -874,11 +1000,13 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional JSONArray associated with an index. The defaultValue is returned if there is no value at that
-     * index or if the value is not a JSONArray.
+     * Get the optional JSONArray associated with an index. The defaultValue is returned if
+     * there is no value at that index or if the value is not a JSONArray.
      *
-     * @param index        The index must be between 0 and length() - 1.
-     * @param defaultValue The default.
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default.
      * @return A JSONArray value.
      */
     public JSONArray optJSONArray(int index, JSONArray defaultValue) {
@@ -887,10 +1015,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional JSONObject associated with an index. Null is returned if there is no value at that index or if
-     * the value is not a JSONObject.
+     * Get the optional JSONObject associated with an index. Null is returned if
+     * there is no value at that index or if the value is not a JSONObject.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return A JSONObject value.
      */
     public JSONObject optJSONObject(int index) {
@@ -898,11 +1027,13 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional JSONObject associated with an index. The defaultValue is returned if there is no value at that
-     * index or if the value is not a JSONObject.
+     * Get the optional JSONObject associated with an index. The defaultValue is returned if
+     * there is no value at that index or if the value is not a JSONObject.
      *
-     * @param index        The index must be between 0 and length() - 1.
-     * @param defaultValue The default.
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default.
      * @return A JSONObject value.
      */
     public JSONObject optJSONObject(int index, JSONObject defaultValue) {
@@ -911,10 +1042,12 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional long value associated with an index. Zero is returned if there is no value for the index, or if
-     * the value is not a number and cannot be converted to a number.
+     * Get the optional long value associated with an index. Zero is returned if
+     * there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The value.
      */
     public long optLong(int index) {
@@ -922,11 +1055,14 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional long value associated with an index. The defaultValue is returned if there is no value for the
-     * index, or if the value is not a number and cannot be converted to a number.
+     * Get the optional long value associated with an index. The defaultValue is
+     * returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
      *
-     * @param index        The index must be between 0 and length() - 1.
-     * @param defaultValue The default value.
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default value.
      * @return The value.
      */
     public long optLong(int index, long defaultValue) {
@@ -938,10 +1074,12 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional Long object associated with an index. Zero is returned if there is no value for the index, or if
-     * the value is not a number and cannot be converted to a number.
+     * Get the optional Long object associated with an index. Zero is returned if
+     * there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return The object.
      */
     public Long optLongObject(int index) {
@@ -949,11 +1087,14 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional Long object associated with an index. The defaultValue is returned if there is no value for the
-     * index, or if the value is not a number and cannot be converted to a number.
+     * Get the optional Long object associated with an index. The defaultValue is
+     * returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
      *
-     * @param index        The index must be between 0 and length() - 1.
-     * @param defaultValue The default object.
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default object.
      * @return The object.
      */
     public Long optLongObject(int index, Long defaultValue) {
@@ -965,11 +1106,13 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get an optional {@link Number} value associated with a key, or <code>null</code> if there is no such key or if
-     * the value is not a number. If the value is a string, an attempt will be made to evaluate it as a number
-     * ({@link BigDecimal}). This method would be used in cases where type coercion of the number value is unwanted.
+     * Get an optional {@link Number} value associated with a key, or <code>null</code>
+     * if there is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number ({@link BigDecimal}). This method
+     * would be used in cases where type coercion of the number value is unwanted.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return An object which is the value.
      */
     public Number optNumber(int index) {
@@ -977,12 +1120,15 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get an optional {@link Number} value associated with a key, or the default if there is no such key or if the
-     * value is not a number. If the value is a string, an attempt will be made to evaluate it as a number
-     * ({@link BigDecimal}). This method would be used in cases where type coercion of the number value is unwanted.
+     * Get an optional {@link Number} value associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number ({@link BigDecimal}). This method
+     * would be used in cases where type coercion of the number value is unwanted.
      *
-     * @param index        The index must be between 0 and length() - 1.
-     * @param defaultValue The default.
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public Number optNumber(int index, Number defaultValue) {
@@ -990,7 +1136,7 @@ public class JSONArray implements Iterable<Object> {
         if (JSONObject.NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof Number) {
+        if (val instanceof Number){
             return (Number) val;
         }
 
@@ -1005,10 +1151,12 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional string value associated with an index. It returns an empty string if there is no value at that
-     * index. If the value is not a string and is not null, then it is converted to a string.
+     * Get the optional string value associated with an index. It returns an
+     * empty string if there is no value at that index. If the value is not a
+     * string and is not null, then it is converted to a string.
      *
-     * @param index The index must be between 0 and length() - 1.
+     * @param index
+     *            The index must be between 0 and length() - 1.
      * @return A String value.
      */
     public String optString(int index) {
@@ -1016,22 +1164,26 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional string associated with an index. The defaultValue is returned if the key is not found.
+     * Get the optional string associated with an index. The defaultValue is
+     * returned if the key is not found.
      *
-     * @param index        The index must be between 0 and length() - 1.
-     * @param defaultValue The default value.
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default value.
      * @return A String value.
      */
     public String optString(int index, String defaultValue) {
         Object object = this.opt(index);
         return JSONObject.NULL.equals(object) ? defaultValue : object
-            .toString();
+                .toString();
     }
 
     /**
      * Append a boolean value. This increases the array's length by one.
      *
-     * @param value A boolean value.
+     * @param value
+     *            A boolean value.
      * @return this.
      */
     public JSONArray put(boolean value) {
@@ -1039,11 +1191,14 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Put a value in the JSONArray, where the value will be a JSONArray which is produced from a Collection.
+     * Put a value in the JSONArray, where the value will be a JSONArray which
+     * is produced from a Collection.
      *
-     * @param value A Collection value.
+     * @param value
+     *            A Collection value.
      * @return this.
-     * @throws JSONException If the value is non-finite number.
+     * @throws JSONException
+     *            If the value is non-finite number.
      */
     public JSONArray put(Collection<?> value) {
         return this.put(new JSONArray(value));
@@ -1052,9 +1207,11 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Append a double value. This increases the array's length by one.
      *
-     * @param value A double value.
+     * @param value
+     *            A double value.
      * @return this.
-     * @throws JSONException if the value is not finite.
+     * @throws JSONException
+     *             if the value is not finite.
      */
     public JSONArray put(double value) throws JSONException {
         return this.put(Double.valueOf(value));
@@ -1063,9 +1220,11 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Append a float value. This increases the array's length by one.
      *
-     * @param value A float value.
+     * @param value
+     *            A float value.
      * @return this.
-     * @throws JSONException if the value is not finite.
+     * @throws JSONException
+     *             if the value is not finite.
      */
     public JSONArray put(float value) throws JSONException {
         return this.put(Float.valueOf(value));
@@ -1074,7 +1233,8 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Append an int value. This increases the array's length by one.
      *
-     * @param value An int value.
+     * @param value
+     *            An int value.
      * @return this.
      */
     public JSONArray put(int value) {
@@ -1084,7 +1244,8 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Append an long value. This increases the array's length by one.
      *
-     * @param value A long value.
+     * @param value
+     *            A long value.
      * @return this.
      */
     public JSONArray put(long value) {
@@ -1092,12 +1253,16 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Put a value in the JSONArray, where the value will be a JSONObject which is produced from a Map.
+     * Put a value in the JSONArray, where the value will be a JSONObject which
+     * is produced from a Map.
      *
-     * @param value A Map value.
+     * @param value
+     *            A Map value.
      * @return this.
-     * @throws JSONException        If a value in the map is non-finite number.
-     * @throws NullPointerException If a key in the map is <code>null</code>
+     * @throws JSONException
+     *            If a value in the map is non-finite number.
+     * @throws NullPointerException
+     *            If a key in the map is <code>null</code>
      */
     public JSONArray put(Map<?, ?> value) {
         return this.put(new JSONObject(value));
@@ -1106,10 +1271,13 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Append an object value. This increases the array's length by one.
      *
-     * @param value An object value. The value should be a Boolean, Double, Integer, JSONArray, JSONObject, Long, or
-     *              String, or the JSONObject.NULL object.
+     * @param value
+     *            An object value. The value should be a Boolean, Double,
+     *            Integer, JSONArray, JSONObject, Long, or String, or the
+     *            JSONObject.NULL object.
      * @return this.
-     * @throws JSONException If the value is non-finite number.
+     * @throws JSONException
+     *            If the value is non-finite number.
      */
     public JSONArray put(Object value) {
         JSONObject.testValidity(value);
@@ -1118,90 +1286,121 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Put or replace a boolean value in the JSONArray. If the index is greater than the length of the JSONArray, then
-     * null elements will be added as necessary to pad it out.
+     * Put or replace a boolean value in the JSONArray. If the index is greater
+     * than the length of the JSONArray, then null elements will be added as
+     * necessary to pad it out.
      *
-     * @param index The subscript.
-     * @param value A boolean value.
+     * @param index
+     *            The subscript.
+     * @param value
+     *            A boolean value.
      * @return this.
-     * @throws JSONException If the index is negative.
+     * @throws JSONException
+     *             If the index is negative.
      */
     public JSONArray put(int index, boolean value) throws JSONException {
         return this.put(index, value ? Boolean.TRUE : Boolean.FALSE);
     }
 
     /**
-     * Put a value in the JSONArray, where the value will be a JSONArray which is produced from a Collection.
+     * Put a value in the JSONArray, where the value will be a JSONArray which
+     * is produced from a Collection.
      *
-     * @param index The subscript.
-     * @param value A Collection value.
+     * @param index
+     *            The subscript.
+     * @param value
+     *            A Collection value.
      * @return this.
-     * @throws JSONException If the index is negative or if the value is non-finite.
+     * @throws JSONException
+     *             If the index is negative or if the value is non-finite.
      */
     public JSONArray put(int index, Collection<?> value) throws JSONException {
         return this.put(index, new JSONArray(value));
     }
 
     /**
-     * Put or replace a double value. If the index is greater than the length of the JSONArray, then null elements will
-     * be added as necessary to pad it out.
+     * Put or replace a double value. If the index is greater than the length of
+     * the JSONArray, then null elements will be added as necessary to pad it
+     * out.
      *
-     * @param index The subscript.
-     * @param value A double value.
+     * @param index
+     *            The subscript.
+     * @param value
+     *            A double value.
      * @return this.
-     * @throws JSONException If the index is negative or if the value is non-finite.
+     * @throws JSONException
+     *             If the index is negative or if the value is non-finite.
      */
     public JSONArray put(int index, double value) throws JSONException {
         return this.put(index, Double.valueOf(value));
     }
 
     /**
-     * Put or replace a float value. If the index is greater than the length of the JSONArray, then null elements will
-     * be added as necessary to pad it out.
+     * Put or replace a float value. If the index is greater than the length of
+     * the JSONArray, then null elements will be added as necessary to pad it
+     * out.
      *
-     * @param index The subscript.
-     * @param value A float value.
+     * @param index
+     *            The subscript.
+     * @param value
+     *            A float value.
      * @return this.
-     * @throws JSONException If the index is negative or if the value is non-finite.
+     * @throws JSONException
+     *             If the index is negative or if the value is non-finite.
      */
     public JSONArray put(int index, float value) throws JSONException {
         return this.put(index, Float.valueOf(value));
     }
 
     /**
-     * Put or replace an int value. If the index is greater than the length of the JSONArray, then null elements will be
-     * added as necessary to pad it out.
+     * Put or replace an int value. If the index is greater than the length of
+     * the JSONArray, then null elements will be added as necessary to pad it
+     * out.
      *
-     * @param index The subscript.
-     * @param value An int value.
+     * @param index
+     *            The subscript.
+     * @param value
+     *            An int value.
      * @return this.
-     * @throws JSONException If the index is negative.
+     * @throws JSONException
+     *             If the index is negative.
      */
     public JSONArray put(int index, int value) throws JSONException {
         return this.put(index, Integer.valueOf(value));
     }
 
     /**
-     * Put or replace a long value. If the index is greater than the length of the JSONArray, then null elements will be
-     * added as necessary to pad it out.
+     * Put or replace a long value. If the index is greater than the length of
+     * the JSONArray, then null elements will be added as necessary to pad it
+     * out.
      *
-     * @param index The subscript.
-     * @param value A long value.
+     * @param index
+     *            The subscript.
+     * @param value
+     *            A long value.
      * @return this.
-     * @throws JSONException If the index is negative.
+     * @throws JSONException
+     *             If the index is negative.
      */
     public JSONArray put(int index, long value) throws JSONException {
         return this.put(index, Long.valueOf(value));
     }
 
     /**
-     * Put a value in the JSONArray, where the value will be a JSONObject that is produced from a Map.
+     * Put a value in the JSONArray, where the value will be a JSONObject that
+     * is produced from a Map.
      *
-     * @param index The subscript.
-     * @param value The Map value.
-     * @return reference to self
-     * @throws JSONException        If the index is negative or if the value is an invalid number.
-     * @throws NullPointerException If a key in the map is <code>null</code>
+     * @param index
+     *            The subscript.
+     * @param value
+     *            The Map value.
+     * @return
+     *             reference to self
+     * @throws JSONException
+     *             If the index is negative or if the value is an invalid
+     *             number.
+     * @throws NullPointerException
+     *             If a key in the map is <code>null</code>
      */
     public JSONArray put(int index, Map<?, ?> value) throws JSONException {
         this.put(index, new JSONObject(value, new JSONParserConfiguration()));
@@ -1209,29 +1408,40 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Put a value in the JSONArray, where the value will be a JSONObject that is produced from a Map.
+     * Put a value in the JSONArray, where the value will be a JSONObject that
+     * is produced from a Map.
      *
-     * @param index                   The subscript
-     * @param value                   The Map value.
-     * @param jsonParserConfiguration Configuration object for the JSON parser
+     * @param index
+     *          The subscript
+     * @param value
+     *          The Map value.
+     * @param jsonParserConfiguration
+     *          Configuration object for the JSON parser
      * @return reference to self
-     * @throws JSONException If the index is negative or if the value is an invalid number.
+     * @throws JSONException
+     *          If the index is negative or if the value is an invalid
+     *          number.
      */
-    public JSONArray put(int index, Map<?, ?> value, JSONParserConfiguration jsonParserConfiguration)
-        throws JSONException {
+    public JSONArray put(int index, Map<?, ?> value, JSONParserConfiguration jsonParserConfiguration) throws JSONException {
         this.put(index, new JSONObject(value, jsonParserConfiguration));
         return this;
     }
 
     /**
-     * Put or replace an object value in the JSONArray. If the index is greater than the length of the JSONArray, then
-     * null elements will be added as necessary to pad it out.
+     * Put or replace an object value in the JSONArray. If the index is greater
+     * than the length of the JSONArray, then null elements will be added as
+     * necessary to pad it out.
      *
-     * @param index The subscript.
-     * @param value The value to put into the array. The value should be a Boolean, Double, Integer, JSONArray,
-     *              JSONObject, Long, or String, or the JSONObject.NULL object.
+     * @param index
+     *            The subscript.
+     * @param value
+     *            The value to put into the array. The value should be a
+     *            Boolean, Double, Integer, JSONArray, JSONObject, Long, or
+     *            String, or the JSONObject.NULL object.
      * @return this.
-     * @throws JSONException If the index is negative or if the value is an invalid number.
+     * @throws JSONException
+     *             If the index is negative or if the value is an invalid
+     *             number.
      */
     public JSONArray put(int index, Object value) throws JSONException {
         if (index < 0) {
@@ -1242,7 +1452,7 @@ public class JSONArray implements Iterable<Object> {
             this.myArrayList.set(index, value);
             return this;
         }
-        if (index == this.length()) {
+        if(index == this.length()){
             // simple append
             return this.put(value);
         }
@@ -1259,7 +1469,8 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Put a collection's elements in to the JSONArray.
      *
-     * @param collection A Collection.
+     * @param collection
+     *            A Collection.
      * @return this.
      */
     public JSONArray putAll(Collection<?> collection) {
@@ -1270,7 +1481,8 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Put an Iterable's elements in to the JSONArray.
      *
-     * @param iter An Iterable.
+     * @param iter
+     *            An Iterable.
      * @return this.
      */
     public JSONArray putAll(Iterable<?> iter) {
@@ -1281,7 +1493,8 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Put a JSONArray's elements in to the JSONArray.
      *
-     * @param array A JSONArray.
+     * @param array
+     *            A JSONArray.
      * @return this.
      */
     public JSONArray putAll(JSONArray array) {
@@ -1294,10 +1507,15 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Put an array's elements in to the JSONArray.
      *
-     * @param array Array. If the parameter passed is null, or not an array or Iterable, an exception will be thrown.
+     * @param array
+     *            Array. If the parameter passed is null, or not an array or Iterable, an
+     *            exception will be thrown.
      * @return this.
-     * @throws JSONException        If not an array, JSONArray, Iterable or if an value is non-finite number.
-     * @throws NullPointerException Thrown if the array parameter is null.
+     *
+     * @throws JSONException
+     *            If not an array, JSONArray, Iterable or if an value is non-finite number.
+     * @throws NullPointerException
+     *            Thrown if the array parameter is null.
      */
     public JSONArray putAll(Object array) throws JSONException {
         this.addAll(array, false);
@@ -1305,8 +1523,9 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Creates a JSONPointer using an initialization string and tries to match it to an item within this JSONArray. For
-     * example, given a JSONArray initialized with this document:
+     * Creates a JSONPointer using an initialization string and tries to
+     * match it to an item within this JSONArray. For example, given a
+     * JSONArray initialized with this document:
      * <pre>
      * [
      *     {"b":"c"}
@@ -1316,8 +1535,8 @@ public class JSONArray implements Iterable<Object> {
      * <pre>
      * "/0/b"
      * </pre>
-     * Then this method will return the String "c" A JSONPointerException may be thrown from code called by this
-     * method.
+     * Then this method will return the String "c"
+     * A JSONPointerException may be thrown from code called by this method.
      *
      * @param jsonPointer string that can be used to create a JSONPointer
      * @return the item matched by the JSONPointer, otherwise null
@@ -1327,7 +1546,8 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Uses a user initialized JSONPointer  and tries to match it to an item within this JSONArray. For example, given a
+     * Uses a user initialized JSONPointer  and tries to
+     * match it to an item within this JSONArray. For example, given a
      * JSONArray initialized with this document:
      * <pre>
      * [
@@ -1338,8 +1558,8 @@ public class JSONArray implements Iterable<Object> {
      * <pre>
      * "/0/b"
      * </pre>
-     * Then this method will return the String "c" A JSONPointerException may be thrown from code called by this
-     * method.
+     * Then this method will return the String "c"
+     * A JSONPointerException may be thrown from code called by this method.
      *
      * @param jsonPointer string that can be used to create a JSONPointer
      * @return the item matched by the JSONPointer, otherwise null
@@ -1349,20 +1569,20 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Queries and returns a value from this object using {@code jsonPointer}, or returns null if the query fails due to
-     * a missing key.
+     * Queries and returns a value from this object using {@code jsonPointer}, or
+     * returns null if the query fails due to a missing key.
      *
      * @param jsonPointer the string representation of the JSON pointer
      * @return the queried value or {@code null}
      * @throws IllegalArgumentException if {@code jsonPointer} has invalid syntax
      */
     public Object optQuery(String jsonPointer) {
-        return optQuery(new JSONPointer(jsonPointer));
+    	return optQuery(new JSONPointer(jsonPointer));
     }
 
     /**
-     * Queries and returns a value from this object using {@code jsonPointer}, or returns null if the query fails due to
-     * a missing key.
+     * Queries and returns a value from this object using {@code jsonPointer}, or
+     * returns null if the query fails due to a missing key.
      *
      * @param jsonPointer The JSON pointer
      * @return the queried value or {@code null}
@@ -1379,8 +1599,10 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Remove an index and close the hole.
      *
-     * @param index The index of the element to be removed.
-     * @return The value that was associated with the index, or null if there was no value.
+     * @param index
+     *            The index of the element to be removed.
+     * @return The value that was associated with the index, or null if there
+     *         was no value.
      */
     public Object remove(int index) {
         return index >= 0 && index < this.length()
@@ -1389,7 +1611,8 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Determine if two JSONArrays are similar. They must contain similar sequences.
+     * Determine if two JSONArrays are similar.
+     * They must contain similar sequences.
      *
      * @param other The other JSONArray
      * @return true if they are equal
@@ -1399,29 +1622,29 @@ public class JSONArray implements Iterable<Object> {
             return false;
         }
         int len = this.length();
-        if (len != ((JSONArray) other).length()) {
+        if (len != ((JSONArray)other).length()) {
             return false;
         }
         for (int i = 0; i < len; i += 1) {
             Object valueThis = this.myArrayList.get(i);
-            Object valueOther = ((JSONArray) other).myArrayList.get(i);
-            if (valueThis == valueOther) {
-                continue;
+            Object valueOther = ((JSONArray)other).myArrayList.get(i);
+            if(valueThis == valueOther) {
+            	continue;
             }
-            if (valueThis == null) {
-                return false;
+            if(valueThis == null) {
+            	return false;
             }
             if (valueThis instanceof JSONObject) {
-                if (!((JSONObject) valueThis).similar(valueOther)) {
+                if (!((JSONObject)valueThis).similar(valueOther)) {
                     return false;
                 }
             } else if (valueThis instanceof JSONArray) {
-                if (!((JSONArray) valueThis).similar(valueOther)) {
+                if (!((JSONArray)valueThis).similar(valueOther)) {
                     return false;
                 }
             } else if (valueThis instanceof Number && valueOther instanceof Number) {
-                if (!JSONObject.isNumberSimilar((Number) valueThis, (Number) valueOther)) {
-                    return false;
+                if (!JSONObject.isNumberSimilar((Number)valueThis, (Number)valueOther)) {
+                	return false;
                 }
             } else if (valueThis instanceof JSONString && valueOther instanceof JSONString) {
                 if (!((JSONString) valueThis).toJSONString().equals(((JSONString) valueOther).toJSONString())) {
@@ -1435,11 +1658,16 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Produce a JSONObject by combining a JSONArray of names with the values of this JSONArray.
+     * Produce a JSONObject by combining a JSONArray of names with the values of
+     * this JSONArray.
      *
-     * @param names A JSONArray containing a list of key strings. These will be paired with the values.
-     * @return A JSONObject, or null if there are no names or if this JSONArray has no values.
-     * @throws JSONException If any of the names are null.
+     * @param names
+     *            A JSONArray containing a list of key strings. These will be
+     *            paired with the values.
+     * @return A JSONObject, or null if there are no names or if this JSONArray
+     *         has no values.
+     * @throws JSONException
+     *             If any of the names are null.
      */
     public JSONObject toJSONObject(JSONArray names) throws JSONException {
         if (names == null || names.isEmpty() || this.isEmpty()) {
@@ -1453,14 +1681,16 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Make a JSON text of this JSONArray. For compactness, no unnecessary whitespace is added. If it is not possible to
-     * produce a syntactically correct JSON text then null will be returned instead. This could occur if the array
-     * contains an invalid number.
+     * Make a JSON text of this JSONArray. For compactness, no unnecessary
+     * whitespace is added. If it is not possible to produce a syntactically
+     * correct JSON text then null will be returned instead. This could occur if
+     * the array contains an invalid number.
      * <p><b>
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
      *
-     * @return a printable, displayable, transmittable representation of the array.
+     * @return a printable, displayable, transmittable representation of the
+     *         array.
      */
     @Override
     public String toString() {
@@ -1490,10 +1720,12 @@ public class JSONArray implements Iterable<Object> {
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
      *
-     * @param indentFactor The number of spaces to add to each level of indentation.
-     * @return a printable, displayable, transmittable representation of the object, beginning with
-     * <code>[</code>&nbsp;<small>(left bracket)</small> and ending with <code>]</code> &nbsp;<small>(right
-     * bracket)</small>.
+     * @param indentFactor
+     *            The number of spaces to add to each level of indentation.
+     * @return a printable, displayable, transmittable representation of the
+     *         object, beginning with <code>[</code>&nbsp;<small>(left
+     *         bracket)</small> and ending with <code>]</code>
+     *         &nbsp;<small>(right bracket)</small>.
      * @throws JSONException if a called function fails
      */
     @SuppressWarnings("resource")
@@ -1503,11 +1735,11 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Write the contents of the JSONArray as JSON text to a writer. For compactness, no whitespace is added.
+     * Write the contents of the JSONArray as JSON text to a writer. For
+     * compactness, no whitespace is added.
      * <p><b>
      * Warning: This method assumes that the data structure is acyclical.
-     * </b>
-     *
+     *</b>
      * @param writer the writer object
      * @return The writer.
      * @throws JSONException if a called function fails
@@ -1535,15 +1767,18 @@ public class JSONArray implements Iterable<Object> {
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
      *
-     * @param writer       Writes the serialized JSON
-     * @param indentFactor The number of spaces to add to each level of indentation.
-     * @param indent       The indentation of the top level.
+     * @param writer
+     *            Writes the serialized JSON
+     * @param indentFactor
+     *            The number of spaces to add to each level of indentation.
+     * @param indent
+     *            The indentation of the top level.
      * @return The writer.
      * @throws JSONException if a called function fails or unable to write
      */
     @SuppressWarnings("resource")
     public Writer write(Writer writer, int indentFactor, int indent)
-        throws JSONException {
+            throws JSONException {
         try {
             boolean needsComma = false;
             int length = this.length();
@@ -1552,7 +1787,7 @@ public class JSONArray implements Iterable<Object> {
             if (length == 1) {
                 try {
                     JSONObject.writeValue(writer, this.myArrayList.get(0),
-                        indentFactor, indent);
+                            indentFactor, indent);
                 } catch (Exception e) {
                     throw new JSONException("Unable to write JSONArray value at index: 0", e);
                 }
@@ -1569,7 +1804,7 @@ public class JSONArray implements Iterable<Object> {
                     JSONObject.indent(writer, newIndent);
                     try {
                         JSONObject.writeValue(writer, this.myArrayList.get(i),
-                            indentFactor, newIndent);
+                                indentFactor, newIndent);
                     } catch (Exception e) {
                         throw new JSONException("Unable to write JSONArray value at index: " + i, e);
                     }
@@ -1588,8 +1823,9 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Returns a java.util.List containing all of the elements in this array. If an element in the array is a JSONArray
-     * or JSONObject it will also be converted to a List and a Map respectively.
+     * Returns a java.util.List containing all of the elements in this array.
+     * If an element in the array is a JSONArray or JSONObject it will also
+     * be converted to a List and a Map respectively.
      * <p>
      * Warning: This method assumes that the data structure is acyclical.
      *
@@ -1623,20 +1859,22 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Add a collection's elements to the JSONArray.
      *
-     * @param collection     A Collection.
-     * @param wrap           {@code true} to call {@link JSONObject#wrap(Object)} for each item, {@code false} to add
-     *                       the items directly
-     * @param recursionDepth Variable for tracking the count of nested object creations.
+     * @param collection
+     *            A Collection.
+     * @param wrap
+     *            {@code true} to call {@link JSONObject#wrap(Object)} for each item,
+     *            {@code false} to add the items directly
+     * @param recursionDepth
+     *            Variable for tracking the count of nested object creations.
      */
-    private void addAll(Collection<?> collection, boolean wrap, int recursionDepth,
-        JSONParserConfiguration jsonParserConfiguration) {
+    private void addAll(Collection<?> collection, boolean wrap, int recursionDepth, JSONParserConfiguration jsonParserConfiguration) {
         this.myArrayList.ensureCapacity(this.myArrayList.size() + collection.size());
         if (wrap) {
-            for (Object o : collection) {
+            for (Object o: collection){
                 this.put(JSONObject.wrap(o, recursionDepth + 1, jsonParserConfiguration));
             }
         } else {
-            for (Object o : collection) {
+            for (Object o: collection){
                 this.put(o);
             }
         }
@@ -1645,17 +1883,19 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Add an Iterable's elements to the JSONArray.
      *
-     * @param iter An Iterable.
-     * @param wrap {@code true} to call {@link JSONObject#wrap(Object)} for each item, {@code false} to add the items
-     *             directly
+     * @param iter
+     *            An Iterable.
+     * @param wrap
+     *            {@code true} to call {@link JSONObject#wrap(Object)} for each item,
+     *            {@code false} to add the items directly
      */
     private void addAll(Iterable<?> iter, boolean wrap) {
         if (wrap) {
-            for (Object o : iter) {
+            for (Object o: iter){
                 this.put(JSONObject.wrap(o));
             }
         } else {
-            for (Object o : iter) {
+            for (Object o: iter){
                 this.put(o);
             }
         }
@@ -1664,44 +1904,56 @@ public class JSONArray implements Iterable<Object> {
     /**
      * Add an array's elements to the JSONArray.
      *
-     * @param array Array. If the parameter passed is null, or not an array, JSONArray, Collection, or Iterable, an
-     *              exception will be thrown.
-     * @param wrap  {@code true} to call {@link JSONObject#wrap(Object)} for each item, {@code false} to add the items
-     *              directly
-     * @throws JSONException If not an array or if an array value is non-finite number.
+     * @param array
+     *          Array. If the parameter passed is null, or not an array,
+     *          JSONArray, Collection, or Iterable, an exception will be
+     *          thrown.
+     * @param wrap
+     *          {@code true} to call {@link JSONObject#wrap(Object)} for each item,
+     *          {@code false} to add the items directly
+     * @throws JSONException
+     *          If not an array or if an array value is non-finite number.
      */
     private void addAll(Object array, boolean wrap) throws JSONException {
-        this.addAll(array, wrap, 0);
+      this.addAll(array, wrap, 0);
     }
 
     /**
      * Add an array's elements to the JSONArray.
      *
-     * @param array          Array. If the parameter passed is null, or not an array, JSONArray, Collection, or
-     *                       Iterable, an exception will be thrown.
-     * @param wrap           {@code true} to call {@link JSONObject#wrap(Object)} for each item, {@code false} to add
-     *                       the items directly
-     * @param recursionDepth Variable for tracking the count of nested object creations.
+     * @param array
+     *            Array. If the parameter passed is null, or not an array,
+     *            JSONArray, Collection, or Iterable, an exception will be
+     *            thrown.
+     * @param wrap
+     *          {@code true} to call {@link JSONObject#wrap(Object)} for each item,
+     *          {@code false} to add the items directly
+     * @param recursionDepth
+     *          Variable for tracking the count of nested object creations.
      */
     private void addAll(Object array, boolean wrap, int recursionDepth) {
         addAll(array, wrap, recursionDepth, new JSONParserConfiguration());
     }
-
     /**
-     * Add an array's elements to the JSONArray. `
-     *
-     * @param array                   Array. If the parameter passed is null, or not an array, JSONArray, Collection, or
-     *                                Iterable, an exception will be thrown.
-     * @param wrap                    {@code true} to call {@link JSONObject#wrap(Object)} for each item, {@code false}
-     *                                to add the items directly
-     * @param recursionDepth          Variable for tracking the count of nested object creations.
-     * @param jsonParserConfiguration Variable to pass parser custom configuration for json parsing.
-     * @throws JSONException        If not an array or if an array value is non-finite number.
-     * @throws NullPointerException Thrown if the array parameter is null.
+     * Add an array's elements to the JSONArray.
+     *`
+     * @param array
+     *            Array. If the parameter passed is null, or not an array,
+     *            JSONArray, Collection, or Iterable, an exception will be
+     *            thrown.
+     * @param wrap
+     *            {@code true} to call {@link JSONObject#wrap(Object)} for each item,
+     *            {@code false} to add the items directly
+     * @param recursionDepth
+     *            Variable for tracking the count of nested object creations.
+     * @param jsonParserConfiguration
+     *            Variable to pass parser custom configuration for json parsing.
+     * @throws JSONException
+     *            If not an array or if an array value is non-finite number.
+     * @throws NullPointerException
+     *            Thrown if the array parameter is null.
      */
-    private void addAll(Object array, boolean wrap, int recursionDepth, JSONParserConfiguration
-        jsonParserConfiguration)
-        throws JSONException {
+    private void addAll(Object array, boolean wrap, int recursionDepth, JSONParserConfiguration jsonParserConfiguration) throws JSONException {
         if (array.getClass().isArray()) {
             int length = Array.getLength(array);
             this.myArrayList.ensureCapacity(this.myArrayList.size() + length);
@@ -1718,44 +1970,43 @@ public class JSONArray implements Iterable<Object> {
             // use the built in array list `addAll` as all object
             // wrapping should have been completed in the original
             // JSONArray
-            this.myArrayList.addAll(((JSONArray) array).myArrayList);
+            this.myArrayList.addAll(((JSONArray)array).myArrayList);
         } else if (array instanceof Collection) {
-            this.addAll((Collection<?>) array, wrap, recursionDepth);
+            this.addAll((Collection<?>)array, wrap, recursionDepth);
         } else if (array instanceof Iterable) {
-            this.addAll((Iterable<?>) array, wrap);
+            this.addAll((Iterable<?>)array, wrap);
         } else {
             throw new JSONException(
-                "JSONArray initial value should be a string or collection or array.");
+                    "JSONArray initial value should be a string or collection or array.");
         }
     }
 
     /**
      * Create a new JSONException in a common format for incorrect conversions.
-     *
-     * @param idx       index of the item
+     * @param idx index of the item
      * @param valueType the type of value being coerced to
-     * @param cause     optional cause of the coercion failure
+     * @param cause optional cause of the coercion failure
      * @return JSONException that can be thrown.
      */
     private static JSONException wrongValueFormatException(
-        int idx,
-        String valueType,
-        Object value,
-        Throwable cause) {
-        if (value == null) {
+            int idx,
+            String valueType,
+            Object value,
+            Throwable cause) {
+        if(value == null) {
             return new JSONException(
-                "JSONArray[" + idx + "] is not a " + valueType + " (null)."
-                , cause);
+                    "JSONArray[" + idx + "] is not a " + valueType + " (null)."
+                    , cause);
         }
         // don't try to toString collections or known object types that could be large.
-        if (value instanceof Map || value instanceof Iterable || value instanceof JSONObject) {
+        if(value instanceof Map || value instanceof Iterable || value instanceof JSONObject) {
             return new JSONException(
-                "JSONArray[" + idx + "] is not a " + valueType + " (" + value.getClass() + ")."
-                , cause);
+                    "JSONArray[" + idx + "] is not a " + valueType + " (" + value.getClass() + ")."
+                    , cause);
         }
         return new JSONException(
-            "JSONArray[" + idx + "] is not a " + valueType + " (" + value.getClass() + " : " + value + ")."
-            , cause);
+                "JSONArray[" + idx + "] is not a " + valueType + " (" + value.getClass() + " : " + value + ")."
+                , cause);
     }
 
 }

--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -113,11 +113,7 @@ public class JSONArray implements Iterable<Object> {
                     this.myArrayList.add(JSONObject.NULL);
                 } else {
                     x.back();
-                    if (jsonParserConfiguration.isStrictMode()) {
-                        this.myArrayList.add(x.nextValue(true));
-                    } else {
-                        this.myArrayList.add(x.nextValue());
-                    }
+                    this.myArrayList.add(x.nextValue(jsonParserConfiguration));
                 }
                 switch (x.nextClean()) {
                     case 0:

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -225,14 +225,7 @@ public class JSONObject {
                 case '}':
                     return;
                 default:
-                    String keyToValidate = getKeyToValidate(x, c, jsonParserConfiguration.isStrictMode());
-                    boolean keyHasQuotes = keyToValidate.startsWith("\"") && keyToValidate.endsWith("\"");
-
-                    if (jsonParserConfiguration.isStrictMode() && !keyHasQuotes) {
-                        throw new JSONException("Key is not surrounded by quotes: " + keyToValidate);
-                    }
-
-                    key = keyToValidate;
+                    key = x.nextSimpleValue(c, jsonParserConfiguration.isStrictMode()).toString();
             }
 
             // The key is followed by ':'.
@@ -285,11 +278,6 @@ public class JSONObject {
         }
         return x.nextValue();
     }
-
-    private String getKeyToValidate(JSONTokener x, char c, boolean strictMode) {
-        return x.nextSimpleValue(c, strictMode).toString();
-    }
-
     /**
      * Construct a JSONObject from a Map.
      *

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -225,7 +225,7 @@ public class JSONObject {
                 case '}':
                     return;
                 default:
-                    key = x.nextSimpleValue(c, jsonParserConfiguration.isStrictMode()).toString();
+                    key = x.nextSimpleValue(c, jsonParserConfiguration).toString();
             }
 
             // The key is followed by ':'.
@@ -244,7 +244,7 @@ public class JSONObject {
                     throw x.syntaxError("Duplicate key \"" + key + "\"");
                 }
 
-                Object value = getValue(x, jsonParserConfiguration.isStrictMode());
+                Object value = x.nextValue(jsonParserConfiguration);
                 // Only add value if non-null
                 if (value != null) {
                     this.put(key, value);
@@ -272,12 +272,6 @@ public class JSONObject {
         }
     }
 
-    private Object getValue(JSONTokener x, boolean strictMode) {
-        if (strictMode) {
-            return x.nextValue(true);
-        }
-        return x.nextValue();
-    }
     /**
      * Construct a JSONObject from a Map.
      *

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -15,51 +15,47 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.IdentityHashMap;
-import java.util.Iterator;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.ResourceBundle;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
- * A JSONObject is an unordered collection of name/value pairs. Its external form is a string wrapped in curly braces
- * with colons between the names and values, and commas between the values and names. The internal form is an object
- * having <code>get</code> and <code>opt</code> methods for accessing the values by name, and <code>put</code> methods
- * for adding or replacing values by name. The values can be any of these types: <code>Boolean</code>,
+ * A JSONObject is an unordered collection of name/value pairs. Its external
+ * form is a string wrapped in curly braces with colons between the names and
+ * values, and commas between the values and names. The internal form is an
+ * object having <code>get</code> and <code>opt</code> methods for accessing
+ * the values by name, and <code>put</code> methods for adding or replacing
+ * values by name. The values can be any of these types: <code>Boolean</code>,
  * <code>JSONArray</code>, <code>JSONObject</code>, <code>Number</code>,
  * <code>String</code>, or the <code>JSONObject.NULL</code> object. A
- * JSONObject constructor can be used to convert an external form JSON text into an internal form whose values can be
- * retrieved with the
+ * JSONObject constructor can be used to convert an external form JSON text
+ * into an internal form whose values can be retrieved with the
  * <code>get</code> and <code>opt</code> methods, or to convert values into a
  * JSON text using the <code>put</code> and <code>toString</code> methods. A
  * <code>get</code> method returns a value if one can be found, and throws an
- * exception if one cannot be found. An <code>opt</code> method returns a default value instead of throwing an
- * exception, and so is useful for obtaining optional values.
+ * exception if one cannot be found. An <code>opt</code> method returns a
+ * default value instead of throwing an exception, and so is useful for
+ * obtaining optional values.
  * <p>
- * The generic <code>get()</code> and <code>opt()</code> methods return an object, which you can cast or query for type.
- * There are also typed
+ * The generic <code>get()</code> and <code>opt()</code> methods return an
+ * object, which you can cast or query for type. There are also typed
  * <code>get</code> and <code>opt</code> methods that do type checking and type
- * coercion for you. The opt methods differ from the get methods in that they do not throw. Instead, they return a
- * specified value, such as null.
+ * coercion for you. The opt methods differ from the get methods in that they
+ * do not throw. Instead, they return a specified value, such as null.
  * <p>
- * The <code>put</code> methods add or replace values in an object. For example,
+ * The <code>put</code> methods add or replace values in an object. For
+ * example,
  *
  * <pre>
  * myString = new JSONObject()
  *         .put(&quot;JSON&quot;, &quot;Hello, World!&quot;).toString();
  * </pre>
- * <p>
+ *
  * produces the string <code>{"JSON": "Hello, World"}</code>.
  * <p>
- * The texts produced by the <code>toString</code> methods strictly conform to the JSON syntax rules. The constructors
- * are more forgiving in the texts they will accept:
+ * The texts produced by the <code>toString</code> methods strictly conform to
+ * the JSON syntax rules. The constructors are more forgiving in the texts they
+ * will accept:
  * <ul>
  * <li>An extra <code>,</code>&nbsp;<small>(comma)</small> may appear just
  * before the closing brace.</li>
@@ -77,15 +73,16 @@ import java.util.regex.Pattern;
  * @version 2016-08-15
  */
 public class JSONObject {
-
     /**
-     * JSONObject.NULL is equivalent to the value that JavaScript calls null, whilst Java's null is equivalent to the
-     * value that JavaScript calls undefined.
+     * JSONObject.NULL is equivalent to the value that JavaScript calls null,
+     * whilst Java's null is equivalent to the value that JavaScript calls
+     * undefined.
      */
     private static final class Null {
 
         /**
-         * There is only intended to be a single instance of the NULL object, so the clone method returns itself.
+         * There is only intended to be a single instance of the NULL object,
+         * so the clone method returns itself.
          *
          * @return NULL.
          */
@@ -97,15 +94,16 @@ public class JSONObject {
         /**
          * A Null object is equal to the null value and to itself.
          *
-         * @param object An object to test for nullness.
-         * @return true if the object parameter is the JSONObject.NULL object or null.
+         * @param object
+         *            An object to test for nullness.
+         * @return true if the object parameter is the JSONObject.NULL object or
+         *         null.
          */
         @Override
         @SuppressWarnings("lgtm[java/unchecked-cast-in-equals]")
         public boolean equals(Object object) {
             return object == null || object == this;
         }
-
         /**
          * A Null object is equal to the null value and to itself.
          *
@@ -128,8 +126,8 @@ public class JSONObject {
     }
 
     /**
-     * Regular Expression Pattern that matches JSON Numbers. This is primarily used for output to guarantee that we are
-     * always writing valid JSON.
+     *  Regular Expression Pattern that matches JSON Numbers. This is primarily used for
+     *  output to guarantee that we are always writing valid JSON.
      */
     static final Pattern NUMBER_PATTERN = Pattern.compile("-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?");
 
@@ -169,13 +167,16 @@ public class JSONObject {
     }
 
     /**
-     * Construct a JSONObject from a subset of another JSONObject. An array of strings is used to identify the keys that
-     * should be copied. Missing keys are ignored.
+     * Construct a JSONObject from a subset of another JSONObject. An array of
+     * strings is used to identify the keys that should be copied. Missing keys
+     * are ignored.
      *
-     * @param jo    A JSONObject.
-     * @param names An array of strings.
+     * @param jo
+     *            A JSONObject.
+     * @param names
+     *            An array of strings.
      */
-    public JSONObject(JSONObject jo, String... names) {
+    public JSONObject(JSONObject jo, String ... names) {
         this(names.length);
         for (int i = 0; i < names.length; i += 1) {
             try {
@@ -188,8 +189,11 @@ public class JSONObject {
     /**
      * Construct a JSONObject from a JSONTokener.
      *
-     * @param x A JSONTokener object containing the source string.
-     * @throws JSONException If there is a syntax error in the source string or a duplicated key.
+     * @param x
+     *            A JSONTokener object containing the source string.
+     * @throws JSONException
+     *             If there is a syntax error in the source string or a
+     *             duplicated key.
      */
     public JSONObject(JSONTokener x) throws JSONException {
         this(x, new JSONParserConfiguration());
@@ -198,9 +202,13 @@ public class JSONObject {
     /**
      * Construct a JSONObject from a JSONTokener with custom json parse configurations.
      *
-     * @param x                       A JSONTokener object containing the source string.
-     * @param jsonParserConfiguration Variable to pass parser custom configuration for json parsing.
-     * @throws JSONException If there is a syntax error in the source string or a duplicated key.
+     * @param x
+     *            A JSONTokener object containing the source string.
+     * @param jsonParserConfiguration
+     *            Variable to pass parser custom configuration for json parsing.
+     * @throws JSONException
+     *             If there is a syntax error in the source string or a
+     *             duplicated key.
      */
     public JSONObject(JSONTokener x, JSONParserConfiguration jsonParserConfiguration) throws JSONException {
         this();
@@ -254,20 +262,20 @@ public class JSONObject {
             // Pairs are separated by ','.
 
             switch (x.nextClean()) {
-                case ';':
-                case ',':
-                    if (x.nextClean() == '}') {
-                        return;
-                    }
-                    if (x.end()) {
-                        throw x.syntaxError("A JSONObject text must end with '}'");
-                    }
-                    x.back();
-                    break;
-                case '}':
+            case ';':
+            case ',':
+                if (x.nextClean() == '}') {
                     return;
-                default:
-                    throw x.syntaxError("Expected a ',' or '}'");
+                }
+                if (x.end()) {
+                    throw x.syntaxError("A JSONObject text must end with '}'");
+                }
+                x.back();
+                break;
+            case '}':
+                return;
+            default:
+                throw x.syntaxError("Expected a ',' or '}'");
             }
         }
     }
@@ -286,19 +294,26 @@ public class JSONObject {
     /**
      * Construct a JSONObject from a Map.
      *
-     * @param m A map object that can be used to initialize the contents of the JSONObject.
-     * @throws JSONException        If a value in the map is non-finite number.
-     * @throws NullPointerException If a key in the map is <code>null</code>
+     * @param m
+     *            A map object that can be used to initialize the contents of
+     *            the JSONObject.
+     * @throws JSONException
+     *            If a value in the map is non-finite number.
+     * @throws NullPointerException
+     *            If a key in the map is <code>null</code>
      */
     public JSONObject(Map<?, ?> m) {
-        this(m, 0, new JSONParserConfiguration());
+      this(m, 0, new JSONParserConfiguration());
     }
 
     /**
      * Construct a JSONObject from a Map with custom json parse configurations.
      *
-     * @param m                       A map object that can be used to initialize the contents of the JSONObject.
-     * @param jsonParserConfiguration Variable to pass parser custom configuration for json parsing.
+     * @param m
+     *            A map object that can be used to initialize the contents of
+     *            the JSONObject.
+     * @param jsonParserConfiguration
+     *            Variable to pass parser custom configuration for json parsing.
      */
     public JSONObject(Map<?, ?> m, JSONParserConfiguration jsonParserConfiguration) {
         this(m, 0, jsonParserConfiguration);
@@ -309,17 +324,16 @@ public class JSONObject {
      */
     private JSONObject(Map<?, ?> m, int recursionDepth, JSONParserConfiguration jsonParserConfiguration) {
         if (recursionDepth > jsonParserConfiguration.getMaxNestingDepth()) {
-            throw new JSONException(
-                "JSONObject has reached recursion depth limit of " + jsonParserConfiguration.getMaxNestingDepth());
+          throw new JSONException("JSONObject has reached recursion depth limit of " + jsonParserConfiguration.getMaxNestingDepth());
         }
         if (m == null) {
             this.map = new HashMap<String, Object>();
         } else {
             this.map = new HashMap<String, Object>(m.size());
-            for (final Entry<?, ?> e : m.entrySet()) {
-                if (e.getKey() == null) {
-                    throw new NullPointerException("Null key.");
-                }
+        	for (final Entry<?, ?> e : m.entrySet()) {
+        	    if(e.getKey() == null) {
+        	        throw new NullPointerException("Null key.");
+        	    }
                 final Object value = e.getValue();
                 if (value != null) {
                     testValidity(value);
@@ -330,24 +344,28 @@ public class JSONObject {
     }
 
     /**
-     * Construct a JSONObject from an Object using bean getters. It reflects on all of the public methods of the object.
-     * For each of the methods with no parameters and a name starting with <code>"get"</code> or
+     * Construct a JSONObject from an Object using bean getters. It reflects on
+     * all of the public methods of the object. For each of the methods with no
+     * parameters and a name starting with <code>"get"</code> or
      * <code>"is"</code> followed by an uppercase letter, the method is invoked,
-     * and a key and the value returned from the getter method are put into the new JSONObject.
+     * and a key and the value returned from the getter method are put into the
+     * new JSONObject.
      * <p>
-     * The key is formed by removing the <code>"get"</code> or <code>"is"</code> prefix. If the second remaining
-     * character is not upper case, then the first character is converted to lower case.
+     * The key is formed by removing the <code>"get"</code> or <code>"is"</code>
+     * prefix. If the second remaining character is not upper case, then the
+     * first character is converted to lower case.
      * <p>
-     * Methods that are <code>static</code>, return <code>void</code>, have parameters, or are "bridge" methods, are
-     * ignored.
+     * Methods that are <code>static</code>, return <code>void</code>,
+     * have parameters, or are "bridge" methods, are ignored.
      * <p>
-     * For example, if an object has a method named <code>"getName"</code>, and if the result of calling
-     * <code>object.getName()</code> is
+     * For example, if an object has a method named <code>"getName"</code>, and
+     * if the result of calling <code>object.getName()</code> is
      * <code>"Larry Fine"</code>, then the JSONObject will contain
      * <code>"name": "Larry Fine"</code>.
      * <p>
-     * The {@link JSONPropertyName} annotation can be used on a bean getter to override key name used in the JSONObject.
-     * For example, using the object above with the <code>getName</code> method, if we annotated it with:
+     * The {@link JSONPropertyName} annotation can be used on a bean getter to
+     * override key name used in the JSONObject. For example, using the object
+     * above with the <code>getName</code> method, if we annotated it with:
      * <pre>
      * &#64;JSONPropertyName("FullName")
      * public String getName() { return this.name; }
@@ -356,27 +374,33 @@ public class JSONObject {
      * <p>
      * Similarly, the {@link JSONPropertyName} annotation can be used on non-
      * <code>get</code> and <code>is</code> methods. We can also override key
-     * name used in the JSONObject as seen below even though the field would normally be ignored:
+     * name used in the JSONObject as seen below even though the field would normally
+     * be ignored:
      * <pre>
      * &#64;JSONPropertyName("FullName")
      * public String fullName() { return this.name; }
      * </pre>
      * The resulting JSON object would contain <code>"FullName": "Larry Fine"</code>
      * <p>
-     * The {@link JSONPropertyIgnore} annotation can be used to force the bean property to not be serialized into JSON.
-     * If both {@link JSONPropertyIgnore} and {@link JSONPropertyName} are defined on the same method, a depth
-     * comparison is performed and the one closest to the concrete class being serialized is used. If both annotations
-     * are at the same level, then the {@link JSONPropertyIgnore} annotation takes precedent and the field is not
-     * serialized. For example, the following declaration would prevent the <code>getName</code> method from being
-     * serialized:
+     * The {@link JSONPropertyIgnore} annotation can be used to force the bean property
+     * to not be serialized into JSON. If both {@link JSONPropertyIgnore} and
+     * {@link JSONPropertyName} are defined on the same method, a depth comparison is
+     * performed and the one closest to the concrete class being serialized is used.
+     * If both annotations are at the same level, then the {@link JSONPropertyIgnore}
+     * annotation takes precedent and the field is not serialized.
+     * For example, the following declaration would prevent the <code>getName</code>
+     * method from being serialized:
      * <pre>
      * &#64;JSONPropertyName("FullName")
      * &#64;JSONPropertyIgnore
      * public String getName() { return this.name; }
      * </pre>
      *
-     * @param bean An object that has getter methods that should be used to make a JSONObject.
-     * @throws JSONException If a getter returned a non-finite number.
+     * @param bean
+     *            An object that has getter methods that should be used to make
+     *            a JSONObject.
+     * @throws JSONException
+     *            If a getter returned a non-finite number.
      */
     public JSONObject(Object bean) {
         this();
@@ -389,14 +413,20 @@ public class JSONObject {
     }
 
     /**
-     * Construct a JSONObject from an Object, using reflection to find the public members. The resulting JSONObject's
-     * keys will be the strings from the names array, and the values will be the field values associated with those keys
-     * in the object. If a key is not found or not visible, then it will not be copied into the new JSONObject.
+     * Construct a JSONObject from an Object, using reflection to find the
+     * public members. The resulting JSONObject's keys will be the strings from
+     * the names array, and the values will be the field values associated with
+     * those keys in the object. If a key is not found or not visible, then it
+     * will not be copied into the new JSONObject.
      *
-     * @param object An object that has fields that should be used to make a JSONObject.
-     * @param names  An array of strings, the names of the fields to be obtained from the object.
+     * @param object
+     *            An object that has fields that should be used to make a
+     *            JSONObject.
+     * @param names
+     *            An array of strings, the names of the fields to be obtained
+     *            from the object.
      */
-    public JSONObject(Object object, String... names) {
+    public JSONObject(Object object, String ... names) {
         this(names.length);
         Class<?> c = object.getClass();
         for (int i = 0; i < names.length; i += 1) {
@@ -409,24 +439,34 @@ public class JSONObject {
     }
 
     /**
-     * Construct a JSONObject from a source JSON text string. This is the most commonly used JSONObject constructor.
+     * Construct a JSONObject from a source JSON text string. This is the most
+     * commonly used JSONObject constructor.
      *
-     * @param source A string beginning with <code>{</code>&nbsp;<small>(left brace)</small> and ending with
-     *               <code>}</code> &nbsp;<small>(right brace)</small>.
-     * @throws JSONException If there is a syntax error in the source string or a duplicated key.
+     * @param source
+     *            A string beginning with <code>{</code>&nbsp;<small>(left
+     *            brace)</small> and ending with <code>}</code>
+     *            &nbsp;<small>(right brace)</small>.
+     * @exception JSONException
+     *                If there is a syntax error in the source string or a
+     *                duplicated key.
      */
     public JSONObject(String source) throws JSONException {
         this(source, new JSONParserConfiguration());
     }
 
     /**
-     * Construct a JSONObject from a source JSON text string with custom json parse configurations. This is the most
-     * commonly used JSONObject constructor.
+     * Construct a JSONObject from a source JSON text string with custom json parse configurations.
+     * This is the most commonly used JSONObject constructor.
      *
-     * @param source                  A string beginning with <code>{</code>&nbsp;<small>(left brace)</small> and ending
-     *                                with <code>}</code> &nbsp;<small>(right brace)</small>.
-     * @param jsonParserConfiguration Variable to pass parser custom configuration for json parsing.
-     * @throws JSONException If there is a syntax error in the source string or a duplicated key.
+     * @param source
+     *            A string beginning with <code>{</code>&nbsp;<small>(left
+     *            brace)</small> and ending with <code>}</code>
+     *            &nbsp;<small>(right brace)</small>.
+     * @param jsonParserConfiguration
+     *            Variable to pass parser custom configuration for json parsing.
+     * @exception JSONException
+     *                If there is a syntax error in the source string or a
+     *                duplicated key.
      */
     public JSONObject(String source, JSONParserConfiguration jsonParserConfiguration) throws JSONException {
         this(new JSONTokener(source), jsonParserConfiguration);
@@ -435,14 +475,17 @@ public class JSONObject {
     /**
      * Construct a JSONObject from a ResourceBundle.
      *
-     * @param baseName The ResourceBundle base name.
-     * @param locale   The Locale to load the ResourceBundle for.
-     * @throws JSONException If any JSONExceptions are detected.
+     * @param baseName
+     *            The ResourceBundle base name.
+     * @param locale
+     *            The Locale to load the ResourceBundle for.
+     * @throws JSONException
+     *             If any JSONExceptions are detected.
      */
     public JSONObject(String baseName, Locale locale) throws JSONException {
         this();
         ResourceBundle bundle = ResourceBundle.getBundle(baseName, locale,
-            Thread.currentThread().getContextClassLoader());
+                Thread.currentThread().getContextClassLoader());
 
 // Iterate through the keys in the bundle.
 
@@ -473,36 +516,44 @@ public class JSONObject {
     }
 
     /**
-     * Constructor to specify an initial capacity of the internal map. Useful for library internal calls where we know,
-     * or at least can best guess, how big this JSONObject will be.
+     * Constructor to specify an initial capacity of the internal map. Useful for library
+     * internal calls where we know, or at least can best guess, how big this JSONObject
+     * will be.
      *
      * @param initialCapacity initial capacity of the internal map.
      */
-    protected JSONObject(int initialCapacity) {
+    protected JSONObject(int initialCapacity){
         this.map = new HashMap<String, Object>(initialCapacity);
     }
 
     /**
-     * Accumulate values under a key. It is similar to the put method except that if there is already an object stored
-     * under the key then a JSONArray is stored under the key to hold all of the accumulated values. If there is already
-     * a JSONArray, then the new value is appended to it. In contrast, the put method replaces the previous value.
-     * <p>
-     * If only one value is accumulated that is not a JSONArray, then the result will be the same as using put. But if
-     * multiple values are accumulated, then the result will be like append.
+     * Accumulate values under a key. It is similar to the put method except
+     * that if there is already an object stored under the key then a JSONArray
+     * is stored under the key to hold all of the accumulated values. If there
+     * is already a JSONArray, then the new value is appended to it. In
+     * contrast, the put method replaces the previous value.
      *
-     * @param key   A key string.
-     * @param value An object to be accumulated under the key.
+     * If only one value is accumulated that is not a JSONArray, then the result
+     * will be the same as using put. But if multiple values are accumulated,
+     * then the result will be like append.
+     *
+     * @param key
+     *            A key string.
+     * @param value
+     *            An object to be accumulated under the key.
      * @return this.
-     * @throws JSONException        If the value is non-finite number.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject accumulate(String key, Object value) throws JSONException {
         testValidity(value);
         Object object = this.opt(key);
         if (object == null) {
             this.put(key,
-                value instanceof JSONArray ? new JSONArray().put(value)
-                    : value);
+                    value instanceof JSONArray ? new JSONArray().put(value)
+                            : value);
         } else if (object instanceof JSONArray) {
             ((JSONArray) object).put(value);
         } else {
@@ -512,16 +563,21 @@ public class JSONObject {
     }
 
     /**
-     * Append values to the array under a key. If the key does not exist in the JSONObject, then the key is put in the
-     * JSONObject with its value being a JSONArray containing the value parameter. If the key was already associated
-     * with a JSONArray, then the value parameter is appended to it.
+     * Append values to the array under a key. If the key does not exist in the
+     * JSONObject, then the key is put in the JSONObject with its value being a
+     * JSONArray containing the value parameter. If the key was already
+     * associated with a JSONArray, then the value parameter is appended to it.
      *
-     * @param key   A key string.
-     * @param value An object to be accumulated under the key.
+     * @param key
+     *            A key string.
+     * @param value
+     *            An object to be accumulated under the key.
      * @return this.
-     * @throws JSONException        If the value is non-finite number or if the current value associated with the key is
-     *                              not a JSONArray.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number or if the current value associated with
+     *             the key is not a JSONArray.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject append(String key, Object value) throws JSONException {
         testValidity(value);
@@ -537,9 +593,11 @@ public class JSONObject {
     }
 
     /**
-     * Produce a string from a double. The string "null" will be returned if the number is not finite.
+     * Produce a string from a double. The string "null" will be returned if the
+     * number is not finite.
      *
-     * @param d A double.
+     * @param d
+     *            A double.
      * @return A String.
      */
     public static String doubleToString(double d) {
@@ -551,7 +609,7 @@ public class JSONObject {
 
         String string = Double.toString(d);
         if (string.indexOf('.') > 0 && string.indexOf('e') < 0
-            && string.indexOf('E') < 0) {
+                && string.indexOf('E') < 0) {
             while (string.endsWith("0")) {
                 string = string.substring(0, string.length() - 1);
             }
@@ -565,9 +623,11 @@ public class JSONObject {
     /**
      * Get the value object associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The object associated with the key.
-     * @throws JSONException if the key is not found.
+     * @throws JSONException
+     *             if the key is not found.
      */
     public Object get(String key) throws JSONException {
         if (key == null) {
@@ -583,15 +643,20 @@ public class JSONObject {
     /**
      * Get the enum value associated with a key.
      *
-     * @param <E>   Enum Type
-     * @param clazz The type of enum to retrieve.
-     * @param key   A key string.
+     * @param <E>
+     *            Enum Type
+     * @param clazz
+     *           The type of enum to retrieve.
+     * @param key
+     *           A key string.
      * @return The enum value associated with the key
-     * @throws JSONException if the key is not found or if the value cannot be converted to an enum.
+     * @throws JSONException
+     *             if the key is not found or if the value cannot be converted
+     *             to an enum.
      */
     public <E extends Enum<E>> E getEnum(Class<E> clazz, String key) throws JSONException {
         E val = optEnum(clazz, key);
-        if (val == null) {
+        if(val==null) {
             // JSONException should really take a throwable argument.
             // If it did, I would re-implement this with the Enum.valueOf
             // method and place any thrown exception in the JSONException
@@ -603,19 +668,22 @@ public class JSONObject {
     /**
      * Get the boolean value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The truth.
-     * @throws JSONException if the value is not a Boolean or the String "true" or "false".
+     * @throws JSONException
+     *             if the value is not a Boolean or the String "true" or
+     *             "false".
      */
     public boolean getBoolean(String key) throws JSONException {
         Object object = this.get(key);
         if (object.equals(Boolean.FALSE)
-            || (object instanceof String && ((String) object)
-            .equalsIgnoreCase("false"))) {
+                || (object instanceof String && ((String) object)
+                        .equalsIgnoreCase("false"))) {
             return false;
         } else if (object.equals(Boolean.TRUE)
-            || (object instanceof String && ((String) object)
-            .equalsIgnoreCase("true"))) {
+                || (object instanceof String && ((String) object)
+                        .equalsIgnoreCase("true"))) {
             return true;
         }
         throw wrongValueFormatException(key, "Boolean", object, null);
@@ -624,9 +692,12 @@ public class JSONObject {
     /**
      * Get the BigInteger value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The numeric value.
-     * @throws JSONException if the key is not found or if the value cannot be converted to BigInteger.
+     * @throws JSONException
+     *             if the key is not found or if the value cannot
+     *             be converted to BigInteger.
      */
     public BigInteger getBigInteger(String key) throws JSONException {
         Object object = this.get(key);
@@ -638,13 +709,17 @@ public class JSONObject {
     }
 
     /**
-     * Get the BigDecimal value associated with a key. If the value is float or double, the
-     * {@link BigDecimal#BigDecimal(double)} constructor will be used. See notes on the constructor for conversion
-     * issues that may arise.
+     * Get the BigDecimal value associated with a key. If the value is float or
+     * double, the {@link BigDecimal#BigDecimal(double)} constructor will
+     * be used. See notes on the constructor for conversion issues that may
+     * arise.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The numeric value.
-     * @throws JSONException if the key is not found or if the value cannot be converted to BigDecimal.
+     * @throws JSONException
+     *             if the key is not found or if the value
+     *             cannot be converted to BigDecimal.
      */
     public BigDecimal getBigDecimal(String key) throws JSONException {
         Object object = this.get(key);
@@ -658,15 +733,17 @@ public class JSONObject {
     /**
      * Get the double value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The numeric value.
-     * @throws JSONException if the key is not found or if the value is not a Number object and cannot be converted to a
-     *                       number.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a Number
+     *             object and cannot be converted to a number.
      */
     public double getDouble(String key) throws JSONException {
         final Object object = this.get(key);
-        if (object instanceof Number) {
-            return ((Number) object).doubleValue();
+        if(object instanceof Number) {
+            return ((Number)object).doubleValue();
         }
         try {
             return Double.parseDouble(object.toString());
@@ -678,15 +755,17 @@ public class JSONObject {
     /**
      * Get the float value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The numeric value.
-     * @throws JSONException if the key is not found or if the value is not a Number object and cannot be converted to a
-     *                       number.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a Number
+     *             object and cannot be converted to a number.
      */
     public float getFloat(String key) throws JSONException {
         final Object object = this.get(key);
-        if (object instanceof Number) {
-            return ((Number) object).floatValue();
+        if(object instanceof Number) {
+            return ((Number)object).floatValue();
         }
         try {
             return Float.parseFloat(object.toString());
@@ -698,16 +777,18 @@ public class JSONObject {
     /**
      * Get the Number value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The numeric value.
-     * @throws JSONException if the key is not found or if the value is not a Number object and cannot be converted to a
-     *                       number.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a Number
+     *             object and cannot be converted to a number.
      */
     public Number getNumber(String key) throws JSONException {
         Object object = this.get(key);
         try {
             if (object instanceof Number) {
-                return (Number) object;
+                return (Number)object;
             }
             return stringToNumber(object.toString());
         } catch (Exception e) {
@@ -718,14 +799,17 @@ public class JSONObject {
     /**
      * Get the int value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The integer value.
-     * @throws JSONException if the key is not found or if the value cannot be converted to an integer.
+     * @throws JSONException
+     *             if the key is not found or if the value cannot be converted
+     *             to an integer.
      */
     public int getInt(String key) throws JSONException {
         final Object object = this.get(key);
-        if (object instanceof Number) {
-            return ((Number) object).intValue();
+        if(object instanceof Number) {
+            return ((Number)object).intValue();
         }
         try {
             return Integer.parseInt(object.toString());
@@ -737,9 +821,11 @@ public class JSONObject {
     /**
      * Get the JSONArray value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return A JSONArray which is the value.
-     * @throws JSONException if the key is not found or if the value is not a JSONArray.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a JSONArray.
      */
     public JSONArray getJSONArray(String key) throws JSONException {
         Object object = this.get(key);
@@ -752,9 +838,11 @@ public class JSONObject {
     /**
      * Get the JSONObject value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return A JSONObject which is the value.
-     * @throws JSONException if the key is not found or if the value is not a JSONObject.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a JSONObject.
      */
     public JSONObject getJSONObject(String key) throws JSONException {
         Object object = this.get(key);
@@ -767,14 +855,17 @@ public class JSONObject {
     /**
      * Get the long value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The long value.
-     * @throws JSONException if the key is not found or if the value cannot be converted to a long.
+     * @throws JSONException
+     *             if the key is not found or if the value cannot be converted
+     *             to a long.
      */
     public long getLong(String key) throws JSONException {
         final Object object = this.get(key);
-        if (object instanceof Number) {
-            return ((Number) object).longValue();
+        if(object instanceof Number) {
+            return ((Number)object).longValue();
         }
         try {
             return Long.parseLong(object.toString());
@@ -786,7 +877,8 @@ public class JSONObject {
     /**
      * Get an array of field names from a JSONObject.
      *
-     * @param jo JSON object
+     * @param jo
+     *            JSON object
      * @return An array of field names, or null if there are no names.
      */
     public static String[] getNames(JSONObject jo) {
@@ -799,7 +891,8 @@ public class JSONObject {
     /**
      * Get an array of public field names from an Object.
      *
-     * @param object object to read
+     * @param object
+     *            object to read
      * @return An array of field names, or null if there are no names.
      */
     public static String[] getNames(Object object) {
@@ -822,9 +915,11 @@ public class JSONObject {
     /**
      * Get the string associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return A string which is the value.
-     * @throws JSONException if there is no string value for the key.
+     * @throws JSONException
+     *             if there is no string value for the key.
      */
     public String getString(String key) throws JSONException {
         Object object = this.get(key);
@@ -837,7 +932,8 @@ public class JSONObject {
     /**
      * Determine if the JSONObject contains a specific key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return true if the key exists in the JSONObject.
      */
     public boolean has(String key) {
@@ -845,15 +941,19 @@ public class JSONObject {
     }
 
     /**
-     * Increment a property of a JSONObject. If there is no such property, create one with a value of 1 (Integer). If
-     * there is such a property, and if it is an Integer, Long, Double, Float, BigInteger, or BigDecimal then add one to
-     * it. No overflow bounds checking is performed, so callers should initialize the key prior to this call with an
-     * appropriate type that can handle the maximum expected value.
+     * Increment a property of a JSONObject. If there is no such property,
+     * create one with a value of 1 (Integer). If there is such a property, and if it is
+     * an Integer, Long, Double, Float, BigInteger, or BigDecimal then add one to it.
+     * No overflow bounds checking is performed, so callers should initialize the key
+     * prior to this call with an appropriate type that can handle the maximum expected
+     * value.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return this.
-     * @throws JSONException If there is already a property with this name that is not an Integer, Long, Double, or
-     *                       Float.
+     * @throws JSONException
+     *             If there is already a property with this name that is not an
+     *             Integer, Long, Double, or Float.
      */
     public JSONObject increment(String key) throws JSONException {
         Object value = this.opt(key);
@@ -864,13 +964,13 @@ public class JSONObject {
         } else if (value instanceof Long) {
             this.put(key, ((Long) value).longValue() + 1L);
         } else if (value instanceof BigInteger) {
-            this.put(key, ((BigInteger) value).add(BigInteger.ONE));
+            this.put(key, ((BigInteger)value).add(BigInteger.ONE));
         } else if (value instanceof Float) {
             this.put(key, ((Float) value).floatValue() + 1.0f);
         } else if (value instanceof Double) {
             this.put(key, ((Double) value).doubleValue() + 1.0d);
         } else if (value instanceof BigDecimal) {
-            this.put(key, ((BigDecimal) value).add(BigDecimal.ONE));
+            this.put(key, ((BigDecimal)value).add(BigDecimal.ONE));
         } else {
             throw new JSONException("Unable to increment [" + quote(key) + "].");
         }
@@ -878,45 +978,53 @@ public class JSONObject {
     }
 
     /**
-     * Determine if the value associated with the key is <code>null</code> or if there is no value.
+     * Determine if the value associated with the key is <code>null</code> or if there is no
+     * value.
      *
-     * @param key A key string.
-     * @return true if there is no value associated with the key or if the value is the JSONObject.NULL object.
+     * @param key
+     *            A key string.
+     * @return true if there is no value associated with the key or if the value
+     *        is the JSONObject.NULL object.
      */
     public boolean isNull(String key) {
         return JSONObject.NULL.equals(this.opt(key));
     }
 
     /**
-     * Get an enumeration of the keys of the JSONObject. Modifying this key Set will also modify the JSONObject. Use
-     * with caution.
+     * Get an enumeration of the keys of the JSONObject. Modifying this key Set will also
+     * modify the JSONObject. Use with caution.
+     *
+     * @see Set#iterator()
      *
      * @return An iterator of the keys.
-     * @see Set#iterator()
      */
     public Iterator<String> keys() {
         return this.keySet().iterator();
     }
 
     /**
-     * Get a set of keys of the JSONObject. Modifying this key Set will also modify the JSONObject. Use with caution.
+     * Get a set of keys of the JSONObject. Modifying this key Set will also modify the
+     * JSONObject. Use with caution.
+     *
+     * @see Map#keySet()
      *
      * @return A keySet.
-     * @see Map#keySet()
      */
     public Set<String> keySet() {
         return this.map.keySet();
     }
 
     /**
-     * Get a set of entries of the JSONObject. These are raw values and may not match what is returned by the JSONObject
-     * get* and opt* functions. Modifying the returned EntrySet or the Entry objects contained therein will modify the
+     * Get a set of entries of the JSONObject. These are raw values and may not
+     * match what is returned by the JSONObject get* and opt* functions. Modifying
+     * the returned EntrySet or the Entry objects contained therein will modify the
      * backing JSONObject. This does not return a clone or a read-only view.
-     * <p>
+     *
      * Use with caution.
      *
-     * @return An Entry Set
      * @see Map#entrySet()
+     *
+     * @return An Entry Set
      */
     protected Set<Entry<String, Object>> entrySet() {
         return this.map.entrySet();
@@ -932,7 +1040,8 @@ public class JSONObject {
     }
 
     /**
-     * Removes all of the elements from this JSONObject. The JSONObject will be empty after this call returns.
+     * Removes all of the elements from this JSONObject.
+     * The JSONObject will be empty after this call returns.
      */
     public void clear() {
         this.map.clear();
@@ -948,23 +1057,27 @@ public class JSONObject {
     }
 
     /**
-     * Produce a JSONArray containing the names of the elements of this JSONObject.
+     * Produce a JSONArray containing the names of the elements of this
+     * JSONObject.
      *
-     * @return A JSONArray containing the key strings, or null if the JSONObject is empty.
+     * @return A JSONArray containing the key strings, or null if the JSONObject
+     *        is empty.
      */
     public JSONArray names() {
-        if (this.map.isEmpty()) {
-            return null;
-        }
+    	if(this.map.isEmpty()) {
+    		return null;
+    	}
         return new JSONArray(this.map.keySet());
     }
 
     /**
      * Produce a string from a Number.
      *
-     * @param number A Number
+     * @param number
+     *            A Number
      * @return A String.
-     * @throws JSONException If n is a non-finite number.
+     * @throws JSONException
+     *             If n is a non-finite number.
      */
     public static String numberToString(Number number) throws JSONException {
         if (number == null) {
@@ -976,7 +1089,7 @@ public class JSONObject {
 
         String string = number.toString();
         if (string.indexOf('.') > 0 && string.indexOf('e') < 0
-            && string.indexOf('E') < 0) {
+                && string.indexOf('E') < 0) {
             while (string.endsWith("0")) {
                 string = string.substring(0, string.length() - 1);
             }
@@ -990,7 +1103,8 @@ public class JSONObject {
     /**
      * Get an optional value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return An object which is the value, or null if there is no value.
      */
     public Object opt(String key) {
@@ -1000,9 +1114,12 @@ public class JSONObject {
     /**
      * Get the enum value associated with a key.
      *
-     * @param <E>   Enum Type
-     * @param clazz The type of enum to retrieve.
-     * @param key   A key string.
+     * @param <E>
+     *            Enum Type
+     * @param clazz
+     *            The type of enum to retrieve.
+     * @param key
+     *            A key string.
      * @return The enum value associated with the key or null if not found
      */
     public <E extends Enum<E>> E optEnum(Class<E> clazz, String key) {
@@ -1012,12 +1129,16 @@ public class JSONObject {
     /**
      * Get the enum value associated with a key.
      *
-     * @param <E>          Enum Type
-     * @param clazz        The type of enum to retrieve.
-     * @param key          A key string.
-     * @param defaultValue The default in case the value is not found
-     * @return The enum value associated with the key or defaultValue if the value is not found or cannot be assigned to
-     * <code>clazz</code>
+     * @param <E>
+     *            Enum Type
+     * @param clazz
+     *            The type of enum to retrieve.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default in case the value is not found
+     * @return The enum value associated with the key or defaultValue
+     *            if the value is not found or cannot be assigned to <code>clazz</code>
      */
     public <E extends Enum<E>> E optEnum(Class<E> clazz, String key, E defaultValue) {
         try {
@@ -1040,10 +1161,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional boolean associated with a key. It returns false if there is no such key, or if the value is not
-     * Boolean.TRUE or the String "true".
+     * Get an optional boolean associated with a key. It returns false if there
+     * is no such key, or if the value is not Boolean.TRUE or the String "true".
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The truth.
      */
     public boolean optBoolean(String key) {
@@ -1051,11 +1173,14 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional boolean associated with a key. It returns the defaultValue if there is no such key, or if it is
-     * not a Boolean or the String "true" or "false" (case insensitive).
+     * Get an optional boolean associated with a key. It returns the
+     * defaultValue if there is no such key, or if it is not a Boolean or the
+     * String "true" or "false" (case insensitive).
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return The truth.
      */
     public boolean optBoolean(String key, boolean defaultValue) {
@@ -1063,7 +1188,7 @@ public class JSONObject {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof Boolean) {
+        if (val instanceof Boolean){
             return ((Boolean) val).booleanValue();
         }
         try {
@@ -1075,10 +1200,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional boolean object associated with a key. It returns false if there is no such key, or if the value
-     * is not Boolean.TRUE or the String "true".
+     * Get an optional boolean object associated with a key. It returns false if there
+     * is no such key, or if the value is not Boolean.TRUE or the String "true".
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The truth.
      */
     public Boolean optBooleanObject(String key) {
@@ -1086,11 +1212,14 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional boolean object associated with a key. It returns the defaultValue if there is no such key, or if
-     * it is not a Boolean or the String "true" or "false" (case insensitive).
+     * Get an optional boolean object associated with a key. It returns the
+     * defaultValue if there is no such key, or if it is not a Boolean or the
+     * String "true" or "false" (case insensitive).
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return The truth.
      */
     public Boolean optBooleanObject(String key, Boolean defaultValue) {
@@ -1098,7 +1227,7 @@ public class JSONObject {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof Boolean) {
+        if (val instanceof Boolean){
             return ((Boolean) val).booleanValue();
         }
         try {
@@ -1110,13 +1239,17 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional BigDecimal associated with a key, or the defaultValue if there is no such key or if its value is
-     * not a number. If the value is a string, an attempt will be made to evaluate it as a number. If the value is float
-     * or double, then the {@link BigDecimal#BigDecimal(double)} constructor will be used. See notes on the constructor
-     * for conversion issues that may arise.
+     * Get an optional BigDecimal associated with a key, or the defaultValue if
+     * there is no such key or if its value is not a number. If the value is a
+     * string, an attempt will be made to evaluate it as a number. If the value
+     * is float or double, then the {@link BigDecimal#BigDecimal(double)}
+     * constructor will be used. See notes on the constructor for conversion
+     * issues that may arise.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public BigDecimal optBigDecimal(String key, BigDecimal defaultValue) {
@@ -1125,38 +1258,39 @@ public class JSONObject {
     }
 
     /**
-     * @param val          value to convert
+     * @param val value to convert
      * @param defaultValue default value to return is the conversion doesn't work or is null.
-     * @return BigDecimal conversion of the original value, or the defaultValue if unable to convert.
+     * @return BigDecimal conversion of the original value, or the defaultValue if unable
+     *          to convert.
      */
     static BigDecimal objectToBigDecimal(Object val, BigDecimal defaultValue) {
         return objectToBigDecimal(val, defaultValue, true);
     }
 
     /**
-     * @param val          value to convert
+     * @param val value to convert
      * @param defaultValue default value to return is the conversion doesn't work or is null.
-     * @param exact        When <code>true</code>, then {@link Double} and {@link Float} values will be converted
-     *                     exactly. When <code>false</code>, they will be converted to {@link String} values before
-     *                     converting to {@link BigDecimal}.
-     * @return BigDecimal conversion of the original value, or the defaultValue if unable to convert.
+     * @param exact When <code>true</code>, then {@link Double} and {@link Float} values will be converted exactly.
+     *      When <code>false</code>, they will be converted to {@link String} values before converting to {@link BigDecimal}.
+     * @return BigDecimal conversion of the original value, or the defaultValue if unable
+     *          to convert.
      */
     static BigDecimal objectToBigDecimal(Object val, BigDecimal defaultValue, boolean exact) {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof BigDecimal) {
+        if (val instanceof BigDecimal){
             return (BigDecimal) val;
         }
-        if (val instanceof BigInteger) {
+        if (val instanceof BigInteger){
             return new BigDecimal((BigInteger) val);
         }
-        if (val instanceof Double || val instanceof Float) {
-            if (!numberIsFinite((Number) val)) {
+        if (val instanceof Double || val instanceof Float){
+            if (!numberIsFinite((Number)val)) {
                 return defaultValue;
             }
             if (exact) {
-                return new BigDecimal(((Number) val).doubleValue());
+                return new BigDecimal(((Number)val).doubleValue());
             }
             // use the string constructor so that we maintain "nice" values for doubles and floats
             // the double constructor will translate doubles to "exact" values instead of the likely
@@ -1164,7 +1298,7 @@ public class JSONObject {
             return new BigDecimal(val.toString());
         }
         if (val instanceof Long || val instanceof Integer
-            || val instanceof Short || val instanceof Byte) {
+                || val instanceof Short || val instanceof Byte){
             return new BigDecimal(((Number) val).longValue());
         }
         // don't check if it's a string in case of unchecked Number subclasses
@@ -1176,11 +1310,14 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional BigInteger associated with a key, or the defaultValue if there is no such key or if its value is
-     * not a number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional BigInteger associated with a key, or the defaultValue if
+     * there is no such key or if its value is not a number. If the value is a
+     * string, an attempt will be made to evaluate it as a number.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public BigInteger optBigInteger(String key, BigInteger defaultValue) {
@@ -1189,28 +1326,29 @@ public class JSONObject {
     }
 
     /**
-     * @param val          value to convert
+     * @param val value to convert
      * @param defaultValue default value to return is the conversion doesn't work or is null.
-     * @return BigInteger conversion of the original value, or the defaultValue if unable to convert.
+     * @return BigInteger conversion of the original value, or the defaultValue if unable
+     *          to convert.
      */
     static BigInteger objectToBigInteger(Object val, BigInteger defaultValue) {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof BigInteger) {
+        if (val instanceof BigInteger){
             return (BigInteger) val;
         }
-        if (val instanceof BigDecimal) {
+        if (val instanceof BigDecimal){
             return ((BigDecimal) val).toBigInteger();
         }
-        if (val instanceof Double || val instanceof Float) {
-            if (!numberIsFinite((Number) val)) {
+        if (val instanceof Double || val instanceof Float){
+            if (!numberIsFinite((Number)val)) {
                 return defaultValue;
             }
             return new BigDecimal(((Number) val).doubleValue()).toBigInteger();
         }
         if (val instanceof Long || val instanceof Integer
-            || val instanceof Short || val instanceof Byte) {
+                || val instanceof Short || val instanceof Byte){
             return BigInteger.valueOf(((Number) val).longValue());
         }
         // don't check if it's a string in case of unchecked Number subclasses
@@ -1221,7 +1359,7 @@ public class JSONObject {
             // this conversion to BigDecimal then to BigInteger is to maintain
             // that type cast support that may truncate the decimal.
             final String valStr = val.toString();
-            if (isDecimalNotation(valStr)) {
+            if(isDecimalNotation(valStr)) {
                 return new BigDecimal(valStr).toBigInteger();
             }
             return new BigInteger(valStr);
@@ -1231,10 +1369,12 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional double associated with a key, or NaN if there is no such key or if its value is not a number. If
-     * the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional double associated with a key, or NaN if there is no such
+     * key or if its value is not a number. If the value is a string, an attempt
+     * will be made to evaluate it as a number.
      *
-     * @param key A string which is the key.
+     * @param key
+     *            A string which is the key.
      * @return An object which is the value.
      */
     public double optDouble(String key) {
@@ -1242,11 +1382,14 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional double associated with a key, or the defaultValue if there is no such key or if its value is not
-     * a number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional double associated with a key, or the defaultValue if
+     * there is no such key or if its value is not a number. If the value is a
+     * string, an attempt will be made to evaluate it as a number.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public double optDouble(String key, double defaultValue) {
@@ -1258,10 +1401,12 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Double object associated with a key, or NaN if there is no such key or if its value is not a
-     * number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional Double object associated with a key, or NaN if there is no such
+     * key or if its value is not a number. If the value is a string, an attempt
+     * will be made to evaluate it as a number.
      *
-     * @param key A string which is the key.
+     * @param key
+     *            A string which is the key.
      * @return An object which is the value.
      */
     public Double optDoubleObject(String key) {
@@ -1269,11 +1414,14 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Double object associated with a key, or the defaultValue if there is no such key or if its value
-     * is not a number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional Double object associated with a key, or the defaultValue if
+     * there is no such key or if its value is not a number. If the value is a
+     * string, an attempt will be made to evaluate it as a number.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public Double optDoubleObject(String key, Double defaultValue) {
@@ -1285,10 +1433,12 @@ public class JSONObject {
     }
 
     /**
-     * Get the optional float value associated with an index. NaN is returned if there is no value for the index, or if
-     * the value is not a number and cannot be converted to a number.
+     * Get the optional float value associated with an index. NaN is returned
+     * if there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The value.
      */
     public float optFloat(String key) {
@@ -1296,11 +1446,14 @@ public class JSONObject {
     }
 
     /**
-     * Get the optional float value associated with an index. The defaultValue is returned if there is no value for the
-     * index, or if the value is not a number and cannot be converted to a number.
+     * Get the optional float value associated with an index. The defaultValue
+     * is returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
      *
-     * @param key          A key string.
-     * @param defaultValue The default value.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default value.
      * @return The value.
      */
     public float optFloat(String key, float defaultValue) {
@@ -1316,10 +1469,12 @@ public class JSONObject {
     }
 
     /**
-     * Get the optional Float object associated with an index. NaN is returned if there is no value for the index, or if
-     * the value is not a number and cannot be converted to a number.
+     * Get the optional Float object associated with an index. NaN is returned
+     * if there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The object.
      */
     public Float optFloatObject(String key) {
@@ -1327,11 +1482,14 @@ public class JSONObject {
     }
 
     /**
-     * Get the optional Float object associated with an index. The defaultValue is returned if there is no value for the
-     * index, or if the value is not a number and cannot be converted to a number.
+     * Get the optional Float object associated with an index. The defaultValue
+     * is returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
      *
-     * @param key          A key string.
-     * @param defaultValue The default object.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default object.
      * @return The object.
      */
     public Float optFloatObject(String key, Float defaultValue) {
@@ -1347,10 +1505,12 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional int value associated with a key, or zero if there is no such key or if the value is not a number.
-     * If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional int value associated with a key, or zero if there is no
+     * such key or if the value is not a number. If the value is a string, an
+     * attempt will be made to evaluate it as a number.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return An object which is the value.
      */
     public int optInt(String key) {
@@ -1358,11 +1518,14 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional int value associated with a key, or the default if there is no such key or if the value is not a
-     * number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional int value associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public int optInt(String key, int defaultValue) {
@@ -1374,10 +1537,12 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Integer object associated with a key, or zero if there is no such key or if the value is not a
-     * number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional Integer object associated with a key, or zero if there is no
+     * such key or if the value is not a number. If the value is a string, an
+     * attempt will be made to evaluate it as a number.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return An object which is the value.
      */
     public Integer optIntegerObject(String key) {
@@ -1385,11 +1550,14 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Integer object associated with a key, or the default if there is no such key or if the value is
-     * not a number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional Integer object associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public Integer optIntegerObject(String key, Integer defaultValue) {
@@ -1401,10 +1569,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional JSONArray associated with a key. It returns null if there is no such key, or if its value is not
-     * a JSONArray.
+     * Get an optional JSONArray associated with a key. It returns null if there
+     * is no such key, or if its value is not a JSONArray.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return A JSONArray which is the value.
      */
     public JSONArray optJSONArray(String key) {
@@ -1412,11 +1581,13 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional JSONArray associated with a key, or the default if there is no such key, or if its value is not a
-     * JSONArray.
+     * Get an optional JSONArray associated with a key, or the default if there
+     * is no such key, or if its value is not a JSONArray.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return A JSONArray which is the value.
      */
     public JSONArray optJSONArray(String key, JSONArray defaultValue) {
@@ -1425,22 +1596,23 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional JSONObject associated with a key. It returns null if there is no such key, or if its value is not
-     * a JSONObject.
+     * Get an optional JSONObject associated with a key. It returns null if
+     * there is no such key, or if its value is not a JSONObject.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return A JSONObject which is the value.
      */
-    public JSONObject optJSONObject(String key) {
-        return this.optJSONObject(key, null);
-    }
+    public JSONObject optJSONObject(String key) { return this.optJSONObject(key, null); }
 
     /**
-     * Get an optional JSONObject associated with a key, or the default if there is no such key or if the value is not a
-     * JSONObject.
+     * Get an optional JSONObject associated with a key, or the default if there
+     * is no such key or if the value is not a JSONObject.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An JSONObject which is the value.
      */
     public JSONObject optJSONObject(String key, JSONObject defaultValue) {
@@ -1449,10 +1621,12 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional long value associated with a key, or zero if there is no such key or if the value is not a
-     * number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional long value associated with a key, or zero if there is no
+     * such key or if the value is not a number. If the value is a string, an
+     * attempt will be made to evaluate it as a number.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return An object which is the value.
      */
     public long optLong(String key) {
@@ -1460,11 +1634,14 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional long value associated with a key, or the default if there is no such key or if the value is not a
-     * number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional long value associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public long optLong(String key, long defaultValue) {
@@ -1477,10 +1654,12 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Long object associated with a key, or zero if there is no such key or if the value is not a
-     * number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional Long object associated with a key, or zero if there is no
+     * such key or if the value is not a number. If the value is a string, an
+     * attempt will be made to evaluate it as a number.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return An object which is the value.
      */
     public Long optLongObject(String key) {
@@ -1488,11 +1667,14 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Long object associated with a key, or the default if there is no such key or if the value is not
-     * a number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional Long object associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public Long optLongObject(String key, Long defaultValue) {
@@ -1505,11 +1687,13 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional {@link Number} value associated with a key, or <code>null</code> if there is no such key or if
-     * the value is not a number. If the value is a string, an attempt will be made to evaluate it as a number
-     * ({@link BigDecimal}). This method would be used in cases where type coercion of the number value is unwanted.
+     * Get an optional {@link Number} value associated with a key, or <code>null</code>
+     * if there is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number ({@link BigDecimal}). This method
+     * would be used in cases where type coercion of the number value is unwanted.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return An object which is the value.
      */
     public Number optNumber(String key) {
@@ -1517,12 +1701,15 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional {@link Number} value associated with a key, or the default if there is no such key or if the
-     * value is not a number. If the value is a string, an attempt will be made to evaluate it as a number. This method
+     * Get an optional {@link Number} value associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number. This method
      * would be used in cases where type coercion of the number value is unwanted.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public Number optNumber(String key, Number defaultValue) {
@@ -1530,7 +1717,7 @@ public class JSONObject {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof Number) {
+        if (val instanceof Number){
             return (Number) val;
         }
 
@@ -1542,10 +1729,12 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional string associated with a key. It returns an empty string if there is no such key. If the value is
-     * not a string and is not null, then it is converted to a string.
+     * Get an optional string associated with a key. It returns an empty string
+     * if there is no such key. If the value is not a string and is not null,
+     * then it is converted to a string.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return A string which is the value.
      */
     public String optString(String key) {
@@ -1553,10 +1742,13 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional string associated with a key. It returns the defaultValue if there is no such key.
+     * Get an optional string associated with a key. It returns the defaultValue
+     * if there is no such key.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return A string which is the value.
      */
     public String optString(String key, String defaultValue) {
@@ -1565,11 +1757,15 @@ public class JSONObject {
     }
 
     /**
-     * Populates the internal map of the JSONObject with the bean properties. The bean can not be recursive.
+     * Populates the internal map of the JSONObject with the bean properties. The
+     * bean can not be recursive.
      *
-     * @param bean the bean
-     * @throws JSONException If a getter returned a non-finite number.
      * @see JSONObject#JSONObject(Object)
+     *
+     * @param bean
+     *            the bean
+     * @throws JSONException
+     *            If a getter returned a non-finite number.
      */
     private void populateMap(Object bean) {
         populateMap(bean, Collections.newSetFromMap(new IdentityHashMap<Object, Boolean>()));
@@ -1586,11 +1782,11 @@ public class JSONObject {
         for (final Method method : methods) {
             final int modifiers = method.getModifiers();
             if (Modifier.isPublic(modifiers)
-                && !Modifier.isStatic(modifiers)
-                && method.getParameterTypes().length == 0
-                && !method.isBridge()
-                && method.getReturnType() != Void.TYPE
-                && isValidMethodName(method.getName())) {
+                    && !Modifier.isStatic(modifiers)
+                    && method.getParameterTypes().length == 0
+                    && !method.isBridge()
+                    && method.getReturnType() != Void.TYPE
+                    && isValidMethodName(method.getName())) {
                 final String key = getKeyNameFromMethod(method);
                 if (key != null && !key.isEmpty()) {
                     try {
@@ -1671,14 +1867,18 @@ public class JSONObject {
     }
 
     /**
-     * Searches the class hierarchy to see if the method or it's super implementations and interfaces has the
-     * annotation.
+     * Searches the class hierarchy to see if the method or it's super
+     * implementations and interfaces has the annotation.
      *
-     * @param <A>             type of the annotation
-     * @param m               method to check
-     * @param annotationClass annotation to look for
-     * @return the {@link Annotation} if the annotation exists on the current method or one of its super class
-     * definitions
+     * @param <A>
+     *            type of the annotation
+     *
+     * @param m
+     *            method to check
+     * @param annotationClass
+     *            annotation to look for
+     * @return the {@link Annotation} if the annotation exists on the current method
+     *         or one of its super class definitions
      */
     private static <A extends Annotation> A getAnnotation(final Method m, final Class<A> annotationClass) {
         // if we have invalid data the result is null
@@ -1709,14 +1909,13 @@ public class JSONObject {
         }
 
         //If the superclass is Object, no annotations will be found any more
-        if (c.getSuperclass().equals(Object.class)) {
+        if (c.getSuperclass().equals(Object.class))
             return null;
-        }
 
         try {
             return getAnnotation(
-                c.getSuperclass().getMethod(m.getName(), m.getParameterTypes()),
-                annotationClass);
+                    c.getSuperclass().getMethod(m.getName(), m.getParameterTypes()),
+                    annotationClass);
         } catch (final SecurityException ex) {
             return null;
         } catch (final NoSuchMethodException ex) {
@@ -1725,11 +1924,14 @@ public class JSONObject {
     }
 
     /**
-     * Searches the class hierarchy to see if the method or it's super implementations and interfaces has the
-     * annotation. Returns the depth of the annotation in the hierarchy.
+     * Searches the class hierarchy to see if the method or it's super
+     * implementations and interfaces has the annotation. Returns the depth of the
+     * annotation in the hierarchy.
      *
-     * @param m               method to check
-     * @param annotationClass annotation to look for
+     * @param m
+     *            method to check
+     * @param annotationClass
+     *            annotation to look for
      * @return Depth of the annotation or -1 if the annotation is not on the method.
      */
     private static int getAnnotationDepth(final Method m, final Class<? extends Annotation> annotationClass) {
@@ -1765,14 +1967,13 @@ public class JSONObject {
         }
 
         //If the superclass is Object, no annotations will be found any more
-        if (c.getSuperclass().equals(Object.class)) {
+        if (c.getSuperclass().equals(Object.class))
             return -1;
-        }
 
         try {
             int d = getAnnotationDepth(
-                c.getSuperclass().getMethod(m.getName(), m.getParameterTypes()),
-                annotationClass);
+                    c.getSuperclass().getMethod(m.getName(), m.getParameterTypes()),
+                    annotationClass);
             if (d > 0) {
                 // since the annotation was on the superclass, add 1
                 return d + 1;
@@ -1788,24 +1989,33 @@ public class JSONObject {
     /**
      * Put a key/boolean pair in the JSONObject.
      *
-     * @param key   A key string.
-     * @param value A boolean which is the value.
+     * @param key
+     *            A key string.
+     * @param value
+     *            A boolean which is the value.
      * @return this.
-     * @throws JSONException        If the value is non-finite number.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject put(String key, boolean value) throws JSONException {
         return this.put(key, value ? Boolean.TRUE : Boolean.FALSE);
     }
 
     /**
-     * Put a key/value pair in the JSONObject, where the value will be a JSONArray which is produced from a Collection.
+     * Put a key/value pair in the JSONObject, where the value will be a
+     * JSONArray which is produced from a Collection.
      *
-     * @param key   A key string.
-     * @param value A Collection value.
+     * @param key
+     *            A key string.
+     * @param value
+     *            A Collection value.
      * @return this.
-     * @throws JSONException        If the value is non-finite number.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject put(String key, Collection<?> value) throws JSONException {
         return this.put(key, new JSONArray(value));
@@ -1814,11 +2024,15 @@ public class JSONObject {
     /**
      * Put a key/double pair in the JSONObject.
      *
-     * @param key   A key string.
-     * @param value A double which is the value.
+     * @param key
+     *            A key string.
+     * @param value
+     *            A double which is the value.
      * @return this.
-     * @throws JSONException        If the value is non-finite number.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject put(String key, double value) throws JSONException {
         return this.put(key, Double.valueOf(value));
@@ -1827,11 +2041,15 @@ public class JSONObject {
     /**
      * Put a key/float pair in the JSONObject.
      *
-     * @param key   A key string.
-     * @param value A float which is the value.
+     * @param key
+     *            A key string.
+     * @param value
+     *            A float which is the value.
      * @return this.
-     * @throws JSONException        If the value is non-finite number.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject put(String key, float value) throws JSONException {
         return this.put(key, Float.valueOf(value));
@@ -1840,11 +2058,15 @@ public class JSONObject {
     /**
      * Put a key/int pair in the JSONObject.
      *
-     * @param key   A key string.
-     * @param value An int which is the value.
+     * @param key
+     *            A key string.
+     * @param value
+     *            An int which is the value.
      * @return this.
-     * @throws JSONException        If the value is non-finite number.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject put(String key, int value) throws JSONException {
         return this.put(key, Integer.valueOf(value));
@@ -1853,39 +2075,53 @@ public class JSONObject {
     /**
      * Put a key/long pair in the JSONObject.
      *
-     * @param key   A key string.
-     * @param value A long which is the value.
+     * @param key
+     *            A key string.
+     * @param value
+     *            A long which is the value.
      * @return this.
-     * @throws JSONException        If the value is non-finite number.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject put(String key, long value) throws JSONException {
         return this.put(key, Long.valueOf(value));
     }
 
     /**
-     * Put a key/value pair in the JSONObject, where the value will be a JSONObject which is produced from a Map.
+     * Put a key/value pair in the JSONObject, where the value will be a
+     * JSONObject which is produced from a Map.
      *
-     * @param key   A key string.
-     * @param value A Map value.
+     * @param key
+     *            A key string.
+     * @param value
+     *            A Map value.
      * @return this.
-     * @throws JSONException        If the value is non-finite number.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject put(String key, Map<?, ?> value) throws JSONException {
         return this.put(key, new JSONObject(value));
     }
 
     /**
-     * Put a key/value pair in the JSONObject. If the value is <code>null</code>, then the key will be removed from the
-     * JSONObject if it is present.
+     * Put a key/value pair in the JSONObject. If the value is <code>null</code>, then the
+     * key will be removed from the JSONObject if it is present.
      *
-     * @param key   A key string.
-     * @param value An object which is the value. It should be of one of these types: Boolean, Double, Integer,
-     *              JSONArray, JSONObject, Long, String, or the JSONObject.NULL object.
+     * @param key
+     *            A key string.
+     * @param value
+     *            An object which is the value. It should be of one of these
+     *            types: Boolean, Double, Integer, JSONArray, JSONObject, Long,
+     *            String, or the JSONObject.NULL object.
      * @return this.
-     * @throws JSONException        If the value is non-finite number.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject put(String key, Object value) throws JSONException {
         if (key == null) {
@@ -1901,13 +2137,17 @@ public class JSONObject {
     }
 
     /**
-     * Put a key/value pair in the JSONObject, but only if the key and the value are both non-null, and only if there is
-     * not already a member with that name.
+     * Put a key/value pair in the JSONObject, but only if the key and the value
+     * are both non-null, and only if there is not already a member with that
+     * name.
      *
-     * @param key   key to insert into
-     * @param value value to insert
+     * @param key
+     *            key to insert into
+     * @param value
+     *            value to insert
      * @return this.
-     * @throws JSONException if the key is a duplicate
+     * @throws JSONException
+     *             if the key is a duplicate
      */
     public JSONObject putOnce(String key, Object value) throws JSONException {
         if (key != null && value != null) {
@@ -1920,13 +2160,18 @@ public class JSONObject {
     }
 
     /**
-     * Put a key/value pair in the JSONObject, but only if the key and the value are both non-null.
+     * Put a key/value pair in the JSONObject, but only if the key and the value
+     * are both non-null.
      *
-     * @param key   A key string.
-     * @param value An object which is the value. It should be of one of these types: Boolean, Double, Integer,
-     *              JSONArray, JSONObject, Long, String, or the JSONObject.NULL object.
+     * @param key
+     *            A key string.
+     * @param value
+     *            An object which is the value. It should be of one of these
+     *            types: Boolean, Double, Integer, JSONArray, JSONObject, Long,
+     *            String, or the JSONObject.NULL object.
      * @return this.
-     * @throws JSONException If the value is a non-finite number.
+     * @throws JSONException
+     *             If the value is a non-finite number.
      */
     public JSONObject putOpt(String key, Object value) throws JSONException {
         if (key != null && value != null) {
@@ -1936,8 +2181,9 @@ public class JSONObject {
     }
 
     /**
-     * Creates a JSONPointer using an initialization string and tries to match it to an item within this JSONObject. For
-     * example, given a JSONObject initialized with this document:
+     * Creates a JSONPointer using an initialization string and tries to
+     * match it to an item within this JSONObject. For example, given a
+     * JSONObject initialized with this document:
      * <pre>
      * {
      *     "a":{"b":"c"}
@@ -1947,8 +2193,8 @@ public class JSONObject {
      * <pre>
      * "/a/b"
      * </pre>
-     * Then this method will return the String "c". A JSONPointerException may be thrown from code called by this
-     * method.
+     * Then this method will return the String "c".
+     * A JSONPointerException may be thrown from code called by this method.
      *
      * @param jsonPointer string that can be used to create a JSONPointer
      * @return the item matched by the JSONPointer, otherwise null
@@ -1956,10 +2202,10 @@ public class JSONObject {
     public Object query(String jsonPointer) {
         return query(new JSONPointer(jsonPointer));
     }
-
     /**
-     * Uses a user initialized JSONPointer  and tries to match it to an item within this JSONObject. For example, given
-     * a JSONObject initialized with this document:
+     * Uses a user initialized JSONPointer  and tries to
+     * match it to an item within this JSONObject. For example, given a
+     * JSONObject initialized with this document:
      * <pre>
      * {
      *     "a":{"b":"c"}
@@ -1969,8 +2215,8 @@ public class JSONObject {
      * <pre>
      * "/a/b"
      * </pre>
-     * Then this method will return the String "c". A JSONPointerException may be thrown from code called by this
-     * method.
+     * Then this method will return the String "c".
+     * A JSONPointerException may be thrown from code called by this method.
      *
      * @param jsonPointer string that can be used to create a JSONPointer
      * @return the item matched by the JSONPointer, otherwise null
@@ -1980,20 +2226,20 @@ public class JSONObject {
     }
 
     /**
-     * Queries and returns a value from this object using {@code jsonPointer}, or returns null if the query fails due to
-     * a missing key.
+     * Queries and returns a value from this object using {@code jsonPointer}, or
+     * returns null if the query fails due to a missing key.
      *
      * @param jsonPointer the string representation of the JSON pointer
      * @return the queried value or {@code null}
      * @throws IllegalArgumentException if {@code jsonPointer} has invalid syntax
      */
     public Object optQuery(String jsonPointer) {
-        return optQuery(new JSONPointer(jsonPointer));
+    	return optQuery(new JSONPointer(jsonPointer));
     }
 
     /**
-     * Queries and returns a value from this object using {@code jsonPointer}, or returns null if the query fails due to
-     * a missing key.
+     * Queries and returns a value from this object using {@code jsonPointer}, or
+     * returns null if the query fails due to a missing key.
      *
      * @param jsonPointer The JSON pointer
      * @return the queried value or {@code null}
@@ -2008,11 +2254,14 @@ public class JSONObject {
     }
 
     /**
-     * Produce a string in double quotes with backslash sequences in all the right places. A backslash will be inserted
-     * within &lt;/, producing &lt;\/, allowing JSON text to be delivered in HTML. In JSON text, a string cannot contain
-     * a control character or an unescaped quote or backslash.
+     * Produce a string in double quotes with backslash sequences in all the
+     * right places. A backslash will be inserted within &lt;/, producing
+     * &lt;\/, allowing JSON text to be delivered in HTML. In JSON text, a
+     * string cannot contain a control character or an unescaped quote or
+     * backslash.
      *
-     * @param string A String
+     * @param string
+     *            A String
      * @return A String correctly formatted for insertion in a JSON text.
      */
     @SuppressWarnings("resource")
@@ -2051,42 +2300,42 @@ public class JSONObject {
             b = c;
             c = string.charAt(i);
             switch (c) {
-                case '\\':
-                case '"':
+            case '\\':
+            case '"':
+                w.write('\\');
+                w.write(c);
+                break;
+            case '/':
+                if (b == '<') {
                     w.write('\\');
-                    w.write(c);
-                    break;
-                case '/':
-                    if (b == '<') {
-                        w.write('\\');
-                    }
-                    w.write(c);
-                    break;
-                case '\b':
-                    w.write("\\b");
-                    break;
-                case '\t':
-                    w.write("\\t");
-                    break;
-                case '\n':
-                    w.write("\\n");
-                    break;
-                case '\f':
-                    w.write("\\f");
-                    break;
-                case '\r':
-                    w.write("\\r");
-                    break;
-                default:
-                    if (c < ' ' || (c >= '\u0080' && c < '\u00a0')
+                }
+                w.write(c);
+                break;
+            case '\b':
+                w.write("\\b");
+                break;
+            case '\t':
+                w.write("\\t");
+                break;
+            case '\n':
+                w.write("\\n");
+                break;
+            case '\f':
+                w.write("\\f");
+                break;
+            case '\r':
+                w.write("\\r");
+                break;
+            default:
+                if (c < ' ' || (c >= '\u0080' && c < '\u00a0')
                         || (c >= '\u2000' && c < '\u2100')) {
-                        w.write("\\u");
-                        hhhh = Integer.toHexString(c);
-                        w.write("0000", 0, 4 - hhhh.length());
-                        w.write(hhhh);
-                    } else {
-                        w.write(c);
-                    }
+                    w.write("\\u");
+                    hhhh = Integer.toHexString(c);
+                    w.write("0000", 0, 4 - hhhh.length());
+                    w.write(hhhh);
+                } else {
+                    w.write(c);
+                }
             }
         }
         w.write('"');
@@ -2096,15 +2345,18 @@ public class JSONObject {
     /**
      * Remove a name and its value, if present.
      *
-     * @param key The name to be removed.
-     * @return The value that was associated with the name, or null if there was no value.
+     * @param key
+     *            The name to be removed.
+     * @return The value that was associated with the name, or null if there was
+     *         no value.
      */
     public Object remove(String key) {
         return this.map.remove(key);
     }
 
     /**
-     * Determine if two JSONObjects are similar. They must contain the same set of names which must be associated with
+     * Determine if two JSONObjects are similar.
+     * They must contain the same set of names which must be associated with
      * similar values.
      *
      * @param other The other JSONObject
@@ -2115,34 +2367,34 @@ public class JSONObject {
             if (!(other instanceof JSONObject)) {
                 return false;
             }
-            if (!this.keySet().equals(((JSONObject) other).keySet())) {
+            if (!this.keySet().equals(((JSONObject)other).keySet())) {
                 return false;
             }
-            for (final Entry<String, ?> entry : this.entrySet()) {
+            for (final Entry<String,?> entry : this.entrySet()) {
                 String name = entry.getKey();
                 Object valueThis = entry.getValue();
-                Object valueOther = ((JSONObject) other).get(name);
-                if (valueThis == valueOther) {
-                    continue;
+                Object valueOther = ((JSONObject)other).get(name);
+                if(valueThis == valueOther) {
+                	continue;
                 }
-                if (valueThis == null) {
-                    return false;
+                if(valueThis == null) {
+                	return false;
                 }
                 if (valueThis instanceof JSONObject) {
-                    if (!((JSONObject) valueThis).similar(valueOther)) {
+                    if (!((JSONObject)valueThis).similar(valueOther)) {
                         return false;
                     }
                 } else if (valueThis instanceof JSONArray) {
-                    if (!((JSONArray) valueThis).similar(valueOther)) {
+                    if (!((JSONArray)valueThis).similar(valueOther)) {
                         return false;
                     }
                 } else if (valueThis instanceof Number && valueOther instanceof Number) {
-                    if (!isNumberSimilar((Number) valueThis, (Number) valueOther)) {
-                        return false;
+                    if (!isNumberSimilar((Number)valueThis, (Number)valueOther)) {
+                    	return false;
                     }
                 } else if (valueThis instanceof JSONString && valueOther instanceof JSONString) {
                     if (!((JSONString) valueThis).toJSONString().equals(((JSONString) valueOther).toJSONString())) {
-                        return false;
+                    	return false;
                     }
                 } else if (!valueThis.equals(valueOther)) {
                     return false;
@@ -2156,13 +2408,14 @@ public class JSONObject {
 
     /**
      * Compares two numbers to see if they are similar.
-     * <p>
-     * If either of the numbers are Double or Float instances, then they are checked to have a finite value. If either
-     * value is not finite (NaN or &#177;infinity), then this function will always return false. If both numbers are
-     * finite, they are first checked to be the same type and implement {@link Comparable}. If they do, then the actual
-     * {@link Comparable#compareTo(Object)} is called. If they are not the same type, or don't implement Comparable,
-     * then they are converted to {@link BigDecimal}s. Finally the BigDecimal values are compared using
-     * {@link BigDecimal#compareTo(BigDecimal)}.
+     *
+     * If either of the numbers are Double or Float instances, then they are checked to have
+     * a finite value. If either value is not finite (NaN or &#177;infinity), then this
+     * function will always return false. If both numbers are finite, they are first checked
+     * to be the same type and implement {@link Comparable}. If they do, then the actual
+     * {@link Comparable#compareTo(Object)} is called. If they are not the same type, or don't
+     * implement Comparable, then they are converted to {@link BigDecimal}s. Finally the
+     * BigDecimal values are compared using {@link BigDecimal#compareTo(BigDecimal)}.
      *
      * @param l the Left value to compare. Can not be <code>null</code>.
      * @param r the right value to compare. Can not be <code>null</code>.
@@ -2176,10 +2429,10 @@ public class JSONObject {
 
         // if the classes are the same and implement Comparable
         // then use the built in compare first.
-        if (l.getClass().equals(r.getClass()) && l instanceof Comparable) {
-            @SuppressWarnings({"rawtypes", "unchecked"})
-            int compareTo = ((Comparable) l).compareTo(r);
-            return compareTo == 0;
+        if(l.getClass().equals(r.getClass()) && l instanceof Comparable) {
+            @SuppressWarnings({ "rawtypes", "unchecked" })
+            int compareTo = ((Comparable)l).compareTo(r);
+            return compareTo==0;
         }
 
         // BigDecimal should be able to handle all of our number types that we support through
@@ -2210,15 +2463,18 @@ public class JSONObject {
      */
     protected static boolean isDecimalNotation(final String val) {
         return val.indexOf('.') > -1 || val.indexOf('e') > -1
-            || val.indexOf('E') > -1 || "-0".equals(val);
+                || val.indexOf('E') > -1 || "-0".equals(val);
     }
 
     /**
-     * Try to convert a string into a number, boolean, or null. If the string can't be converted, return the string.
+     * Try to convert a string into a number, boolean, or null. If the string
+     * can't be converted, return the string.
      *
-     * @param string A String. can not be null.
+     * @param string
+     *            A String. can not be null.
      * @return A simple JSON value.
-     * @throws NullPointerException Thrown if the string is null.
+     * @throws NullPointerException
+     *             Thrown if the string is null.
      */
     // Changes to this method must be copied to the corresponding method in
     // the XML class to keep full support for Android
@@ -2254,14 +2510,14 @@ public class JSONObject {
     }
 
     /**
-     * Converts a string to a number using the narrowest possible type. Possible returns for this function are
-     * BigDecimal, Double, BigInteger, Long, and Integer. When a Double is returned, it should always be a valid Double
-     * and not NaN or +-infinity.
+     * Converts a string to a number using the narrowest possible type. Possible
+     * returns for this function are BigDecimal, Double, BigInteger, Long, and Integer.
+     * When a Double is returned, it should always be a valid Double and not NaN or +-infinity.
      *
      * @param val value to convert
      * @return Number representation of the value.
-     * @throws NumberFormatException thrown if the value is not a valid number. A public caller should catch this and
-     *                               wrap it in a {@link JSONException} if applicable.
+     * @throws NumberFormatException thrown if the value is not a valid number. A public
+     *      caller should catch this and wrap it in a {@link JSONException} if applicable.
      */
     protected static Number stringToNumber(final String val) throws NumberFormatException {
         char initial = val.charAt(0);
@@ -2273,7 +2529,7 @@ public class JSONObject {
                 // keep that by forcing a decimal.
                 try {
                     BigDecimal bd = new BigDecimal(val);
-                    if (initial == '-' && BigDecimal.ZERO.compareTo(bd) == 0) {
+                    if(initial == '-' && BigDecimal.ZERO.compareTo(bd)==0) {
                         return Double.valueOf(-0.0);
                     }
                     return bd;
@@ -2281,26 +2537,26 @@ public class JSONObject {
                     // this is to support "Hex Floats" like this: 0x1.0P-1074
                     try {
                         Double d = Double.valueOf(val);
-                        if (d.isNaN() || d.isInfinite()) {
-                            throw new NumberFormatException("val [" + val + "] is not a valid number.");
+                        if(d.isNaN() || d.isInfinite()) {
+                            throw new NumberFormatException("val ["+val+"] is not a valid number.");
                         }
                         return d;
                     } catch (NumberFormatException ignore) {
-                        throw new NumberFormatException("val [" + val + "] is not a valid number.");
+                        throw new NumberFormatException("val ["+val+"] is not a valid number.");
                     }
                 }
             }
             // block items like 00 01 etc. Java number parsers treat these as Octal.
-            if (initial == '0' && val.length() > 1) {
+            if(initial == '0' && val.length() > 1) {
                 char at1 = val.charAt(1);
-                if (at1 >= '0' && at1 <= '9') {
-                    throw new NumberFormatException("val [" + val + "] is not a valid number.");
+                if(at1 >= '0' && at1 <= '9') {
+                    throw new NumberFormatException("val ["+val+"] is not a valid number.");
                 }
             } else if (initial == '-' && val.length() > 2) {
                 char at1 = val.charAt(1);
                 char at2 = val.charAt(2);
-                if (at1 == '0' && at2 >= '0' && at2 <= '9') {
-                    throw new NumberFormatException("val [" + val + "] is not a valid number.");
+                if(at1 == '0' && at2 >= '0' && at2 <= '9') {
+                    throw new NumberFormatException("val ["+val+"] is not a valid number.");
                 }
             }
             // integer representation.
@@ -2312,22 +2568,24 @@ public class JSONObject {
             // only what they need. i.e. Less runtime overhead if the value is
             // long lived.
             BigInteger bi = new BigInteger(val);
-            if (bi.bitLength() <= 31) {
+            if(bi.bitLength() <= 31){
                 return Integer.valueOf(bi.intValue());
             }
-            if (bi.bitLength() <= 63) {
+            if(bi.bitLength() <= 63){
                 return Long.valueOf(bi.longValue());
             }
             return bi;
         }
-        throw new NumberFormatException("val [" + val + "] is not a valid number.");
+        throw new NumberFormatException("val ["+val+"] is not a valid number.");
     }
 
     /**
      * Throw an exception if the object is a NaN or infinite number.
      *
-     * @param o The object to test.
-     * @throws JSONException If o is a non-finite number.
+     * @param o
+     *            The object to test.
+     * @throws JSONException
+     *             If o is a non-finite number.
      */
     public static void testValidity(Object o) throws JSONException {
         if (o instanceof Number && !numberIsFinite((Number) o)) {
@@ -2336,12 +2594,15 @@ public class JSONObject {
     }
 
     /**
-     * Produce a JSONArray containing the values of the members of this JSONObject.
+     * Produce a JSONArray containing the values of the members of this
+     * JSONObject.
      *
-     * @param names A JSONArray containing a list of key strings. This determines the sequence of the values in the
-     *              result.
+     * @param names
+     *            A JSONArray containing a list of key strings. This determines
+     *            the sequence of the values in the result.
      * @return A JSONArray of values.
-     * @throws JSONException If any of the values are non-finite numbers.
+     * @throws JSONException
+     *             If any of the values are non-finite numbers.
      */
     public JSONArray toJSONArray(JSONArray names) throws JSONException {
         if (names == null || names.isEmpty()) {
@@ -2355,15 +2616,17 @@ public class JSONObject {
     }
 
     /**
-     * Make a JSON text of this JSONObject. For compactness, no whitespace is added. If this would not result in a
-     * syntactically correct JSON text, then null will be returned instead.
+     * Make a JSON text of this JSONObject. For compactness, no whitespace is
+     * added. If this would not result in a syntactically correct JSON text,
+     * then null will be returned instead.
      * <p><b>
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
      *
-     * @return a printable, displayable, portable, transmittable representation of the object, beginning with
-     * <code>{</code>&nbsp;<small>(left brace)</small> and ending with <code>}</code>&nbsp;<small>(right
-     * brace)</small>.
+     * @return a printable, displayable, portable, transmittable representation
+     *         of the object, beginning with <code>{</code>&nbsp;<small>(left
+     *         brace)</small> and ending with <code>}</code>&nbsp;<small>(right
+     *         brace)</small>.
      */
     @Override
     public String toString() {
@@ -2391,11 +2654,14 @@ public class JSONObject {
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
      *
-     * @param indentFactor The number of spaces to add to each level of indentation.
-     * @return a printable, displayable, portable, transmittable representation of the object, beginning with
-     * <code>{</code>&nbsp;<small>(left brace)</small> and ending with <code>}</code>&nbsp;<small>(right
-     * brace)</small>.
-     * @throws JSONException If the object contains an invalid number.
+     * @param indentFactor
+     *            The number of spaces to add to each level of indentation.
+     * @return a printable, displayable, portable, transmittable representation
+     *         of the object, beginning with <code>{</code>&nbsp;<small>(left
+     *         brace)</small> and ending with <code>}</code>&nbsp;<small>(right
+     *         brace)</small>.
+     * @throws JSONException
+     *             If the object contains an invalid number.
      */
     @SuppressWarnings("resource")
     public String toString(int indentFactor) throws JSONException {
@@ -2404,37 +2670,47 @@ public class JSONObject {
     }
 
     /**
-     * Make a JSON text of an Object value. If the object has an value.toJSONString() method, then that method will be
-     * used to produce the JSON text. The method is required to produce a strictly conforming text. If the object does
-     * not contain a toJSONString method (which is the most common case), then a text will be produced by other means.
-     * If the value is an array or Collection, then a JSONArray will be made from it and its toJSONString method will be
-     * called. If the value is a MAP, then a JSONObject will be made from it and its toJSONString method will be called.
-     * Otherwise, the value's toString method will be called, and the result will be quoted.
+     * Make a JSON text of an Object value. If the object has an
+     * value.toJSONString() method, then that method will be used to produce the
+     * JSON text. The method is required to produce a strictly conforming text.
+     * If the object does not contain a toJSONString method (which is the most
+     * common case), then a text will be produced by other means. If the value
+     * is an array or Collection, then a JSONArray will be made from it and its
+     * toJSONString method will be called. If the value is a MAP, then a
+     * JSONObject will be made from it and its toJSONString method will be
+     * called. Otherwise, the value's toString method will be called, and the
+     * result will be quoted.
      *
      * <p>
      * Warning: This method assumes that the data structure is acyclical.
      *
-     * @param value The value to be serialized.
-     * @return a printable, displayable, transmittable representation of the object, beginning with
-     * <code>{</code>&nbsp;<small>(left brace)</small> and ending with <code>}</code>&nbsp;<small>(right
-     * brace)</small>.
-     * @throws JSONException If the value is or contains an invalid number.
+     * @param value
+     *            The value to be serialized.
+     * @return a printable, displayable, transmittable representation of the
+     *         object, beginning with <code>{</code>&nbsp;<small>(left
+     *         brace)</small> and ending with <code>}</code>&nbsp;<small>(right
+     *         brace)</small>.
+     * @throws JSONException
+     *             If the value is or contains an invalid number.
      */
     public static String valueToString(Object value) throws JSONException {
-        // moves the implementation to JSONWriter as:
-        // 1. It makes more sense to be part of the writer class
-        // 2. For Android support this method is not available. By implementing it in the Writer
-        //    Android users can use the writer with the built in Android JSONObject implementation.
+    	// moves the implementation to JSONWriter as:
+    	// 1. It makes more sense to be part of the writer class
+    	// 2. For Android support this method is not available. By implementing it in the Writer
+    	//    Android users can use the writer with the built in Android JSONObject implementation.
         return JSONWriter.valueToString(value);
     }
 
     /**
-     * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL object. If it is an array or
-     * collection, wrap it in a JSONArray. If it is a map, wrap it in a JSONObject. If it is a standard property
-     * (Double, String, et al) then it is already wrapped. Otherwise, if it comes from one of the java packages, turn it
-     * into a string. And if it doesn't, try to wrap it in a JSONObject. If the wrapping fails, then null is returned.
+     * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL
+     * object. If it is an array or collection, wrap it in a JSONArray. If it is
+     * a map, wrap it in a JSONObject. If it is a standard property (Double,
+     * String, et al) then it is already wrapped. Otherwise, if it comes from
+     * one of the java packages, turn it into a string. And if it doesn't, try
+     * to wrap it in a JSONObject. If the wrapping fails, then null is returned.
      *
-     * @param object The object to wrap
+     * @param object
+     *            The object to wrap
      * @return The wrapped value
      */
     public static Object wrap(Object object) {
@@ -2442,38 +2718,42 @@ public class JSONObject {
     }
 
     /**
-     * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL object. If it is an array or
-     * collection, wrap it in a JSONArray. If it is a map, wrap it in a JSONObject. If it is a standard property
-     * (Double, String, et al) then it is already wrapped. Otherwise, if it comes from one of the java packages, turn it
-     * into a string. And if it doesn't, try to wrap it in a JSONObject. If the wrapping fails, then null is returned.
+     * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL
+     * object. If it is an array or collection, wrap it in a JSONArray. If it is
+     * a map, wrap it in a JSONObject. If it is a standard property (Double,
+     * String, et al) then it is already wrapped. Otherwise, if it comes from
+     * one of the java packages, turn it into a string. And if it doesn't, try
+     * to wrap it in a JSONObject. If the wrapping fails, then null is returned.
      *
-     * @param object                  The object to wrap
-     * @param recursionDepth          Variable for tracking the count of nested object creations.
-     * @param jsonParserConfiguration Variable to pass parser custom configuration for json parsing.
+     * @param object
+     *            The object to wrap
+     * @param recursionDepth
+     *            Variable for tracking the count of nested object creations.
+     * @param jsonParserConfiguration
+     *            Variable to pass parser custom configuration for json parsing.
      * @return The wrapped value
      */
     static Object wrap(Object object, int recursionDepth, JSONParserConfiguration jsonParserConfiguration) {
-        return wrap(object, null, recursionDepth, jsonParserConfiguration);
+      return wrap(object, null, recursionDepth, jsonParserConfiguration);
     }
 
     private static Object wrap(Object object, Set<Object> objectsRecord) {
-        return wrap(object, objectsRecord, 0, new JSONParserConfiguration());
+      return wrap(object, objectsRecord, 0, new JSONParserConfiguration());
     }
 
-    private static Object wrap(Object object, Set<Object> objectsRecord, int recursionDepth,
-        JSONParserConfiguration jsonParserConfiguration) {
+    private static Object wrap(Object object, Set<Object> objectsRecord, int recursionDepth, JSONParserConfiguration jsonParserConfiguration) {
         try {
             if (NULL.equals(object)) {
                 return NULL;
             }
             if (object instanceof JSONObject || object instanceof JSONArray
-                || NULL.equals(object) || object instanceof JSONString
-                || object instanceof Byte || object instanceof Character
-                || object instanceof Short || object instanceof Integer
-                || object instanceof Long || object instanceof Boolean
-                || object instanceof Float || object instanceof Double
-                || object instanceof String || object instanceof BigInteger
-                || object instanceof BigDecimal || object instanceof Enum) {
+                    || NULL.equals(object) || object instanceof JSONString
+                    || object instanceof Byte || object instanceof Character
+                    || object instanceof Short || object instanceof Integer
+                    || object instanceof Long || object instanceof Boolean
+                    || object instanceof Float || object instanceof Double
+                    || object instanceof String || object instanceof BigInteger
+                    || object instanceof BigDecimal || object instanceof Enum) {
                 return object;
             }
 
@@ -2490,17 +2770,18 @@ public class JSONObject {
             }
             Package objectPackage = object.getClass().getPackage();
             String objectPackageName = objectPackage != null ? objectPackage
-                .getName() : "";
+                    .getName() : "";
             if (objectPackageName.startsWith("java.")
-                || objectPackageName.startsWith("javax.")
-                || object.getClass().getClassLoader() == null) {
+                    || objectPackageName.startsWith("javax.")
+                    || object.getClass().getClassLoader() == null) {
                 return object.toString();
             }
             if (objectsRecord != null) {
                 return new JSONObject(object, objectsRecord);
             }
             return new JSONObject(object);
-        } catch (JSONException exception) {
+        }
+        catch (JSONException exception) {
             throw exception;
         } catch (Exception exception) {
             return null;
@@ -2508,11 +2789,11 @@ public class JSONObject {
     }
 
     /**
-     * Write the contents of the JSONObject as JSON text to a writer. For compactness, no whitespace is added.
+     * Write the contents of the JSONObject as JSON text to a writer. For
+     * compactness, no whitespace is added.
      * <p><b>
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
-     *
      * @param writer the writer object
      * @return The writer.
      * @throws JSONException if a called function has an error
@@ -2523,7 +2804,7 @@ public class JSONObject {
 
     @SuppressWarnings("resource")
     static final Writer writeValue(Writer writer, Object value,
-        int indentFactor, int indent) throws JSONException, IOException {
+            int indentFactor, int indent) throws JSONException, IOException {
         if (value == null || value.equals(null)) {
             writer.write("null");
         } else if (value instanceof JSONString) {
@@ -2537,7 +2818,7 @@ public class JSONObject {
         } else if (value instanceof Number) {
             // not all Numbers may match actual JSON Numbers. i.e. fractions or Imaginary
             final String numberAsString = numberToString((Number) value);
-            if (NUMBER_PATTERN.matcher(numberAsString).matches()) {
+            if(NUMBER_PATTERN.matcher(numberAsString).matches()) {
                 writer.write(numberAsString);
             } else {
                 // The Number value is not a valid JSON number.
@@ -2547,7 +2828,7 @@ public class JSONObject {
         } else if (value instanceof Boolean) {
             writer.write(value.toString());
         } else if (value instanceof Enum<?>) {
-            writer.write(quote(((Enum<?>) value).name()));
+            writer.write(quote(((Enum<?>)value).name()));
         } else if (value instanceof JSONObject) {
             ((JSONObject) value).write(writer, indentFactor, indent);
         } else if (value instanceof JSONArray) {
@@ -2589,36 +2870,40 @@ public class JSONObject {
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
      *
-     * @param writer       Writes the serialized JSON
-     * @param indentFactor The number of spaces to add to each level of indentation.
-     * @param indent       The indentation of the top level.
+     * @param writer
+     *            Writes the serialized JSON
+     * @param indentFactor
+     *            The number of spaces to add to each level of indentation.
+     * @param indent
+     *            The indentation of the top level.
      * @return The writer.
-     * @throws JSONException if a called function has an error or a write error occurs
+     * @throws JSONException if a called function has an error or a write error
+     * occurs
      */
     @SuppressWarnings("resource")
     public Writer write(Writer writer, int indentFactor, int indent)
-        throws JSONException {
+            throws JSONException {
         try {
             boolean needsComma = false;
             final int length = this.length();
             writer.write('{');
 
             if (length == 1) {
-                final Entry<String, ?> entry = this.entrySet().iterator().next();
+            	final Entry<String,?> entry = this.entrySet().iterator().next();
                 final String key = entry.getKey();
                 writer.write(quote(key));
                 writer.write(':');
                 if (indentFactor > 0) {
                     writer.write(' ');
                 }
-                try {
+                try{
                     writeValue(writer, entry.getValue(), indentFactor, indent);
                 } catch (Exception e) {
                     throw new JSONException("Unable to write JSONObject value for key: " + key, e);
                 }
             } else if (length != 0) {
                 final int newIndent = indent + indentFactor;
-                for (final Entry<String, ?> entry : this.entrySet()) {
+                for (final Entry<String,?> entry : this.entrySet()) {
                     if (needsComma) {
                         writer.write(',');
                     }
@@ -2652,8 +2937,9 @@ public class JSONObject {
     }
 
     /**
-     * Returns a java.util.Map containing all of the entries in this object. If an entry in the object is a JSONArray or
-     * JSONObject it will also be converted.
+     * Returns a java.util.Map containing all of the entries in this object.
+     * If an entry in the object is a JSONArray or JSONObject it will also
+     * be converted.
      * <p>
      * Warning: This method assumes that the data structure is acyclical.
      *
@@ -2679,37 +2965,35 @@ public class JSONObject {
 
     /**
      * Create a new JSONException in a common format for incorrect conversions.
-     *
-     * @param key       name of the key
+     * @param key name of the key
      * @param valueType the type of value being coerced to
-     * @param cause     optional cause of the coercion failure
+     * @param cause optional cause of the coercion failure
      * @return JSONException that can be thrown.
      */
     private static JSONException wrongValueFormatException(
-        String key,
-        String valueType,
-        Object value,
-        Throwable cause) {
-        if (value == null) {
+            String key,
+            String valueType,
+            Object value,
+            Throwable cause) {
+        if(value == null) {
 
             return new JSONException(
-                "JSONObject[" + quote(key) + "] is not a " + valueType + " (null)."
-                , cause);
+                    "JSONObject[" + quote(key) + "] is not a " + valueType + " (null)."
+                    , cause);
         }
         // don't try to toString collections or known object types that could be large.
-        if (value instanceof Map || value instanceof Iterable || value instanceof JSONObject) {
+        if(value instanceof Map || value instanceof Iterable || value instanceof JSONObject) {
             return new JSONException(
-                "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + ")."
-                , cause);
+                    "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + ")."
+                    , cause);
         }
         return new JSONException(
-            "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + " : " + value + ")."
-            , cause);
+                "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + " : " + value + ")."
+                , cause);
     }
 
     /**
      * Create a new JSONException in a common format for recursive object definition.
-     *
      * @param key name of the key
      * @return JSONException that can be thrown.
      */
@@ -2721,28 +3005,21 @@ public class JSONObject {
 
     /**
      * For a prospective number, remove the leading zeros
-     *
      * @param value prospective number
      * @return number without leading zeros
      */
-    private static String removeLeadingZerosOfNumber(String value) {
-        if (value.equals("-")) {
-            return value;
-        }
+    private static String removeLeadingZerosOfNumber(String value){
+        if (value.equals("-")){return value;}
         boolean negativeFirstChar = (value.charAt(0) == '-');
-        int counter = negativeFirstChar ? 1 : 0;
-        while (counter < value.length()) {
-            if (value.charAt(counter) != '0') {
-                if (negativeFirstChar) {
-                    return "-".concat(value.substring(counter));
-                }
+        int counter = negativeFirstChar ? 1:0;
+        while (counter < value.length()){
+            if (value.charAt(counter) != '0'){
+                if (negativeFirstChar) {return "-".concat(value.substring(counter));}
                 return value.substring(counter);
             }
             ++counter;
         }
-        if (negativeFirstChar) {
-            return "-0";
-        }
+        if (negativeFirstChar) {return "-0";}
         return "0";
     }
 }

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -15,47 +15,51 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.ResourceBundle;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
- * A JSONObject is an unordered collection of name/value pairs. Its external
- * form is a string wrapped in curly braces with colons between the names and
- * values, and commas between the values and names. The internal form is an
- * object having <code>get</code> and <code>opt</code> methods for accessing
- * the values by name, and <code>put</code> methods for adding or replacing
- * values by name. The values can be any of these types: <code>Boolean</code>,
+ * A JSONObject is an unordered collection of name/value pairs. Its external form is a string wrapped in curly braces
+ * with colons between the names and values, and commas between the values and names. The internal form is an object
+ * having <code>get</code> and <code>opt</code> methods for accessing the values by name, and <code>put</code> methods
+ * for adding or replacing values by name. The values can be any of these types: <code>Boolean</code>,
  * <code>JSONArray</code>, <code>JSONObject</code>, <code>Number</code>,
  * <code>String</code>, or the <code>JSONObject.NULL</code> object. A
- * JSONObject constructor can be used to convert an external form JSON text
- * into an internal form whose values can be retrieved with the
+ * JSONObject constructor can be used to convert an external form JSON text into an internal form whose values can be
+ * retrieved with the
  * <code>get</code> and <code>opt</code> methods, or to convert values into a
  * JSON text using the <code>put</code> and <code>toString</code> methods. A
  * <code>get</code> method returns a value if one can be found, and throws an
- * exception if one cannot be found. An <code>opt</code> method returns a
- * default value instead of throwing an exception, and so is useful for
- * obtaining optional values.
+ * exception if one cannot be found. An <code>opt</code> method returns a default value instead of throwing an
+ * exception, and so is useful for obtaining optional values.
  * <p>
- * The generic <code>get()</code> and <code>opt()</code> methods return an
- * object, which you can cast or query for type. There are also typed
+ * The generic <code>get()</code> and <code>opt()</code> methods return an object, which you can cast or query for type.
+ * There are also typed
  * <code>get</code> and <code>opt</code> methods that do type checking and type
- * coercion for you. The opt methods differ from the get methods in that they
- * do not throw. Instead, they return a specified value, such as null.
+ * coercion for you. The opt methods differ from the get methods in that they do not throw. Instead, they return a
+ * specified value, such as null.
  * <p>
- * The <code>put</code> methods add or replace values in an object. For
- * example,
+ * The <code>put</code> methods add or replace values in an object. For example,
  *
  * <pre>
  * myString = new JSONObject()
  *         .put(&quot;JSON&quot;, &quot;Hello, World!&quot;).toString();
  * </pre>
- *
+ * <p>
  * produces the string <code>{"JSON": "Hello, World"}</code>.
  * <p>
- * The texts produced by the <code>toString</code> methods strictly conform to
- * the JSON syntax rules. The constructors are more forgiving in the texts they
- * will accept:
+ * The texts produced by the <code>toString</code> methods strictly conform to the JSON syntax rules. The constructors
+ * are more forgiving in the texts they will accept:
  * <ul>
  * <li>An extra <code>,</code>&nbsp;<small>(comma)</small> may appear just
  * before the closing brace.</li>
@@ -73,16 +77,15 @@ import java.util.regex.Pattern;
  * @version 2016-08-15
  */
 public class JSONObject {
+
     /**
-     * JSONObject.NULL is equivalent to the value that JavaScript calls null,
-     * whilst Java's null is equivalent to the value that JavaScript calls
-     * undefined.
+     * JSONObject.NULL is equivalent to the value that JavaScript calls null, whilst Java's null is equivalent to the
+     * value that JavaScript calls undefined.
      */
     private static final class Null {
 
         /**
-         * There is only intended to be a single instance of the NULL object,
-         * so the clone method returns itself.
+         * There is only intended to be a single instance of the NULL object, so the clone method returns itself.
          *
          * @return NULL.
          */
@@ -94,16 +97,15 @@ public class JSONObject {
         /**
          * A Null object is equal to the null value and to itself.
          *
-         * @param object
-         *            An object to test for nullness.
-         * @return true if the object parameter is the JSONObject.NULL object or
-         *         null.
+         * @param object An object to test for nullness.
+         * @return true if the object parameter is the JSONObject.NULL object or null.
          */
         @Override
         @SuppressWarnings("lgtm[java/unchecked-cast-in-equals]")
         public boolean equals(Object object) {
             return object == null || object == this;
         }
+
         /**
          * A Null object is equal to the null value and to itself.
          *
@@ -126,8 +128,8 @@ public class JSONObject {
     }
 
     /**
-     *  Regular Expression Pattern that matches JSON Numbers. This is primarily used for
-     *  output to guarantee that we are always writing valid JSON.
+     * Regular Expression Pattern that matches JSON Numbers. This is primarily used for output to guarantee that we are
+     * always writing valid JSON.
      */
     static final Pattern NUMBER_PATTERN = Pattern.compile("-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?");
 
@@ -167,16 +169,13 @@ public class JSONObject {
     }
 
     /**
-     * Construct a JSONObject from a subset of another JSONObject. An array of
-     * strings is used to identify the keys that should be copied. Missing keys
-     * are ignored.
+     * Construct a JSONObject from a subset of another JSONObject. An array of strings is used to identify the keys that
+     * should be copied. Missing keys are ignored.
      *
-     * @param jo
-     *            A JSONObject.
-     * @param names
-     *            An array of strings.
+     * @param jo    A JSONObject.
+     * @param names An array of strings.
      */
-    public JSONObject(JSONObject jo, String ... names) {
+    public JSONObject(JSONObject jo, String... names) {
         this(names.length);
         for (int i = 0; i < names.length; i += 1) {
             try {
@@ -189,11 +188,8 @@ public class JSONObject {
     /**
      * Construct a JSONObject from a JSONTokener.
      *
-     * @param x
-     *            A JSONTokener object containing the source string.
-     * @throws JSONException
-     *             If there is a syntax error in the source string or a
-     *             duplicated key.
+     * @param x A JSONTokener object containing the source string.
+     * @throws JSONException If there is a syntax error in the source string or a duplicated key.
      */
     public JSONObject(JSONTokener x) throws JSONException {
         this(x, new JSONParserConfiguration());
@@ -202,13 +198,9 @@ public class JSONObject {
     /**
      * Construct a JSONObject from a JSONTokener with custom json parse configurations.
      *
-     * @param x
-     *            A JSONTokener object containing the source string.
-     * @param jsonParserConfiguration
-     *            Variable to pass parser custom configuration for json parsing.
-     * @throws JSONException
-     *             If there is a syntax error in the source string or a
-     *             duplicated key.
+     * @param x                       A JSONTokener object containing the source string.
+     * @param jsonParserConfiguration Variable to pass parser custom configuration for json parsing.
+     * @throws JSONException If there is a syntax error in the source string or a duplicated key.
      */
     public JSONObject(JSONTokener x, JSONParserConfiguration jsonParserConfiguration) throws JSONException {
         this();
@@ -221,12 +213,19 @@ public class JSONObject {
         for (;;) {
             c = x.nextClean();
             switch (c) {
-            case 0:
-                throw x.syntaxError("A JSONObject text must end with '}'");
-            case '}':
-                return;
-            default:
-                key = x.nextSimpleValue(c).toString();
+                case 0:
+                    throw x.syntaxError("A JSONObject text must end with '}'");
+                case '}':
+                    return;
+                default:
+                    String keyToValidate = getKeyToValidate(x, c, jsonParserConfiguration.isStrictMode());
+                    boolean keyHasQuotes = keyToValidate.startsWith("\"") && keyToValidate.endsWith("\"");
+
+                    if (jsonParserConfiguration.isStrictMode() && !keyHasQuotes) {
+                        throw new JSONException("Key is not surrounded by quotes: " + keyToValidate);
+                    }
+
+                    key = keyToValidate;
             }
 
             // The key is followed by ':'.
@@ -245,7 +244,7 @@ public class JSONObject {
                     throw x.syntaxError("Duplicate key \"" + key + "\"");
                 }
 
-                Object value = x.nextValue();
+                Object value = getValue(x, jsonParserConfiguration.isStrictMode());
                 // Only add value if non-null
                 if (value != null) {
                     this.put(key, value);
@@ -255,47 +254,51 @@ public class JSONObject {
             // Pairs are separated by ','.
 
             switch (x.nextClean()) {
-            case ';':
-            case ',':
-                if (x.nextClean() == '}') {
+                case ';':
+                case ',':
+                    if (x.nextClean() == '}') {
+                        return;
+                    }
+                    if (x.end()) {
+                        throw x.syntaxError("A JSONObject text must end with '}'");
+                    }
+                    x.back();
+                    break;
+                case '}':
                     return;
-                }
-                if (x.end()) {
-                    throw x.syntaxError("A JSONObject text must end with '}'");
-                }
-                x.back();
-                break;
-            case '}':
-                return;
-            default:
-                throw x.syntaxError("Expected a ',' or '}'");
+                default:
+                    throw x.syntaxError("Expected a ',' or '}'");
             }
         }
+    }
+
+    private Object getValue(JSONTokener x, boolean strictMode) {
+        if (strictMode) {
+            return x.nextValue(true);
+        }
+        return x.nextValue();
+    }
+
+    private String getKeyToValidate(JSONTokener x, char c, boolean strictMode) {
+        return x.nextSimpleValue(c, strictMode).toString();
     }
 
     /**
      * Construct a JSONObject from a Map.
      *
-     * @param m
-     *            A map object that can be used to initialize the contents of
-     *            the JSONObject.
-     * @throws JSONException
-     *            If a value in the map is non-finite number.
-     * @throws NullPointerException
-     *            If a key in the map is <code>null</code>
+     * @param m A map object that can be used to initialize the contents of the JSONObject.
+     * @throws JSONException        If a value in the map is non-finite number.
+     * @throws NullPointerException If a key in the map is <code>null</code>
      */
     public JSONObject(Map<?, ?> m) {
-      this(m, 0, new JSONParserConfiguration());
+        this(m, 0, new JSONParserConfiguration());
     }
 
     /**
      * Construct a JSONObject from a Map with custom json parse configurations.
      *
-     * @param m
-     *            A map object that can be used to initialize the contents of
-     *            the JSONObject.
-     * @param jsonParserConfiguration
-     *            Variable to pass parser custom configuration for json parsing.
+     * @param m                       A map object that can be used to initialize the contents of the JSONObject.
+     * @param jsonParserConfiguration Variable to pass parser custom configuration for json parsing.
      */
     public JSONObject(Map<?, ?> m, JSONParserConfiguration jsonParserConfiguration) {
         this(m, 0, jsonParserConfiguration);
@@ -306,16 +309,17 @@ public class JSONObject {
      */
     private JSONObject(Map<?, ?> m, int recursionDepth, JSONParserConfiguration jsonParserConfiguration) {
         if (recursionDepth > jsonParserConfiguration.getMaxNestingDepth()) {
-          throw new JSONException("JSONObject has reached recursion depth limit of " + jsonParserConfiguration.getMaxNestingDepth());
+            throw new JSONException(
+                "JSONObject has reached recursion depth limit of " + jsonParserConfiguration.getMaxNestingDepth());
         }
         if (m == null) {
             this.map = new HashMap<String, Object>();
         } else {
             this.map = new HashMap<String, Object>(m.size());
-        	for (final Entry<?, ?> e : m.entrySet()) {
-        	    if(e.getKey() == null) {
-        	        throw new NullPointerException("Null key.");
-        	    }
+            for (final Entry<?, ?> e : m.entrySet()) {
+                if (e.getKey() == null) {
+                    throw new NullPointerException("Null key.");
+                }
                 final Object value = e.getValue();
                 if (value != null) {
                     testValidity(value);
@@ -326,28 +330,24 @@ public class JSONObject {
     }
 
     /**
-     * Construct a JSONObject from an Object using bean getters. It reflects on
-     * all of the public methods of the object. For each of the methods with no
-     * parameters and a name starting with <code>"get"</code> or
+     * Construct a JSONObject from an Object using bean getters. It reflects on all of the public methods of the object.
+     * For each of the methods with no parameters and a name starting with <code>"get"</code> or
      * <code>"is"</code> followed by an uppercase letter, the method is invoked,
-     * and a key and the value returned from the getter method are put into the
-     * new JSONObject.
+     * and a key and the value returned from the getter method are put into the new JSONObject.
      * <p>
-     * The key is formed by removing the <code>"get"</code> or <code>"is"</code>
-     * prefix. If the second remaining character is not upper case, then the
-     * first character is converted to lower case.
+     * The key is formed by removing the <code>"get"</code> or <code>"is"</code> prefix. If the second remaining
+     * character is not upper case, then the first character is converted to lower case.
      * <p>
-     * Methods that are <code>static</code>, return <code>void</code>,
-     * have parameters, or are "bridge" methods, are ignored.
+     * Methods that are <code>static</code>, return <code>void</code>, have parameters, or are "bridge" methods, are
+     * ignored.
      * <p>
-     * For example, if an object has a method named <code>"getName"</code>, and
-     * if the result of calling <code>object.getName()</code> is
+     * For example, if an object has a method named <code>"getName"</code>, and if the result of calling
+     * <code>object.getName()</code> is
      * <code>"Larry Fine"</code>, then the JSONObject will contain
      * <code>"name": "Larry Fine"</code>.
      * <p>
-     * The {@link JSONPropertyName} annotation can be used on a bean getter to
-     * override key name used in the JSONObject. For example, using the object
-     * above with the <code>getName</code> method, if we annotated it with:
+     * The {@link JSONPropertyName} annotation can be used on a bean getter to override key name used in the JSONObject.
+     * For example, using the object above with the <code>getName</code> method, if we annotated it with:
      * <pre>
      * &#64;JSONPropertyName("FullName")
      * public String getName() { return this.name; }
@@ -356,33 +356,27 @@ public class JSONObject {
      * <p>
      * Similarly, the {@link JSONPropertyName} annotation can be used on non-
      * <code>get</code> and <code>is</code> methods. We can also override key
-     * name used in the JSONObject as seen below even though the field would normally
-     * be ignored:
+     * name used in the JSONObject as seen below even though the field would normally be ignored:
      * <pre>
      * &#64;JSONPropertyName("FullName")
      * public String fullName() { return this.name; }
      * </pre>
      * The resulting JSON object would contain <code>"FullName": "Larry Fine"</code>
      * <p>
-     * The {@link JSONPropertyIgnore} annotation can be used to force the bean property
-     * to not be serialized into JSON. If both {@link JSONPropertyIgnore} and
-     * {@link JSONPropertyName} are defined on the same method, a depth comparison is
-     * performed and the one closest to the concrete class being serialized is used.
-     * If both annotations are at the same level, then the {@link JSONPropertyIgnore}
-     * annotation takes precedent and the field is not serialized.
-     * For example, the following declaration would prevent the <code>getName</code>
-     * method from being serialized:
+     * The {@link JSONPropertyIgnore} annotation can be used to force the bean property to not be serialized into JSON.
+     * If both {@link JSONPropertyIgnore} and {@link JSONPropertyName} are defined on the same method, a depth
+     * comparison is performed and the one closest to the concrete class being serialized is used. If both annotations
+     * are at the same level, then the {@link JSONPropertyIgnore} annotation takes precedent and the field is not
+     * serialized. For example, the following declaration would prevent the <code>getName</code> method from being
+     * serialized:
      * <pre>
      * &#64;JSONPropertyName("FullName")
      * &#64;JSONPropertyIgnore
      * public String getName() { return this.name; }
      * </pre>
      *
-     * @param bean
-     *            An object that has getter methods that should be used to make
-     *            a JSONObject.
-     * @throws JSONException
-     *            If a getter returned a non-finite number.
+     * @param bean An object that has getter methods that should be used to make a JSONObject.
+     * @throws JSONException If a getter returned a non-finite number.
      */
     public JSONObject(Object bean) {
         this();
@@ -395,20 +389,14 @@ public class JSONObject {
     }
 
     /**
-     * Construct a JSONObject from an Object, using reflection to find the
-     * public members. The resulting JSONObject's keys will be the strings from
-     * the names array, and the values will be the field values associated with
-     * those keys in the object. If a key is not found or not visible, then it
-     * will not be copied into the new JSONObject.
+     * Construct a JSONObject from an Object, using reflection to find the public members. The resulting JSONObject's
+     * keys will be the strings from the names array, and the values will be the field values associated with those keys
+     * in the object. If a key is not found or not visible, then it will not be copied into the new JSONObject.
      *
-     * @param object
-     *            An object that has fields that should be used to make a
-     *            JSONObject.
-     * @param names
-     *            An array of strings, the names of the fields to be obtained
-     *            from the object.
+     * @param object An object that has fields that should be used to make a JSONObject.
+     * @param names  An array of strings, the names of the fields to be obtained from the object.
      */
-    public JSONObject(Object object, String ... names) {
+    public JSONObject(Object object, String... names) {
         this(names.length);
         Class<?> c = object.getClass();
         for (int i = 0; i < names.length; i += 1) {
@@ -421,34 +409,24 @@ public class JSONObject {
     }
 
     /**
-     * Construct a JSONObject from a source JSON text string. This is the most
-     * commonly used JSONObject constructor.
+     * Construct a JSONObject from a source JSON text string. This is the most commonly used JSONObject constructor.
      *
-     * @param source
-     *            A string beginning with <code>{</code>&nbsp;<small>(left
-     *            brace)</small> and ending with <code>}</code>
-     *            &nbsp;<small>(right brace)</small>.
-     * @exception JSONException
-     *                If there is a syntax error in the source string or a
-     *                duplicated key.
+     * @param source A string beginning with <code>{</code>&nbsp;<small>(left brace)</small> and ending with
+     *               <code>}</code> &nbsp;<small>(right brace)</small>.
+     * @throws JSONException If there is a syntax error in the source string or a duplicated key.
      */
     public JSONObject(String source) throws JSONException {
         this(source, new JSONParserConfiguration());
     }
 
     /**
-     * Construct a JSONObject from a source JSON text string with custom json parse configurations.
-     * This is the most commonly used JSONObject constructor.
+     * Construct a JSONObject from a source JSON text string with custom json parse configurations. This is the most
+     * commonly used JSONObject constructor.
      *
-     * @param source
-     *            A string beginning with <code>{</code>&nbsp;<small>(left
-     *            brace)</small> and ending with <code>}</code>
-     *            &nbsp;<small>(right brace)</small>.
-     * @param jsonParserConfiguration
-     *            Variable to pass parser custom configuration for json parsing.
-     * @exception JSONException
-     *                If there is a syntax error in the source string or a
-     *                duplicated key.
+     * @param source                  A string beginning with <code>{</code>&nbsp;<small>(left brace)</small> and ending
+     *                                with <code>}</code> &nbsp;<small>(right brace)</small>.
+     * @param jsonParserConfiguration Variable to pass parser custom configuration for json parsing.
+     * @throws JSONException If there is a syntax error in the source string or a duplicated key.
      */
     public JSONObject(String source, JSONParserConfiguration jsonParserConfiguration) throws JSONException {
         this(new JSONTokener(source), jsonParserConfiguration);
@@ -457,17 +435,14 @@ public class JSONObject {
     /**
      * Construct a JSONObject from a ResourceBundle.
      *
-     * @param baseName
-     *            The ResourceBundle base name.
-     * @param locale
-     *            The Locale to load the ResourceBundle for.
-     * @throws JSONException
-     *             If any JSONExceptions are detected.
+     * @param baseName The ResourceBundle base name.
+     * @param locale   The Locale to load the ResourceBundle for.
+     * @throws JSONException If any JSONExceptions are detected.
      */
     public JSONObject(String baseName, Locale locale) throws JSONException {
         this();
         ResourceBundle bundle = ResourceBundle.getBundle(baseName, locale,
-                Thread.currentThread().getContextClassLoader());
+            Thread.currentThread().getContextClassLoader());
 
 // Iterate through the keys in the bundle.
 
@@ -498,44 +473,36 @@ public class JSONObject {
     }
 
     /**
-     * Constructor to specify an initial capacity of the internal map. Useful for library
-     * internal calls where we know, or at least can best guess, how big this JSONObject
-     * will be.
+     * Constructor to specify an initial capacity of the internal map. Useful for library internal calls where we know,
+     * or at least can best guess, how big this JSONObject will be.
      *
      * @param initialCapacity initial capacity of the internal map.
      */
-    protected JSONObject(int initialCapacity){
+    protected JSONObject(int initialCapacity) {
         this.map = new HashMap<String, Object>(initialCapacity);
     }
 
     /**
-     * Accumulate values under a key. It is similar to the put method except
-     * that if there is already an object stored under the key then a JSONArray
-     * is stored under the key to hold all of the accumulated values. If there
-     * is already a JSONArray, then the new value is appended to it. In
-     * contrast, the put method replaces the previous value.
+     * Accumulate values under a key. It is similar to the put method except that if there is already an object stored
+     * under the key then a JSONArray is stored under the key to hold all of the accumulated values. If there is already
+     * a JSONArray, then the new value is appended to it. In contrast, the put method replaces the previous value.
+     * <p>
+     * If only one value is accumulated that is not a JSONArray, then the result will be the same as using put. But if
+     * multiple values are accumulated, then the result will be like append.
      *
-     * If only one value is accumulated that is not a JSONArray, then the result
-     * will be the same as using put. But if multiple values are accumulated,
-     * then the result will be like append.
-     *
-     * @param key
-     *            A key string.
-     * @param value
-     *            An object to be accumulated under the key.
+     * @param key   A key string.
+     * @param value An object to be accumulated under the key.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject accumulate(String key, Object value) throws JSONException {
         testValidity(value);
         Object object = this.opt(key);
         if (object == null) {
             this.put(key,
-                    value instanceof JSONArray ? new JSONArray().put(value)
-                            : value);
+                value instanceof JSONArray ? new JSONArray().put(value)
+                    : value);
         } else if (object instanceof JSONArray) {
             ((JSONArray) object).put(value);
         } else {
@@ -545,21 +512,16 @@ public class JSONObject {
     }
 
     /**
-     * Append values to the array under a key. If the key does not exist in the
-     * JSONObject, then the key is put in the JSONObject with its value being a
-     * JSONArray containing the value parameter. If the key was already
-     * associated with a JSONArray, then the value parameter is appended to it.
+     * Append values to the array under a key. If the key does not exist in the JSONObject, then the key is put in the
+     * JSONObject with its value being a JSONArray containing the value parameter. If the key was already associated
+     * with a JSONArray, then the value parameter is appended to it.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            An object to be accumulated under the key.
+     * @param key   A key string.
+     * @param value An object to be accumulated under the key.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number or if the current value associated with
-     *             the key is not a JSONArray.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number or if the current value associated with the key is
+     *                              not a JSONArray.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject append(String key, Object value) throws JSONException {
         testValidity(value);
@@ -575,11 +537,9 @@ public class JSONObject {
     }
 
     /**
-     * Produce a string from a double. The string "null" will be returned if the
-     * number is not finite.
+     * Produce a string from a double. The string "null" will be returned if the number is not finite.
      *
-     * @param d
-     *            A double.
+     * @param d A double.
      * @return A String.
      */
     public static String doubleToString(double d) {
@@ -591,7 +551,7 @@ public class JSONObject {
 
         String string = Double.toString(d);
         if (string.indexOf('.') > 0 && string.indexOf('e') < 0
-                && string.indexOf('E') < 0) {
+            && string.indexOf('E') < 0) {
             while (string.endsWith("0")) {
                 string = string.substring(0, string.length() - 1);
             }
@@ -605,11 +565,9 @@ public class JSONObject {
     /**
      * Get the value object associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The object associated with the key.
-     * @throws JSONException
-     *             if the key is not found.
+     * @throws JSONException if the key is not found.
      */
     public Object get(String key) throws JSONException {
         if (key == null) {
@@ -625,20 +583,15 @@ public class JSONObject {
     /**
      * Get the enum value associated with a key.
      *
-     * @param <E>
-     *            Enum Type
-     * @param clazz
-     *           The type of enum to retrieve.
-     * @param key
-     *           A key string.
+     * @param <E>   Enum Type
+     * @param clazz The type of enum to retrieve.
+     * @param key   A key string.
      * @return The enum value associated with the key
-     * @throws JSONException
-     *             if the key is not found or if the value cannot be converted
-     *             to an enum.
+     * @throws JSONException if the key is not found or if the value cannot be converted to an enum.
      */
     public <E extends Enum<E>> E getEnum(Class<E> clazz, String key) throws JSONException {
         E val = optEnum(clazz, key);
-        if(val==null) {
+        if (val == null) {
             // JSONException should really take a throwable argument.
             // If it did, I would re-implement this with the Enum.valueOf
             // method and place any thrown exception in the JSONException
@@ -650,22 +603,19 @@ public class JSONObject {
     /**
      * Get the boolean value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The truth.
-     * @throws JSONException
-     *             if the value is not a Boolean or the String "true" or
-     *             "false".
+     * @throws JSONException if the value is not a Boolean or the String "true" or "false".
      */
     public boolean getBoolean(String key) throws JSONException {
         Object object = this.get(key);
         if (object.equals(Boolean.FALSE)
-                || (object instanceof String && ((String) object)
-                        .equalsIgnoreCase("false"))) {
+            || (object instanceof String && ((String) object)
+            .equalsIgnoreCase("false"))) {
             return false;
         } else if (object.equals(Boolean.TRUE)
-                || (object instanceof String && ((String) object)
-                        .equalsIgnoreCase("true"))) {
+            || (object instanceof String && ((String) object)
+            .equalsIgnoreCase("true"))) {
             return true;
         }
         throw wrongValueFormatException(key, "Boolean", object, null);
@@ -674,12 +624,9 @@ public class JSONObject {
     /**
      * Get the BigInteger value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value cannot
-     *             be converted to BigInteger.
+     * @throws JSONException if the key is not found or if the value cannot be converted to BigInteger.
      */
     public BigInteger getBigInteger(String key) throws JSONException {
         Object object = this.get(key);
@@ -691,17 +638,13 @@ public class JSONObject {
     }
 
     /**
-     * Get the BigDecimal value associated with a key. If the value is float or
-     * double, the {@link BigDecimal#BigDecimal(double)} constructor will
-     * be used. See notes on the constructor for conversion issues that may
-     * arise.
+     * Get the BigDecimal value associated with a key. If the value is float or double, the
+     * {@link BigDecimal#BigDecimal(double)} constructor will be used. See notes on the constructor for conversion
+     * issues that may arise.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value
-     *             cannot be converted to BigDecimal.
+     * @throws JSONException if the key is not found or if the value cannot be converted to BigDecimal.
      */
     public BigDecimal getBigDecimal(String key) throws JSONException {
         Object object = this.get(key);
@@ -715,17 +658,15 @@ public class JSONObject {
     /**
      * Get the double value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a Number
-     *             object and cannot be converted to a number.
+     * @throws JSONException if the key is not found or if the value is not a Number object and cannot be converted to a
+     *                       number.
      */
     public double getDouble(String key) throws JSONException {
         final Object object = this.get(key);
-        if(object instanceof Number) {
-            return ((Number)object).doubleValue();
+        if (object instanceof Number) {
+            return ((Number) object).doubleValue();
         }
         try {
             return Double.parseDouble(object.toString());
@@ -737,17 +678,15 @@ public class JSONObject {
     /**
      * Get the float value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a Number
-     *             object and cannot be converted to a number.
+     * @throws JSONException if the key is not found or if the value is not a Number object and cannot be converted to a
+     *                       number.
      */
     public float getFloat(String key) throws JSONException {
         final Object object = this.get(key);
-        if(object instanceof Number) {
-            return ((Number)object).floatValue();
+        if (object instanceof Number) {
+            return ((Number) object).floatValue();
         }
         try {
             return Float.parseFloat(object.toString());
@@ -759,18 +698,16 @@ public class JSONObject {
     /**
      * Get the Number value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a Number
-     *             object and cannot be converted to a number.
+     * @throws JSONException if the key is not found or if the value is not a Number object and cannot be converted to a
+     *                       number.
      */
     public Number getNumber(String key) throws JSONException {
         Object object = this.get(key);
         try {
             if (object instanceof Number) {
-                return (Number)object;
+                return (Number) object;
             }
             return stringToNumber(object.toString());
         } catch (Exception e) {
@@ -781,17 +718,14 @@ public class JSONObject {
     /**
      * Get the int value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The integer value.
-     * @throws JSONException
-     *             if the key is not found or if the value cannot be converted
-     *             to an integer.
+     * @throws JSONException if the key is not found or if the value cannot be converted to an integer.
      */
     public int getInt(String key) throws JSONException {
         final Object object = this.get(key);
-        if(object instanceof Number) {
-            return ((Number)object).intValue();
+        if (object instanceof Number) {
+            return ((Number) object).intValue();
         }
         try {
             return Integer.parseInt(object.toString());
@@ -803,11 +737,9 @@ public class JSONObject {
     /**
      * Get the JSONArray value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return A JSONArray which is the value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a JSONArray.
+     * @throws JSONException if the key is not found or if the value is not a JSONArray.
      */
     public JSONArray getJSONArray(String key) throws JSONException {
         Object object = this.get(key);
@@ -820,11 +752,9 @@ public class JSONObject {
     /**
      * Get the JSONObject value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return A JSONObject which is the value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a JSONObject.
+     * @throws JSONException if the key is not found or if the value is not a JSONObject.
      */
     public JSONObject getJSONObject(String key) throws JSONException {
         Object object = this.get(key);
@@ -837,17 +767,14 @@ public class JSONObject {
     /**
      * Get the long value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The long value.
-     * @throws JSONException
-     *             if the key is not found or if the value cannot be converted
-     *             to a long.
+     * @throws JSONException if the key is not found or if the value cannot be converted to a long.
      */
     public long getLong(String key) throws JSONException {
         final Object object = this.get(key);
-        if(object instanceof Number) {
-            return ((Number)object).longValue();
+        if (object instanceof Number) {
+            return ((Number) object).longValue();
         }
         try {
             return Long.parseLong(object.toString());
@@ -859,8 +786,7 @@ public class JSONObject {
     /**
      * Get an array of field names from a JSONObject.
      *
-     * @param jo
-     *            JSON object
+     * @param jo JSON object
      * @return An array of field names, or null if there are no names.
      */
     public static String[] getNames(JSONObject jo) {
@@ -873,8 +799,7 @@ public class JSONObject {
     /**
      * Get an array of public field names from an Object.
      *
-     * @param object
-     *            object to read
+     * @param object object to read
      * @return An array of field names, or null if there are no names.
      */
     public static String[] getNames(Object object) {
@@ -897,11 +822,9 @@ public class JSONObject {
     /**
      * Get the string associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return A string which is the value.
-     * @throws JSONException
-     *             if there is no string value for the key.
+     * @throws JSONException if there is no string value for the key.
      */
     public String getString(String key) throws JSONException {
         Object object = this.get(key);
@@ -914,8 +837,7 @@ public class JSONObject {
     /**
      * Determine if the JSONObject contains a specific key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return true if the key exists in the JSONObject.
      */
     public boolean has(String key) {
@@ -923,19 +845,15 @@ public class JSONObject {
     }
 
     /**
-     * Increment a property of a JSONObject. If there is no such property,
-     * create one with a value of 1 (Integer). If there is such a property, and if it is
-     * an Integer, Long, Double, Float, BigInteger, or BigDecimal then add one to it.
-     * No overflow bounds checking is performed, so callers should initialize the key
-     * prior to this call with an appropriate type that can handle the maximum expected
-     * value.
+     * Increment a property of a JSONObject. If there is no such property, create one with a value of 1 (Integer). If
+     * there is such a property, and if it is an Integer, Long, Double, Float, BigInteger, or BigDecimal then add one to
+     * it. No overflow bounds checking is performed, so callers should initialize the key prior to this call with an
+     * appropriate type that can handle the maximum expected value.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return this.
-     * @throws JSONException
-     *             If there is already a property with this name that is not an
-     *             Integer, Long, Double, or Float.
+     * @throws JSONException If there is already a property with this name that is not an Integer, Long, Double, or
+     *                       Float.
      */
     public JSONObject increment(String key) throws JSONException {
         Object value = this.opt(key);
@@ -946,13 +864,13 @@ public class JSONObject {
         } else if (value instanceof Long) {
             this.put(key, ((Long) value).longValue() + 1L);
         } else if (value instanceof BigInteger) {
-            this.put(key, ((BigInteger)value).add(BigInteger.ONE));
+            this.put(key, ((BigInteger) value).add(BigInteger.ONE));
         } else if (value instanceof Float) {
             this.put(key, ((Float) value).floatValue() + 1.0f);
         } else if (value instanceof Double) {
             this.put(key, ((Double) value).doubleValue() + 1.0d);
         } else if (value instanceof BigDecimal) {
-            this.put(key, ((BigDecimal)value).add(BigDecimal.ONE));
+            this.put(key, ((BigDecimal) value).add(BigDecimal.ONE));
         } else {
             throw new JSONException("Unable to increment [" + quote(key) + "].");
         }
@@ -960,53 +878,45 @@ public class JSONObject {
     }
 
     /**
-     * Determine if the value associated with the key is <code>null</code> or if there is no
-     * value.
+     * Determine if the value associated with the key is <code>null</code> or if there is no value.
      *
-     * @param key
-     *            A key string.
-     * @return true if there is no value associated with the key or if the value
-     *        is the JSONObject.NULL object.
+     * @param key A key string.
+     * @return true if there is no value associated with the key or if the value is the JSONObject.NULL object.
      */
     public boolean isNull(String key) {
         return JSONObject.NULL.equals(this.opt(key));
     }
 
     /**
-     * Get an enumeration of the keys of the JSONObject. Modifying this key Set will also
-     * modify the JSONObject. Use with caution.
-     *
-     * @see Set#iterator()
+     * Get an enumeration of the keys of the JSONObject. Modifying this key Set will also modify the JSONObject. Use
+     * with caution.
      *
      * @return An iterator of the keys.
+     * @see Set#iterator()
      */
     public Iterator<String> keys() {
         return this.keySet().iterator();
     }
 
     /**
-     * Get a set of keys of the JSONObject. Modifying this key Set will also modify the
-     * JSONObject. Use with caution.
-     *
-     * @see Map#keySet()
+     * Get a set of keys of the JSONObject. Modifying this key Set will also modify the JSONObject. Use with caution.
      *
      * @return A keySet.
+     * @see Map#keySet()
      */
     public Set<String> keySet() {
         return this.map.keySet();
     }
 
     /**
-     * Get a set of entries of the JSONObject. These are raw values and may not
-     * match what is returned by the JSONObject get* and opt* functions. Modifying
-     * the returned EntrySet or the Entry objects contained therein will modify the
+     * Get a set of entries of the JSONObject. These are raw values and may not match what is returned by the JSONObject
+     * get* and opt* functions. Modifying the returned EntrySet or the Entry objects contained therein will modify the
      * backing JSONObject. This does not return a clone or a read-only view.
-     *
+     * <p>
      * Use with caution.
      *
-     * @see Map#entrySet()
-     *
      * @return An Entry Set
+     * @see Map#entrySet()
      */
     protected Set<Entry<String, Object>> entrySet() {
         return this.map.entrySet();
@@ -1022,8 +932,7 @@ public class JSONObject {
     }
 
     /**
-     * Removes all of the elements from this JSONObject.
-     * The JSONObject will be empty after this call returns.
+     * Removes all of the elements from this JSONObject. The JSONObject will be empty after this call returns.
      */
     public void clear() {
         this.map.clear();
@@ -1039,27 +948,23 @@ public class JSONObject {
     }
 
     /**
-     * Produce a JSONArray containing the names of the elements of this
-     * JSONObject.
+     * Produce a JSONArray containing the names of the elements of this JSONObject.
      *
-     * @return A JSONArray containing the key strings, or null if the JSONObject
-     *        is empty.
+     * @return A JSONArray containing the key strings, or null if the JSONObject is empty.
      */
     public JSONArray names() {
-    	if(this.map.isEmpty()) {
-    		return null;
-    	}
+        if (this.map.isEmpty()) {
+            return null;
+        }
         return new JSONArray(this.map.keySet());
     }
 
     /**
      * Produce a string from a Number.
      *
-     * @param number
-     *            A Number
+     * @param number A Number
      * @return A String.
-     * @throws JSONException
-     *             If n is a non-finite number.
+     * @throws JSONException If n is a non-finite number.
      */
     public static String numberToString(Number number) throws JSONException {
         if (number == null) {
@@ -1071,7 +976,7 @@ public class JSONObject {
 
         String string = number.toString();
         if (string.indexOf('.') > 0 && string.indexOf('e') < 0
-                && string.indexOf('E') < 0) {
+            && string.indexOf('E') < 0) {
             while (string.endsWith("0")) {
                 string = string.substring(0, string.length() - 1);
             }
@@ -1085,8 +990,7 @@ public class JSONObject {
     /**
      * Get an optional value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return An object which is the value, or null if there is no value.
      */
     public Object opt(String key) {
@@ -1096,12 +1000,9 @@ public class JSONObject {
     /**
      * Get the enum value associated with a key.
      *
-     * @param <E>
-     *            Enum Type
-     * @param clazz
-     *            The type of enum to retrieve.
-     * @param key
-     *            A key string.
+     * @param <E>   Enum Type
+     * @param clazz The type of enum to retrieve.
+     * @param key   A key string.
      * @return The enum value associated with the key or null if not found
      */
     public <E extends Enum<E>> E optEnum(Class<E> clazz, String key) {
@@ -1111,16 +1012,12 @@ public class JSONObject {
     /**
      * Get the enum value associated with a key.
      *
-     * @param <E>
-     *            Enum Type
-     * @param clazz
-     *            The type of enum to retrieve.
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default in case the value is not found
-     * @return The enum value associated with the key or defaultValue
-     *            if the value is not found or cannot be assigned to <code>clazz</code>
+     * @param <E>          Enum Type
+     * @param clazz        The type of enum to retrieve.
+     * @param key          A key string.
+     * @param defaultValue The default in case the value is not found
+     * @return The enum value associated with the key or defaultValue if the value is not found or cannot be assigned to
+     * <code>clazz</code>
      */
     public <E extends Enum<E>> E optEnum(Class<E> clazz, String key, E defaultValue) {
         try {
@@ -1143,11 +1040,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional boolean associated with a key. It returns false if there
-     * is no such key, or if the value is not Boolean.TRUE or the String "true".
+     * Get an optional boolean associated with a key. It returns false if there is no such key, or if the value is not
+     * Boolean.TRUE or the String "true".
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The truth.
      */
     public boolean optBoolean(String key) {
@@ -1155,14 +1051,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional boolean associated with a key. It returns the
-     * defaultValue if there is no such key, or if it is not a Boolean or the
-     * String "true" or "false" (case insensitive).
+     * Get an optional boolean associated with a key. It returns the defaultValue if there is no such key, or if it is
+     * not a Boolean or the String "true" or "false" (case insensitive).
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return The truth.
      */
     public boolean optBoolean(String key, boolean defaultValue) {
@@ -1170,7 +1063,7 @@ public class JSONObject {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof Boolean){
+        if (val instanceof Boolean) {
             return ((Boolean) val).booleanValue();
         }
         try {
@@ -1182,11 +1075,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional boolean object associated with a key. It returns false if there
-     * is no such key, or if the value is not Boolean.TRUE or the String "true".
+     * Get an optional boolean object associated with a key. It returns false if there is no such key, or if the value
+     * is not Boolean.TRUE or the String "true".
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The truth.
      */
     public Boolean optBooleanObject(String key) {
@@ -1194,14 +1086,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional boolean object associated with a key. It returns the
-     * defaultValue if there is no such key, or if it is not a Boolean or the
-     * String "true" or "false" (case insensitive).
+     * Get an optional boolean object associated with a key. It returns the defaultValue if there is no such key, or if
+     * it is not a Boolean or the String "true" or "false" (case insensitive).
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return The truth.
      */
     public Boolean optBooleanObject(String key, Boolean defaultValue) {
@@ -1209,7 +1098,7 @@ public class JSONObject {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof Boolean){
+        if (val instanceof Boolean) {
             return ((Boolean) val).booleanValue();
         }
         try {
@@ -1221,17 +1110,13 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional BigDecimal associated with a key, or the defaultValue if
-     * there is no such key or if its value is not a number. If the value is a
-     * string, an attempt will be made to evaluate it as a number. If the value
-     * is float or double, then the {@link BigDecimal#BigDecimal(double)}
-     * constructor will be used. See notes on the constructor for conversion
-     * issues that may arise.
+     * Get an optional BigDecimal associated with a key, or the defaultValue if there is no such key or if its value is
+     * not a number. If the value is a string, an attempt will be made to evaluate it as a number. If the value is float
+     * or double, then the {@link BigDecimal#BigDecimal(double)} constructor will be used. See notes on the constructor
+     * for conversion issues that may arise.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public BigDecimal optBigDecimal(String key, BigDecimal defaultValue) {
@@ -1240,39 +1125,38 @@ public class JSONObject {
     }
 
     /**
-     * @param val value to convert
+     * @param val          value to convert
      * @param defaultValue default value to return is the conversion doesn't work or is null.
-     * @return BigDecimal conversion of the original value, or the defaultValue if unable
-     *          to convert.
+     * @return BigDecimal conversion of the original value, or the defaultValue if unable to convert.
      */
     static BigDecimal objectToBigDecimal(Object val, BigDecimal defaultValue) {
         return objectToBigDecimal(val, defaultValue, true);
     }
-    
+
     /**
-     * @param val value to convert
+     * @param val          value to convert
      * @param defaultValue default value to return is the conversion doesn't work or is null.
-     * @param exact When <code>true</code>, then {@link Double} and {@link Float} values will be converted exactly.
-     *      When <code>false</code>, they will be converted to {@link String} values before converting to {@link BigDecimal}.
-     * @return BigDecimal conversion of the original value, or the defaultValue if unable
-     *          to convert.
+     * @param exact        When <code>true</code>, then {@link Double} and {@link Float} values will be converted
+     *                     exactly. When <code>false</code>, they will be converted to {@link String} values before
+     *                     converting to {@link BigDecimal}.
+     * @return BigDecimal conversion of the original value, or the defaultValue if unable to convert.
      */
     static BigDecimal objectToBigDecimal(Object val, BigDecimal defaultValue, boolean exact) {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof BigDecimal){
+        if (val instanceof BigDecimal) {
             return (BigDecimal) val;
         }
-        if (val instanceof BigInteger){
+        if (val instanceof BigInteger) {
             return new BigDecimal((BigInteger) val);
         }
-        if (val instanceof Double || val instanceof Float){
-            if (!numberIsFinite((Number)val)) {
+        if (val instanceof Double || val instanceof Float) {
+            if (!numberIsFinite((Number) val)) {
                 return defaultValue;
             }
             if (exact) {
-                return new BigDecimal(((Number)val).doubleValue());
+                return new BigDecimal(((Number) val).doubleValue());
             }
             // use the string constructor so that we maintain "nice" values for doubles and floats
             // the double constructor will translate doubles to "exact" values instead of the likely
@@ -1280,7 +1164,7 @@ public class JSONObject {
             return new BigDecimal(val.toString());
         }
         if (val instanceof Long || val instanceof Integer
-                || val instanceof Short || val instanceof Byte){
+            || val instanceof Short || val instanceof Byte) {
             return new BigDecimal(((Number) val).longValue());
         }
         // don't check if it's a string in case of unchecked Number subclasses
@@ -1292,14 +1176,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional BigInteger associated with a key, or the defaultValue if
-     * there is no such key or if its value is not a number. If the value is a
-     * string, an attempt will be made to evaluate it as a number.
+     * Get an optional BigInteger associated with a key, or the defaultValue if there is no such key or if its value is
+     * not a number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public BigInteger optBigInteger(String key, BigInteger defaultValue) {
@@ -1308,29 +1189,28 @@ public class JSONObject {
     }
 
     /**
-     * @param val value to convert
+     * @param val          value to convert
      * @param defaultValue default value to return is the conversion doesn't work or is null.
-     * @return BigInteger conversion of the original value, or the defaultValue if unable
-     *          to convert.
+     * @return BigInteger conversion of the original value, or the defaultValue if unable to convert.
      */
     static BigInteger objectToBigInteger(Object val, BigInteger defaultValue) {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof BigInteger){
+        if (val instanceof BigInteger) {
             return (BigInteger) val;
         }
-        if (val instanceof BigDecimal){
+        if (val instanceof BigDecimal) {
             return ((BigDecimal) val).toBigInteger();
         }
-        if (val instanceof Double || val instanceof Float){
-            if (!numberIsFinite((Number)val)) {
+        if (val instanceof Double || val instanceof Float) {
+            if (!numberIsFinite((Number) val)) {
                 return defaultValue;
             }
             return new BigDecimal(((Number) val).doubleValue()).toBigInteger();
         }
         if (val instanceof Long || val instanceof Integer
-                || val instanceof Short || val instanceof Byte){
+            || val instanceof Short || val instanceof Byte) {
             return BigInteger.valueOf(((Number) val).longValue());
         }
         // don't check if it's a string in case of unchecked Number subclasses
@@ -1341,7 +1221,7 @@ public class JSONObject {
             // this conversion to BigDecimal then to BigInteger is to maintain
             // that type cast support that may truncate the decimal.
             final String valStr = val.toString();
-            if(isDecimalNotation(valStr)) {
+            if (isDecimalNotation(valStr)) {
                 return new BigDecimal(valStr).toBigInteger();
             }
             return new BigInteger(valStr);
@@ -1351,12 +1231,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional double associated with a key, or NaN if there is no such
-     * key or if its value is not a number. If the value is a string, an attempt
-     * will be made to evaluate it as a number.
+     * Get an optional double associated with a key, or NaN if there is no such key or if its value is not a number. If
+     * the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A string which is the key.
+     * @param key A string which is the key.
      * @return An object which is the value.
      */
     public double optDouble(String key) {
@@ -1364,14 +1242,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional double associated with a key, or the defaultValue if
-     * there is no such key or if its value is not a number. If the value is a
-     * string, an attempt will be made to evaluate it as a number.
+     * Get an optional double associated with a key, or the defaultValue if there is no such key or if its value is not
+     * a number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public double optDouble(String key, double defaultValue) {
@@ -1383,12 +1258,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Double object associated with a key, or NaN if there is no such
-     * key or if its value is not a number. If the value is a string, an attempt
-     * will be made to evaluate it as a number.
+     * Get an optional Double object associated with a key, or NaN if there is no such key or if its value is not a
+     * number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A string which is the key.
+     * @param key A string which is the key.
      * @return An object which is the value.
      */
     public Double optDoubleObject(String key) {
@@ -1396,14 +1269,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Double object associated with a key, or the defaultValue if
-     * there is no such key or if its value is not a number. If the value is a
-     * string, an attempt will be made to evaluate it as a number.
+     * Get an optional Double object associated with a key, or the defaultValue if there is no such key or if its value
+     * is not a number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public Double optDoubleObject(String key, Double defaultValue) {
@@ -1415,12 +1285,10 @@ public class JSONObject {
     }
 
     /**
-     * Get the optional float value associated with an index. NaN is returned
-     * if there is no value for the index, or if the value is not a number and
-     * cannot be converted to a number.
+     * Get the optional float value associated with an index. NaN is returned if there is no value for the index, or if
+     * the value is not a number and cannot be converted to a number.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The value.
      */
     public float optFloat(String key) {
@@ -1428,14 +1296,11 @@ public class JSONObject {
     }
 
     /**
-     * Get the optional float value associated with an index. The defaultValue
-     * is returned if there is no value for the index, or if the value is not a
-     * number and cannot be converted to a number.
+     * Get the optional float value associated with an index. The defaultValue is returned if there is no value for the
+     * index, or if the value is not a number and cannot be converted to a number.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default value.
+     * @param key          A key string.
+     * @param defaultValue The default value.
      * @return The value.
      */
     public float optFloat(String key, float defaultValue) {
@@ -1451,12 +1316,10 @@ public class JSONObject {
     }
 
     /**
-     * Get the optional Float object associated with an index. NaN is returned
-     * if there is no value for the index, or if the value is not a number and
-     * cannot be converted to a number.
+     * Get the optional Float object associated with an index. NaN is returned if there is no value for the index, or if
+     * the value is not a number and cannot be converted to a number.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The object.
      */
     public Float optFloatObject(String key) {
@@ -1464,14 +1327,11 @@ public class JSONObject {
     }
 
     /**
-     * Get the optional Float object associated with an index. The defaultValue
-     * is returned if there is no value for the index, or if the value is not a
-     * number and cannot be converted to a number.
+     * Get the optional Float object associated with an index. The defaultValue is returned if there is no value for the
+     * index, or if the value is not a number and cannot be converted to a number.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default object.
+     * @param key          A key string.
+     * @param defaultValue The default object.
      * @return The object.
      */
     public Float optFloatObject(String key, Float defaultValue) {
@@ -1487,12 +1347,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional int value associated with a key, or zero if there is no
-     * such key or if the value is not a number. If the value is a string, an
-     * attempt will be made to evaluate it as a number.
+     * Get an optional int value associated with a key, or zero if there is no such key or if the value is not a number.
+     * If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return An object which is the value.
      */
     public int optInt(String key) {
@@ -1500,14 +1358,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional int value associated with a key, or the default if there
-     * is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number.
+     * Get an optional int value associated with a key, or the default if there is no such key or if the value is not a
+     * number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public int optInt(String key, int defaultValue) {
@@ -1519,12 +1374,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Integer object associated with a key, or zero if there is no
-     * such key or if the value is not a number. If the value is a string, an
-     * attempt will be made to evaluate it as a number.
+     * Get an optional Integer object associated with a key, or zero if there is no such key or if the value is not a
+     * number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return An object which is the value.
      */
     public Integer optIntegerObject(String key) {
@@ -1532,14 +1385,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Integer object associated with a key, or the default if there
-     * is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number.
+     * Get an optional Integer object associated with a key, or the default if there is no such key or if the value is
+     * not a number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public Integer optIntegerObject(String key, Integer defaultValue) {
@@ -1551,11 +1401,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional JSONArray associated with a key. It returns null if there
-     * is no such key, or if its value is not a JSONArray.
+     * Get an optional JSONArray associated with a key. It returns null if there is no such key, or if its value is not
+     * a JSONArray.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return A JSONArray which is the value.
      */
     public JSONArray optJSONArray(String key) {
@@ -1563,13 +1412,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional JSONArray associated with a key, or the default if there
-     * is no such key, or if its value is not a JSONArray.
+     * Get an optional JSONArray associated with a key, or the default if there is no such key, or if its value is not a
+     * JSONArray.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return A JSONArray which is the value.
      */
     public JSONArray optJSONArray(String key, JSONArray defaultValue) {
@@ -1578,23 +1425,22 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional JSONObject associated with a key. It returns null if
-     * there is no such key, or if its value is not a JSONObject.
+     * Get an optional JSONObject associated with a key. It returns null if there is no such key, or if its value is not
+     * a JSONObject.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return A JSONObject which is the value.
      */
-    public JSONObject optJSONObject(String key) { return this.optJSONObject(key, null); }
+    public JSONObject optJSONObject(String key) {
+        return this.optJSONObject(key, null);
+    }
 
     /**
-     * Get an optional JSONObject associated with a key, or the default if there
-     * is no such key or if the value is not a JSONObject.
+     * Get an optional JSONObject associated with a key, or the default if there is no such key or if the value is not a
+     * JSONObject.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An JSONObject which is the value.
      */
     public JSONObject optJSONObject(String key, JSONObject defaultValue) {
@@ -1603,12 +1449,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional long value associated with a key, or zero if there is no
-     * such key or if the value is not a number. If the value is a string, an
-     * attempt will be made to evaluate it as a number.
+     * Get an optional long value associated with a key, or zero if there is no such key or if the value is not a
+     * number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return An object which is the value.
      */
     public long optLong(String key) {
@@ -1616,14 +1460,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional long value associated with a key, or the default if there
-     * is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number.
+     * Get an optional long value associated with a key, or the default if there is no such key or if the value is not a
+     * number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public long optLong(String key, long defaultValue) {
@@ -1636,12 +1477,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Long object associated with a key, or zero if there is no
-     * such key or if the value is not a number. If the value is a string, an
-     * attempt will be made to evaluate it as a number.
+     * Get an optional Long object associated with a key, or zero if there is no such key or if the value is not a
+     * number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return An object which is the value.
      */
     public Long optLongObject(String key) {
@@ -1649,14 +1488,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Long object associated with a key, or the default if there
-     * is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number.
+     * Get an optional Long object associated with a key, or the default if there is no such key or if the value is not
+     * a number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public Long optLongObject(String key, Long defaultValue) {
@@ -1669,13 +1505,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional {@link Number} value associated with a key, or <code>null</code>
-     * if there is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number ({@link BigDecimal}). This method
-     * would be used in cases where type coercion of the number value is unwanted.
+     * Get an optional {@link Number} value associated with a key, or <code>null</code> if there is no such key or if
+     * the value is not a number. If the value is a string, an attempt will be made to evaluate it as a number
+     * ({@link BigDecimal}). This method would be used in cases where type coercion of the number value is unwanted.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return An object which is the value.
      */
     public Number optNumber(String key) {
@@ -1683,15 +1517,12 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional {@link Number} value associated with a key, or the default if there
-     * is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number. This method
+     * Get an optional {@link Number} value associated with a key, or the default if there is no such key or if the
+     * value is not a number. If the value is a string, an attempt will be made to evaluate it as a number. This method
      * would be used in cases where type coercion of the number value is unwanted.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public Number optNumber(String key, Number defaultValue) {
@@ -1699,7 +1530,7 @@ public class JSONObject {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof Number){
+        if (val instanceof Number) {
             return (Number) val;
         }
 
@@ -1711,12 +1542,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional string associated with a key. It returns an empty string
-     * if there is no such key. If the value is not a string and is not null,
-     * then it is converted to a string.
+     * Get an optional string associated with a key. It returns an empty string if there is no such key. If the value is
+     * not a string and is not null, then it is converted to a string.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return A string which is the value.
      */
     public String optString(String key) {
@@ -1724,13 +1553,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional string associated with a key. It returns the defaultValue
-     * if there is no such key.
+     * Get an optional string associated with a key. It returns the defaultValue if there is no such key.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return A string which is the value.
      */
     public String optString(String key, String defaultValue) {
@@ -1739,15 +1565,11 @@ public class JSONObject {
     }
 
     /**
-     * Populates the internal map of the JSONObject with the bean properties. The
-     * bean can not be recursive.
+     * Populates the internal map of the JSONObject with the bean properties. The bean can not be recursive.
      *
+     * @param bean the bean
+     * @throws JSONException If a getter returned a non-finite number.
      * @see JSONObject#JSONObject(Object)
-     *
-     * @param bean
-     *            the bean
-     * @throws JSONException
-     *            If a getter returned a non-finite number.
      */
     private void populateMap(Object bean) {
         populateMap(bean, Collections.newSetFromMap(new IdentityHashMap<Object, Boolean>()));
@@ -1764,11 +1586,11 @@ public class JSONObject {
         for (final Method method : methods) {
             final int modifiers = method.getModifiers();
             if (Modifier.isPublic(modifiers)
-                    && !Modifier.isStatic(modifiers)
-                    && method.getParameterTypes().length == 0
-                    && !method.isBridge()
-                    && method.getReturnType() != Void.TYPE
-                    && isValidMethodName(method.getName())) {
+                && !Modifier.isStatic(modifiers)
+                && method.getParameterTypes().length == 0
+                && !method.isBridge()
+                && method.getReturnType() != Void.TYPE
+                && isValidMethodName(method.getName())) {
                 final String key = getKeyNameFromMethod(method);
                 if (key != null && !key.isEmpty()) {
                     try {
@@ -1849,18 +1671,14 @@ public class JSONObject {
     }
 
     /**
-     * Searches the class hierarchy to see if the method or it's super
-     * implementations and interfaces has the annotation.
+     * Searches the class hierarchy to see if the method or it's super implementations and interfaces has the
+     * annotation.
      *
-     * @param <A>
-     *            type of the annotation
-     *
-     * @param m
-     *            method to check
-     * @param annotationClass
-     *            annotation to look for
-     * @return the {@link Annotation} if the annotation exists on the current method
-     *         or one of its super class definitions
+     * @param <A>             type of the annotation
+     * @param m               method to check
+     * @param annotationClass annotation to look for
+     * @return the {@link Annotation} if the annotation exists on the current method or one of its super class
+     * definitions
      */
     private static <A extends Annotation> A getAnnotation(final Method m, final Class<A> annotationClass) {
         // if we have invalid data the result is null
@@ -1891,13 +1709,14 @@ public class JSONObject {
         }
 
         //If the superclass is Object, no annotations will be found any more
-        if (c.getSuperclass().equals(Object.class))
+        if (c.getSuperclass().equals(Object.class)) {
             return null;
+        }
 
         try {
             return getAnnotation(
-                    c.getSuperclass().getMethod(m.getName(), m.getParameterTypes()),
-                    annotationClass);
+                c.getSuperclass().getMethod(m.getName(), m.getParameterTypes()),
+                annotationClass);
         } catch (final SecurityException ex) {
             return null;
         } catch (final NoSuchMethodException ex) {
@@ -1906,14 +1725,11 @@ public class JSONObject {
     }
 
     /**
-     * Searches the class hierarchy to see if the method or it's super
-     * implementations and interfaces has the annotation. Returns the depth of the
-     * annotation in the hierarchy.
+     * Searches the class hierarchy to see if the method or it's super implementations and interfaces has the
+     * annotation. Returns the depth of the annotation in the hierarchy.
      *
-     * @param m
-     *            method to check
-     * @param annotationClass
-     *            annotation to look for
+     * @param m               method to check
+     * @param annotationClass annotation to look for
      * @return Depth of the annotation or -1 if the annotation is not on the method.
      */
     private static int getAnnotationDepth(final Method m, final Class<? extends Annotation> annotationClass) {
@@ -1949,13 +1765,14 @@ public class JSONObject {
         }
 
         //If the superclass is Object, no annotations will be found any more
-        if (c.getSuperclass().equals(Object.class))
+        if (c.getSuperclass().equals(Object.class)) {
             return -1;
+        }
 
         try {
             int d = getAnnotationDepth(
-                    c.getSuperclass().getMethod(m.getName(), m.getParameterTypes()),
-                    annotationClass);
+                c.getSuperclass().getMethod(m.getName(), m.getParameterTypes()),
+                annotationClass);
             if (d > 0) {
                 // since the annotation was on the superclass, add 1
                 return d + 1;
@@ -1971,33 +1788,24 @@ public class JSONObject {
     /**
      * Put a key/boolean pair in the JSONObject.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            A boolean which is the value.
+     * @param key   A key string.
+     * @param value A boolean which is the value.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject put(String key, boolean value) throws JSONException {
         return this.put(key, value ? Boolean.TRUE : Boolean.FALSE);
     }
 
     /**
-     * Put a key/value pair in the JSONObject, where the value will be a
-     * JSONArray which is produced from a Collection.
+     * Put a key/value pair in the JSONObject, where the value will be a JSONArray which is produced from a Collection.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            A Collection value.
+     * @param key   A key string.
+     * @param value A Collection value.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject put(String key, Collection<?> value) throws JSONException {
         return this.put(key, new JSONArray(value));
@@ -2006,15 +1814,11 @@ public class JSONObject {
     /**
      * Put a key/double pair in the JSONObject.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            A double which is the value.
+     * @param key   A key string.
+     * @param value A double which is the value.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject put(String key, double value) throws JSONException {
         return this.put(key, Double.valueOf(value));
@@ -2023,15 +1827,11 @@ public class JSONObject {
     /**
      * Put a key/float pair in the JSONObject.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            A float which is the value.
+     * @param key   A key string.
+     * @param value A float which is the value.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject put(String key, float value) throws JSONException {
         return this.put(key, Float.valueOf(value));
@@ -2040,15 +1840,11 @@ public class JSONObject {
     /**
      * Put a key/int pair in the JSONObject.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            An int which is the value.
+     * @param key   A key string.
+     * @param value An int which is the value.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject put(String key, int value) throws JSONException {
         return this.put(key, Integer.valueOf(value));
@@ -2057,53 +1853,39 @@ public class JSONObject {
     /**
      * Put a key/long pair in the JSONObject.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            A long which is the value.
+     * @param key   A key string.
+     * @param value A long which is the value.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject put(String key, long value) throws JSONException {
         return this.put(key, Long.valueOf(value));
     }
 
     /**
-     * Put a key/value pair in the JSONObject, where the value will be a
-     * JSONObject which is produced from a Map.
+     * Put a key/value pair in the JSONObject, where the value will be a JSONObject which is produced from a Map.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            A Map value.
+     * @param key   A key string.
+     * @param value A Map value.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject put(String key, Map<?, ?> value) throws JSONException {
         return this.put(key, new JSONObject(value));
     }
 
     /**
-     * Put a key/value pair in the JSONObject. If the value is <code>null</code>, then the
-     * key will be removed from the JSONObject if it is present.
+     * Put a key/value pair in the JSONObject. If the value is <code>null</code>, then the key will be removed from the
+     * JSONObject if it is present.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            An object which is the value. It should be of one of these
-     *            types: Boolean, Double, Integer, JSONArray, JSONObject, Long,
-     *            String, or the JSONObject.NULL object.
+     * @param key   A key string.
+     * @param value An object which is the value. It should be of one of these types: Boolean, Double, Integer,
+     *              JSONArray, JSONObject, Long, String, or the JSONObject.NULL object.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject put(String key, Object value) throws JSONException {
         if (key == null) {
@@ -2119,17 +1901,13 @@ public class JSONObject {
     }
 
     /**
-     * Put a key/value pair in the JSONObject, but only if the key and the value
-     * are both non-null, and only if there is not already a member with that
-     * name.
+     * Put a key/value pair in the JSONObject, but only if the key and the value are both non-null, and only if there is
+     * not already a member with that name.
      *
-     * @param key
-     *            key to insert into
-     * @param value
-     *            value to insert
+     * @param key   key to insert into
+     * @param value value to insert
      * @return this.
-     * @throws JSONException
-     *             if the key is a duplicate
+     * @throws JSONException if the key is a duplicate
      */
     public JSONObject putOnce(String key, Object value) throws JSONException {
         if (key != null && value != null) {
@@ -2142,18 +1920,13 @@ public class JSONObject {
     }
 
     /**
-     * Put a key/value pair in the JSONObject, but only if the key and the value
-     * are both non-null.
+     * Put a key/value pair in the JSONObject, but only if the key and the value are both non-null.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            An object which is the value. It should be of one of these
-     *            types: Boolean, Double, Integer, JSONArray, JSONObject, Long,
-     *            String, or the JSONObject.NULL object.
+     * @param key   A key string.
+     * @param value An object which is the value. It should be of one of these types: Boolean, Double, Integer,
+     *              JSONArray, JSONObject, Long, String, or the JSONObject.NULL object.
      * @return this.
-     * @throws JSONException
-     *             If the value is a non-finite number.
+     * @throws JSONException If the value is a non-finite number.
      */
     public JSONObject putOpt(String key, Object value) throws JSONException {
         if (key != null && value != null) {
@@ -2163,9 +1936,8 @@ public class JSONObject {
     }
 
     /**
-     * Creates a JSONPointer using an initialization string and tries to
-     * match it to an item within this JSONObject. For example, given a
-     * JSONObject initialized with this document:
+     * Creates a JSONPointer using an initialization string and tries to match it to an item within this JSONObject. For
+     * example, given a JSONObject initialized with this document:
      * <pre>
      * {
      *     "a":{"b":"c"}
@@ -2175,8 +1947,8 @@ public class JSONObject {
      * <pre>
      * "/a/b"
      * </pre>
-     * Then this method will return the String "c".
-     * A JSONPointerException may be thrown from code called by this method.
+     * Then this method will return the String "c". A JSONPointerException may be thrown from code called by this
+     * method.
      *
      * @param jsonPointer string that can be used to create a JSONPointer
      * @return the item matched by the JSONPointer, otherwise null
@@ -2184,10 +1956,10 @@ public class JSONObject {
     public Object query(String jsonPointer) {
         return query(new JSONPointer(jsonPointer));
     }
+
     /**
-     * Uses a user initialized JSONPointer  and tries to
-     * match it to an item within this JSONObject. For example, given a
-     * JSONObject initialized with this document:
+     * Uses a user initialized JSONPointer  and tries to match it to an item within this JSONObject. For example, given
+     * a JSONObject initialized with this document:
      * <pre>
      * {
      *     "a":{"b":"c"}
@@ -2197,8 +1969,8 @@ public class JSONObject {
      * <pre>
      * "/a/b"
      * </pre>
-     * Then this method will return the String "c".
-     * A JSONPointerException may be thrown from code called by this method.
+     * Then this method will return the String "c". A JSONPointerException may be thrown from code called by this
+     * method.
      *
      * @param jsonPointer string that can be used to create a JSONPointer
      * @return the item matched by the JSONPointer, otherwise null
@@ -2208,20 +1980,20 @@ public class JSONObject {
     }
 
     /**
-     * Queries and returns a value from this object using {@code jsonPointer}, or
-     * returns null if the query fails due to a missing key.
+     * Queries and returns a value from this object using {@code jsonPointer}, or returns null if the query fails due to
+     * a missing key.
      *
      * @param jsonPointer the string representation of the JSON pointer
      * @return the queried value or {@code null}
      * @throws IllegalArgumentException if {@code jsonPointer} has invalid syntax
      */
     public Object optQuery(String jsonPointer) {
-    	return optQuery(new JSONPointer(jsonPointer));
+        return optQuery(new JSONPointer(jsonPointer));
     }
 
     /**
-     * Queries and returns a value from this object using {@code jsonPointer}, or
-     * returns null if the query fails due to a missing key.
+     * Queries and returns a value from this object using {@code jsonPointer}, or returns null if the query fails due to
+     * a missing key.
      *
      * @param jsonPointer The JSON pointer
      * @return the queried value or {@code null}
@@ -2236,14 +2008,11 @@ public class JSONObject {
     }
 
     /**
-     * Produce a string in double quotes with backslash sequences in all the
-     * right places. A backslash will be inserted within &lt;/, producing
-     * &lt;\/, allowing JSON text to be delivered in HTML. In JSON text, a
-     * string cannot contain a control character or an unescaped quote or
-     * backslash.
+     * Produce a string in double quotes with backslash sequences in all the right places. A backslash will be inserted
+     * within &lt;/, producing &lt;\/, allowing JSON text to be delivered in HTML. In JSON text, a string cannot contain
+     * a control character or an unescaped quote or backslash.
      *
-     * @param string
-     *            A String
+     * @param string A String
      * @return A String correctly formatted for insertion in a JSON text.
      */
     @SuppressWarnings("resource")
@@ -2282,42 +2051,42 @@ public class JSONObject {
             b = c;
             c = string.charAt(i);
             switch (c) {
-            case '\\':
-            case '"':
-                w.write('\\');
-                w.write(c);
-                break;
-            case '/':
-                if (b == '<') {
+                case '\\':
+                case '"':
                     w.write('\\');
-                }
-                w.write(c);
-                break;
-            case '\b':
-                w.write("\\b");
-                break;
-            case '\t':
-                w.write("\\t");
-                break;
-            case '\n':
-                w.write("\\n");
-                break;
-            case '\f':
-                w.write("\\f");
-                break;
-            case '\r':
-                w.write("\\r");
-                break;
-            default:
-                if (c < ' ' || (c >= '\u0080' && c < '\u00a0')
-                        || (c >= '\u2000' && c < '\u2100')) {
-                    w.write("\\u");
-                    hhhh = Integer.toHexString(c);
-                    w.write("0000", 0, 4 - hhhh.length());
-                    w.write(hhhh);
-                } else {
                     w.write(c);
-                }
+                    break;
+                case '/':
+                    if (b == '<') {
+                        w.write('\\');
+                    }
+                    w.write(c);
+                    break;
+                case '\b':
+                    w.write("\\b");
+                    break;
+                case '\t':
+                    w.write("\\t");
+                    break;
+                case '\n':
+                    w.write("\\n");
+                    break;
+                case '\f':
+                    w.write("\\f");
+                    break;
+                case '\r':
+                    w.write("\\r");
+                    break;
+                default:
+                    if (c < ' ' || (c >= '\u0080' && c < '\u00a0')
+                        || (c >= '\u2000' && c < '\u2100')) {
+                        w.write("\\u");
+                        hhhh = Integer.toHexString(c);
+                        w.write("0000", 0, 4 - hhhh.length());
+                        w.write(hhhh);
+                    } else {
+                        w.write(c);
+                    }
             }
         }
         w.write('"');
@@ -2327,18 +2096,15 @@ public class JSONObject {
     /**
      * Remove a name and its value, if present.
      *
-     * @param key
-     *            The name to be removed.
-     * @return The value that was associated with the name, or null if there was
-     *         no value.
+     * @param key The name to be removed.
+     * @return The value that was associated with the name, or null if there was no value.
      */
     public Object remove(String key) {
         return this.map.remove(key);
     }
 
     /**
-     * Determine if two JSONObjects are similar.
-     * They must contain the same set of names which must be associated with
+     * Determine if two JSONObjects are similar. They must contain the same set of names which must be associated with
      * similar values.
      *
      * @param other The other JSONObject
@@ -2349,34 +2115,34 @@ public class JSONObject {
             if (!(other instanceof JSONObject)) {
                 return false;
             }
-            if (!this.keySet().equals(((JSONObject)other).keySet())) {
+            if (!this.keySet().equals(((JSONObject) other).keySet())) {
                 return false;
             }
-            for (final Entry<String,?> entry : this.entrySet()) {
+            for (final Entry<String, ?> entry : this.entrySet()) {
                 String name = entry.getKey();
                 Object valueThis = entry.getValue();
-                Object valueOther = ((JSONObject)other).get(name);
-                if(valueThis == valueOther) {
-                	continue;
+                Object valueOther = ((JSONObject) other).get(name);
+                if (valueThis == valueOther) {
+                    continue;
                 }
-                if(valueThis == null) {
-                	return false;
+                if (valueThis == null) {
+                    return false;
                 }
                 if (valueThis instanceof JSONObject) {
-                    if (!((JSONObject)valueThis).similar(valueOther)) {
+                    if (!((JSONObject) valueThis).similar(valueOther)) {
                         return false;
                     }
                 } else if (valueThis instanceof JSONArray) {
-                    if (!((JSONArray)valueThis).similar(valueOther)) {
+                    if (!((JSONArray) valueThis).similar(valueOther)) {
                         return false;
                     }
                 } else if (valueThis instanceof Number && valueOther instanceof Number) {
-                    if (!isNumberSimilar((Number)valueThis, (Number)valueOther)) {
-                    	return false;
+                    if (!isNumberSimilar((Number) valueThis, (Number) valueOther)) {
+                        return false;
                     }
                 } else if (valueThis instanceof JSONString && valueOther instanceof JSONString) {
                     if (!((JSONString) valueThis).toJSONString().equals(((JSONString) valueOther).toJSONString())) {
-                    	return false;
+                        return false;
                     }
                 } else if (!valueThis.equals(valueOther)) {
                     return false;
@@ -2390,14 +2156,13 @@ public class JSONObject {
 
     /**
      * Compares two numbers to see if they are similar.
-     *
-     * If either of the numbers are Double or Float instances, then they are checked to have
-     * a finite value. If either value is not finite (NaN or &#177;infinity), then this
-     * function will always return false. If both numbers are finite, they are first checked
-     * to be the same type and implement {@link Comparable}. If they do, then the actual
-     * {@link Comparable#compareTo(Object)} is called. If they are not the same type, or don't
-     * implement Comparable, then they are converted to {@link BigDecimal}s. Finally the
-     * BigDecimal values are compared using {@link BigDecimal#compareTo(BigDecimal)}.
+     * <p>
+     * If either of the numbers are Double or Float instances, then they are checked to have a finite value. If either
+     * value is not finite (NaN or &#177;infinity), then this function will always return false. If both numbers are
+     * finite, they are first checked to be the same type and implement {@link Comparable}. If they do, then the actual
+     * {@link Comparable#compareTo(Object)} is called. If they are not the same type, or don't implement Comparable,
+     * then they are converted to {@link BigDecimal}s. Finally the BigDecimal values are compared using
+     * {@link BigDecimal#compareTo(BigDecimal)}.
      *
      * @param l the Left value to compare. Can not be <code>null</code>.
      * @param r the right value to compare. Can not be <code>null</code>.
@@ -2411,10 +2176,10 @@ public class JSONObject {
 
         // if the classes are the same and implement Comparable
         // then use the built in compare first.
-        if(l.getClass().equals(r.getClass()) && l instanceof Comparable) {
-            @SuppressWarnings({ "rawtypes", "unchecked" })
-            int compareTo = ((Comparable)l).compareTo(r);
-            return compareTo==0;
+        if (l.getClass().equals(r.getClass()) && l instanceof Comparable) {
+            @SuppressWarnings({"rawtypes", "unchecked"})
+            int compareTo = ((Comparable) l).compareTo(r);
+            return compareTo == 0;
         }
 
         // BigDecimal should be able to handle all of our number types that we support through
@@ -2445,18 +2210,15 @@ public class JSONObject {
      */
     protected static boolean isDecimalNotation(final String val) {
         return val.indexOf('.') > -1 || val.indexOf('e') > -1
-                || val.indexOf('E') > -1 || "-0".equals(val);
+            || val.indexOf('E') > -1 || "-0".equals(val);
     }
 
     /**
-     * Try to convert a string into a number, boolean, or null. If the string
-     * can't be converted, return the string.
+     * Try to convert a string into a number, boolean, or null. If the string can't be converted, return the string.
      *
-     * @param string
-     *            A String. can not be null.
+     * @param string A String. can not be null.
      * @return A simple JSON value.
-     * @throws NullPointerException
-     *             Thrown if the string is null.
+     * @throws NullPointerException Thrown if the string is null.
      */
     // Changes to this method must be copied to the corresponding method in
     // the XML class to keep full support for Android
@@ -2492,14 +2254,14 @@ public class JSONObject {
     }
 
     /**
-     * Converts a string to a number using the narrowest possible type. Possible
-     * returns for this function are BigDecimal, Double, BigInteger, Long, and Integer.
-     * When a Double is returned, it should always be a valid Double and not NaN or +-infinity.
+     * Converts a string to a number using the narrowest possible type. Possible returns for this function are
+     * BigDecimal, Double, BigInteger, Long, and Integer. When a Double is returned, it should always be a valid Double
+     * and not NaN or +-infinity.
      *
      * @param val value to convert
      * @return Number representation of the value.
-     * @throws NumberFormatException thrown if the value is not a valid number. A public
-     *      caller should catch this and wrap it in a {@link JSONException} if applicable.
+     * @throws NumberFormatException thrown if the value is not a valid number. A public caller should catch this and
+     *                               wrap it in a {@link JSONException} if applicable.
      */
     protected static Number stringToNumber(final String val) throws NumberFormatException {
         char initial = val.charAt(0);
@@ -2511,7 +2273,7 @@ public class JSONObject {
                 // keep that by forcing a decimal.
                 try {
                     BigDecimal bd = new BigDecimal(val);
-                    if(initial == '-' && BigDecimal.ZERO.compareTo(bd)==0) {
+                    if (initial == '-' && BigDecimal.ZERO.compareTo(bd) == 0) {
                         return Double.valueOf(-0.0);
                     }
                     return bd;
@@ -2519,26 +2281,26 @@ public class JSONObject {
                     // this is to support "Hex Floats" like this: 0x1.0P-1074
                     try {
                         Double d = Double.valueOf(val);
-                        if(d.isNaN() || d.isInfinite()) {
-                            throw new NumberFormatException("val ["+val+"] is not a valid number.");
+                        if (d.isNaN() || d.isInfinite()) {
+                            throw new NumberFormatException("val [" + val + "] is not a valid number.");
                         }
                         return d;
                     } catch (NumberFormatException ignore) {
-                        throw new NumberFormatException("val ["+val+"] is not a valid number.");
+                        throw new NumberFormatException("val [" + val + "] is not a valid number.");
                     }
                 }
             }
             // block items like 00 01 etc. Java number parsers treat these as Octal.
-            if(initial == '0' && val.length() > 1) {
+            if (initial == '0' && val.length() > 1) {
                 char at1 = val.charAt(1);
-                if(at1 >= '0' && at1 <= '9') {
-                    throw new NumberFormatException("val ["+val+"] is not a valid number.");
+                if (at1 >= '0' && at1 <= '9') {
+                    throw new NumberFormatException("val [" + val + "] is not a valid number.");
                 }
             } else if (initial == '-' && val.length() > 2) {
                 char at1 = val.charAt(1);
                 char at2 = val.charAt(2);
-                if(at1 == '0' && at2 >= '0' && at2 <= '9') {
-                    throw new NumberFormatException("val ["+val+"] is not a valid number.");
+                if (at1 == '0' && at2 >= '0' && at2 <= '9') {
+                    throw new NumberFormatException("val [" + val + "] is not a valid number.");
                 }
             }
             // integer representation.
@@ -2550,24 +2312,22 @@ public class JSONObject {
             // only what they need. i.e. Less runtime overhead if the value is
             // long lived.
             BigInteger bi = new BigInteger(val);
-            if(bi.bitLength() <= 31){
+            if (bi.bitLength() <= 31) {
                 return Integer.valueOf(bi.intValue());
             }
-            if(bi.bitLength() <= 63){
+            if (bi.bitLength() <= 63) {
                 return Long.valueOf(bi.longValue());
             }
             return bi;
         }
-        throw new NumberFormatException("val ["+val+"] is not a valid number.");
+        throw new NumberFormatException("val [" + val + "] is not a valid number.");
     }
 
     /**
      * Throw an exception if the object is a NaN or infinite number.
      *
-     * @param o
-     *            The object to test.
-     * @throws JSONException
-     *             If o is a non-finite number.
+     * @param o The object to test.
+     * @throws JSONException If o is a non-finite number.
      */
     public static void testValidity(Object o) throws JSONException {
         if (o instanceof Number && !numberIsFinite((Number) o)) {
@@ -2576,15 +2336,12 @@ public class JSONObject {
     }
 
     /**
-     * Produce a JSONArray containing the values of the members of this
-     * JSONObject.
+     * Produce a JSONArray containing the values of the members of this JSONObject.
      *
-     * @param names
-     *            A JSONArray containing a list of key strings. This determines
-     *            the sequence of the values in the result.
+     * @param names A JSONArray containing a list of key strings. This determines the sequence of the values in the
+     *              result.
      * @return A JSONArray of values.
-     * @throws JSONException
-     *             If any of the values are non-finite numbers.
+     * @throws JSONException If any of the values are non-finite numbers.
      */
     public JSONArray toJSONArray(JSONArray names) throws JSONException {
         if (names == null || names.isEmpty()) {
@@ -2598,17 +2355,15 @@ public class JSONObject {
     }
 
     /**
-     * Make a JSON text of this JSONObject. For compactness, no whitespace is
-     * added. If this would not result in a syntactically correct JSON text,
-     * then null will be returned instead.
+     * Make a JSON text of this JSONObject. For compactness, no whitespace is added. If this would not result in a
+     * syntactically correct JSON text, then null will be returned instead.
      * <p><b>
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
      *
-     * @return a printable, displayable, portable, transmittable representation
-     *         of the object, beginning with <code>{</code>&nbsp;<small>(left
-     *         brace)</small> and ending with <code>}</code>&nbsp;<small>(right
-     *         brace)</small>.
+     * @return a printable, displayable, portable, transmittable representation of the object, beginning with
+     * <code>{</code>&nbsp;<small>(left brace)</small> and ending with <code>}</code>&nbsp;<small>(right
+     * brace)</small>.
      */
     @Override
     public String toString() {
@@ -2636,14 +2391,11 @@ public class JSONObject {
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
      *
-     * @param indentFactor
-     *            The number of spaces to add to each level of indentation.
-     * @return a printable, displayable, portable, transmittable representation
-     *         of the object, beginning with <code>{</code>&nbsp;<small>(left
-     *         brace)</small> and ending with <code>}</code>&nbsp;<small>(right
-     *         brace)</small>.
-     * @throws JSONException
-     *             If the object contains an invalid number.
+     * @param indentFactor The number of spaces to add to each level of indentation.
+     * @return a printable, displayable, portable, transmittable representation of the object, beginning with
+     * <code>{</code>&nbsp;<small>(left brace)</small> and ending with <code>}</code>&nbsp;<small>(right
+     * brace)</small>.
+     * @throws JSONException If the object contains an invalid number.
      */
     @SuppressWarnings("resource")
     public String toString(int indentFactor) throws JSONException {
@@ -2652,47 +2404,37 @@ public class JSONObject {
     }
 
     /**
-     * Make a JSON text of an Object value. If the object has an
-     * value.toJSONString() method, then that method will be used to produce the
-     * JSON text. The method is required to produce a strictly conforming text.
-     * If the object does not contain a toJSONString method (which is the most
-     * common case), then a text will be produced by other means. If the value
-     * is an array or Collection, then a JSONArray will be made from it and its
-     * toJSONString method will be called. If the value is a MAP, then a
-     * JSONObject will be made from it and its toJSONString method will be
-     * called. Otherwise, the value's toString method will be called, and the
-     * result will be quoted.
+     * Make a JSON text of an Object value. If the object has an value.toJSONString() method, then that method will be
+     * used to produce the JSON text. The method is required to produce a strictly conforming text. If the object does
+     * not contain a toJSONString method (which is the most common case), then a text will be produced by other means.
+     * If the value is an array or Collection, then a JSONArray will be made from it and its toJSONString method will be
+     * called. If the value is a MAP, then a JSONObject will be made from it and its toJSONString method will be called.
+     * Otherwise, the value's toString method will be called, and the result will be quoted.
      *
      * <p>
      * Warning: This method assumes that the data structure is acyclical.
      *
-     * @param value
-     *            The value to be serialized.
-     * @return a printable, displayable, transmittable representation of the
-     *         object, beginning with <code>{</code>&nbsp;<small>(left
-     *         brace)</small> and ending with <code>}</code>&nbsp;<small>(right
-     *         brace)</small>.
-     * @throws JSONException
-     *             If the value is or contains an invalid number.
+     * @param value The value to be serialized.
+     * @return a printable, displayable, transmittable representation of the object, beginning with
+     * <code>{</code>&nbsp;<small>(left brace)</small> and ending with <code>}</code>&nbsp;<small>(right
+     * brace)</small>.
+     * @throws JSONException If the value is or contains an invalid number.
      */
     public static String valueToString(Object value) throws JSONException {
-    	// moves the implementation to JSONWriter as:
-    	// 1. It makes more sense to be part of the writer class
-    	// 2. For Android support this method is not available. By implementing it in the Writer
-    	//    Android users can use the writer with the built in Android JSONObject implementation.
+        // moves the implementation to JSONWriter as:
+        // 1. It makes more sense to be part of the writer class
+        // 2. For Android support this method is not available. By implementing it in the Writer
+        //    Android users can use the writer with the built in Android JSONObject implementation.
         return JSONWriter.valueToString(value);
     }
 
     /**
-     * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL
-     * object. If it is an array or collection, wrap it in a JSONArray. If it is
-     * a map, wrap it in a JSONObject. If it is a standard property (Double,
-     * String, et al) then it is already wrapped. Otherwise, if it comes from
-     * one of the java packages, turn it into a string. And if it doesn't, try
-     * to wrap it in a JSONObject. If the wrapping fails, then null is returned.
+     * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL object. If it is an array or
+     * collection, wrap it in a JSONArray. If it is a map, wrap it in a JSONObject. If it is a standard property
+     * (Double, String, et al) then it is already wrapped. Otherwise, if it comes from one of the java packages, turn it
+     * into a string. And if it doesn't, try to wrap it in a JSONObject. If the wrapping fails, then null is returned.
      *
-     * @param object
-     *            The object to wrap
+     * @param object The object to wrap
      * @return The wrapped value
      */
     public static Object wrap(Object object) {
@@ -2700,42 +2442,38 @@ public class JSONObject {
     }
 
     /**
-     * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL
-     * object. If it is an array or collection, wrap it in a JSONArray. If it is
-     * a map, wrap it in a JSONObject. If it is a standard property (Double,
-     * String, et al) then it is already wrapped. Otherwise, if it comes from
-     * one of the java packages, turn it into a string. And if it doesn't, try
-     * to wrap it in a JSONObject. If the wrapping fails, then null is returned.
+     * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL object. If it is an array or
+     * collection, wrap it in a JSONArray. If it is a map, wrap it in a JSONObject. If it is a standard property
+     * (Double, String, et al) then it is already wrapped. Otherwise, if it comes from one of the java packages, turn it
+     * into a string. And if it doesn't, try to wrap it in a JSONObject. If the wrapping fails, then null is returned.
      *
-     * @param object
-     *            The object to wrap
-     * @param recursionDepth
-     *            Variable for tracking the count of nested object creations.
-     * @param jsonParserConfiguration
-     *            Variable to pass parser custom configuration for json parsing.
+     * @param object                  The object to wrap
+     * @param recursionDepth          Variable for tracking the count of nested object creations.
+     * @param jsonParserConfiguration Variable to pass parser custom configuration for json parsing.
      * @return The wrapped value
      */
     static Object wrap(Object object, int recursionDepth, JSONParserConfiguration jsonParserConfiguration) {
-      return wrap(object, null, recursionDepth, jsonParserConfiguration);
+        return wrap(object, null, recursionDepth, jsonParserConfiguration);
     }
 
     private static Object wrap(Object object, Set<Object> objectsRecord) {
-      return wrap(object, objectsRecord, 0, new JSONParserConfiguration());
+        return wrap(object, objectsRecord, 0, new JSONParserConfiguration());
     }
 
-    private static Object wrap(Object object, Set<Object> objectsRecord, int recursionDepth, JSONParserConfiguration jsonParserConfiguration) {
+    private static Object wrap(Object object, Set<Object> objectsRecord, int recursionDepth,
+        JSONParserConfiguration jsonParserConfiguration) {
         try {
             if (NULL.equals(object)) {
                 return NULL;
             }
             if (object instanceof JSONObject || object instanceof JSONArray
-                    || NULL.equals(object) || object instanceof JSONString
-                    || object instanceof Byte || object instanceof Character
-                    || object instanceof Short || object instanceof Integer
-                    || object instanceof Long || object instanceof Boolean
-                    || object instanceof Float || object instanceof Double
-                    || object instanceof String || object instanceof BigInteger
-                    || object instanceof BigDecimal || object instanceof Enum) {
+                || NULL.equals(object) || object instanceof JSONString
+                || object instanceof Byte || object instanceof Character
+                || object instanceof Short || object instanceof Integer
+                || object instanceof Long || object instanceof Boolean
+                || object instanceof Float || object instanceof Double
+                || object instanceof String || object instanceof BigInteger
+                || object instanceof BigDecimal || object instanceof Enum) {
                 return object;
             }
 
@@ -2752,18 +2490,17 @@ public class JSONObject {
             }
             Package objectPackage = object.getClass().getPackage();
             String objectPackageName = objectPackage != null ? objectPackage
-                    .getName() : "";
+                .getName() : "";
             if (objectPackageName.startsWith("java.")
-                    || objectPackageName.startsWith("javax.")
-                    || object.getClass().getClassLoader() == null) {
+                || objectPackageName.startsWith("javax.")
+                || object.getClass().getClassLoader() == null) {
                 return object.toString();
             }
             if (objectsRecord != null) {
                 return new JSONObject(object, objectsRecord);
             }
             return new JSONObject(object);
-        }
-        catch (JSONException exception) {
+        } catch (JSONException exception) {
             throw exception;
         } catch (Exception exception) {
             return null;
@@ -2771,11 +2508,11 @@ public class JSONObject {
     }
 
     /**
-     * Write the contents of the JSONObject as JSON text to a writer. For
-     * compactness, no whitespace is added.
+     * Write the contents of the JSONObject as JSON text to a writer. For compactness, no whitespace is added.
      * <p><b>
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
+     *
      * @param writer the writer object
      * @return The writer.
      * @throws JSONException if a called function has an error
@@ -2786,7 +2523,7 @@ public class JSONObject {
 
     @SuppressWarnings("resource")
     static final Writer writeValue(Writer writer, Object value,
-            int indentFactor, int indent) throws JSONException, IOException {
+        int indentFactor, int indent) throws JSONException, IOException {
         if (value == null || value.equals(null)) {
             writer.write("null");
         } else if (value instanceof JSONString) {
@@ -2800,7 +2537,7 @@ public class JSONObject {
         } else if (value instanceof Number) {
             // not all Numbers may match actual JSON Numbers. i.e. fractions or Imaginary
             final String numberAsString = numberToString((Number) value);
-            if(NUMBER_PATTERN.matcher(numberAsString).matches()) {
+            if (NUMBER_PATTERN.matcher(numberAsString).matches()) {
                 writer.write(numberAsString);
             } else {
                 // The Number value is not a valid JSON number.
@@ -2810,7 +2547,7 @@ public class JSONObject {
         } else if (value instanceof Boolean) {
             writer.write(value.toString());
         } else if (value instanceof Enum<?>) {
-            writer.write(quote(((Enum<?>)value).name()));
+            writer.write(quote(((Enum<?>) value).name()));
         } else if (value instanceof JSONObject) {
             ((JSONObject) value).write(writer, indentFactor, indent);
         } else if (value instanceof JSONArray) {
@@ -2852,40 +2589,36 @@ public class JSONObject {
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
      *
-     * @param writer
-     *            Writes the serialized JSON
-     * @param indentFactor
-     *            The number of spaces to add to each level of indentation.
-     * @param indent
-     *            The indentation of the top level.
+     * @param writer       Writes the serialized JSON
+     * @param indentFactor The number of spaces to add to each level of indentation.
+     * @param indent       The indentation of the top level.
      * @return The writer.
-     * @throws JSONException if a called function has an error or a write error
-     * occurs
+     * @throws JSONException if a called function has an error or a write error occurs
      */
     @SuppressWarnings("resource")
     public Writer write(Writer writer, int indentFactor, int indent)
-            throws JSONException {
+        throws JSONException {
         try {
             boolean needsComma = false;
             final int length = this.length();
             writer.write('{');
 
             if (length == 1) {
-            	final Entry<String,?> entry = this.entrySet().iterator().next();
+                final Entry<String, ?> entry = this.entrySet().iterator().next();
                 final String key = entry.getKey();
                 writer.write(quote(key));
                 writer.write(':');
                 if (indentFactor > 0) {
                     writer.write(' ');
                 }
-                try{
+                try {
                     writeValue(writer, entry.getValue(), indentFactor, indent);
                 } catch (Exception e) {
                     throw new JSONException("Unable to write JSONObject value for key: " + key, e);
                 }
             } else if (length != 0) {
                 final int newIndent = indent + indentFactor;
-                for (final Entry<String,?> entry : this.entrySet()) {
+                for (final Entry<String, ?> entry : this.entrySet()) {
                     if (needsComma) {
                         writer.write(',');
                     }
@@ -2919,9 +2652,8 @@ public class JSONObject {
     }
 
     /**
-     * Returns a java.util.Map containing all of the entries in this object.
-     * If an entry in the object is a JSONArray or JSONObject it will also
-     * be converted.
+     * Returns a java.util.Map containing all of the entries in this object. If an entry in the object is a JSONArray or
+     * JSONObject it will also be converted.
      * <p>
      * Warning: This method assumes that the data structure is acyclical.
      *
@@ -2947,35 +2679,37 @@ public class JSONObject {
 
     /**
      * Create a new JSONException in a common format for incorrect conversions.
-     * @param key name of the key
+     *
+     * @param key       name of the key
      * @param valueType the type of value being coerced to
-     * @param cause optional cause of the coercion failure
+     * @param cause     optional cause of the coercion failure
      * @return JSONException that can be thrown.
      */
     private static JSONException wrongValueFormatException(
-            String key,
-            String valueType,
-            Object value,
-            Throwable cause) {
-        if(value == null) {
+        String key,
+        String valueType,
+        Object value,
+        Throwable cause) {
+        if (value == null) {
 
             return new JSONException(
-                    "JSONObject[" + quote(key) + "] is not a " + valueType + " (null)."
-                    , cause);
+                "JSONObject[" + quote(key) + "] is not a " + valueType + " (null)."
+                , cause);
         }
         // don't try to toString collections or known object types that could be large.
-        if(value instanceof Map || value instanceof Iterable || value instanceof JSONObject) {
+        if (value instanceof Map || value instanceof Iterable || value instanceof JSONObject) {
             return new JSONException(
-                    "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + ")."
-                    , cause);
+                "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + ")."
+                , cause);
         }
         return new JSONException(
-                "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + " : " + value + ")."
-                , cause);
+            "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + " : " + value + ")."
+            , cause);
     }
 
     /**
      * Create a new JSONException in a common format for recursive object definition.
+     *
      * @param key name of the key
      * @return JSONException that can be thrown.
      */
@@ -2987,21 +2721,28 @@ public class JSONObject {
 
     /**
      * For a prospective number, remove the leading zeros
+     *
      * @param value prospective number
      * @return number without leading zeros
      */
-    private static String removeLeadingZerosOfNumber(String value){
-        if (value.equals("-")){return value;}
+    private static String removeLeadingZerosOfNumber(String value) {
+        if (value.equals("-")) {
+            return value;
+        }
         boolean negativeFirstChar = (value.charAt(0) == '-');
-        int counter = negativeFirstChar ? 1:0;
-        while (counter < value.length()){
-            if (value.charAt(counter) != '0'){
-                if (negativeFirstChar) {return "-".concat(value.substring(counter));}
+        int counter = negativeFirstChar ? 1 : 0;
+        while (counter < value.length()) {
+            if (value.charAt(counter) != '0') {
+                if (negativeFirstChar) {
+                    return "-".concat(value.substring(counter));
+                }
                 return value.substring(counter);
             }
             ++counter;
         }
-        if (negativeFirstChar) {return "-0";}
+        if (negativeFirstChar) {
+            return "-0";
+        }
         return "0";
     }
 }

--- a/src/main/java/org/json/JSONParserConfiguration.java
+++ b/src/main/java/org/json/JSONParserConfiguration.java
@@ -4,10 +4,18 @@ package org.json;
  * Configuration object for the JSON parser. The configuration is immutable.
  */
 public class JSONParserConfiguration extends ParserConfiguration {
+
     /**
      * Used to indicate whether to overwrite duplicate key or not.
      */
     private boolean overwriteDuplicateKey;
+
+    /**
+     * This flag, when set to true, instructs the parser to throw a JSONException if it encounters an invalid character
+     * immediately following the final ']' character in the input. This is useful for ensuring strict adherence to the
+     * JSON syntax, as any characters after the final closing bracket of a JSON array are considered invalid.
+     */
+    private boolean strictMode;
 
     /**
      * Configuration with the default values.
@@ -26,10 +34,9 @@ public class JSONParserConfiguration extends ParserConfiguration {
     }
 
     /**
-     * Defines the maximum nesting depth that the parser will descend before throwing an exception
-     * when parsing a map into JSONObject or parsing a {@link java.util.Collection} instance into
-     * JSONArray. The default max nesting depth is 512, which means the parser will throw a JsonException
-     * if the maximum depth is reached.
+     * Defines the maximum nesting depth that the parser will descend before throwing an exception when parsing a map
+     * into JSONObject or parsing a {@link java.util.Collection} instance into JSONArray. The default max nesting depth
+     * is 512, which means the parser will throw a JsonException if the maximum depth is reached.
      *
      * @param maxNestingDepth the maximum nesting depth allowed to the JSON parser
      * @return The existing configuration will not be modified. A new configuration is returned.
@@ -44,9 +51,8 @@ public class JSONParserConfiguration extends ParserConfiguration {
     }
 
     /**
-     * Controls the parser's behavior when meeting duplicate keys.
-     * If set to false, the parser will throw a JSONException when meeting a duplicate key.
-     * Or the duplicate key's value will be overwritten.
+     * Controls the parser's behavior when meeting duplicate keys. If set to false, the parser will throw a
+     * JSONException when meeting a duplicate key. Or the duplicate key's value will be overwritten.
      *
      * @param overwriteDuplicateKey defines should the parser overwrite duplicate keys.
      * @return The existing configuration will not be modified. A new configuration is returned.
@@ -58,13 +64,45 @@ public class JSONParserConfiguration extends ParserConfiguration {
         return clone;
     }
 
+
     /**
-     * The parser's behavior when meeting duplicate keys, controls whether the parser should
-     * overwrite duplicate keys or not.
+     * Sets the strict mode configuration for the JSON parser.
+     * <p>
+     * When strict mode is enabled, the parser will throw a JSONException if it encounters an invalid character
+     * immediately following the final ']' character in the input. This is useful for ensuring strict adherence to the
+     * JSON syntax, as any characters after the final closing bracket of a JSON array are considered invalid.
+     *
+     * @param mode a boolean value indicating whether strict mode should be enabled or not
+     * @return a new JSONParserConfiguration instance with the updated strict mode setting
+     */
+    public JSONParserConfiguration withStrictMode(final boolean mode) {
+        JSONParserConfiguration clone = this.clone();
+        clone.strictMode = mode;
+
+        return clone;
+    }
+
+    /**
+     * The parser's behavior when meeting duplicate keys, controls whether the parser should overwrite duplicate keys or
+     * not.
      *
      * @return The <code>overwriteDuplicateKey</code> configuration value.
      */
     public boolean isOverwriteDuplicateKey() {
         return this.overwriteDuplicateKey;
+    }
+
+
+    /**
+     * Retrieves the current strict mode setting of the JSON parser.
+     * <p>
+     * Strict mode, when enabled, instructs the parser to throw a JSONException if it encounters an invalid character
+     * immediately following the final ']' character in the input. This ensures strict adherence to the JSON syntax, as
+     * any characters after the final closing bracket of a JSON array are considered invalid.
+     *
+     * @return the current strict mode setting. True if strict mode is enabled, false otherwise.
+     */
+    public boolean isStrictMode() {
+        return this.strictMode;
     }
 }

--- a/src/main/java/org/json/JSONParserConfiguration.java
+++ b/src/main/java/org/json/JSONParserConfiguration.java
@@ -6,12 +6,10 @@ package org.json;
 public class JSONParserConfiguration extends ParserConfiguration {
 
     /** Original Configuration of the JSON Parser. */
-    public static final JSONParserConfiguration ORIGINAL
-        = new JSONParserConfiguration();
+    public static final JSONParserConfiguration ORIGINAL = new JSONParserConfiguration();
 
     /** Original configuration of the JSON Parser except that values are kept as strings. */
-    public static final JSONParserConfiguration KEEP_STRINGS
-        = new JSONParserConfiguration().withKeepStrings(true);
+    public static final JSONParserConfiguration KEEP_STRINGS = new JSONParserConfiguration().withKeepStrings(true);
 
     /**
      * Used to indicate whether to overwrite duplicate key or not.
@@ -98,24 +96,6 @@ public class JSONParserConfiguration extends ParserConfiguration {
     }
 
     /**
-     * Allows single quotes mode configuration for JSON parser when strictMode is on.
-     * <p>
-     * If this option is set to true when strict Mode is enabled, the parser will allow single quoted fields.
-     * <p>
-     * This option is false by default.
-     *
-     * @param mode a boolean value indicating whether single quotes should be allowed or not
-     * @return a new JSONParserConfiguration instance with the updated strict mode setting
-     */
-    public JSONParserConfiguration allowSingleQuotes(final boolean mode) {
-        JSONParserConfiguration clone = this.clone();
-        clone.strictMode = this.strictMode;
-        clone.allowSingleQuotes = mode;
-
-        return clone;
-    }
-
-    /**
      * The parser's behavior when meeting duplicate keys, controls whether the parser should
      * overwrite duplicate keys or not.
      *
@@ -138,14 +118,4 @@ public class JSONParserConfiguration extends ParserConfiguration {
     public boolean isStrictMode() {
         return this.strictMode;
     }
-
-    /**
-     * Retrieves the allow single quotes option.
-     * <p>
-     * Allow Single Quotes, when enabled during strict mode, instructs the parser to allow single quoted JSON fields.
-     * The parser will not throw a JSONException if compliant single quoted fields are found in the JSON structure.
-     *
-     * @return the current allow single quotes setting.
-     */
-    public boolean isAllowSingleQuotes() {return this.allowSingleQuotes;}
 }

--- a/src/main/java/org/json/JSONParserConfiguration.java
+++ b/src/main/java/org/json/JSONParserConfiguration.java
@@ -24,11 +24,6 @@ public class JSONParserConfiguration extends ParserConfiguration {
     private boolean strictMode;
 
     /**
-     * Allows Single Quotes when strictMode is true. Has no effect if strictMode is false.
-     */
-    private boolean allowSingleQuotes;
-
-    /**
      * Configuration with the default values.
      */
     public JSONParserConfiguration() {

--- a/src/main/java/org/json/JSONParserConfiguration.java
+++ b/src/main/java/org/json/JSONParserConfiguration.java
@@ -4,6 +4,15 @@ package org.json;
  * Configuration object for the JSON parser. The configuration is immutable.
  */
 public class JSONParserConfiguration extends ParserConfiguration {
+
+    /** Original Configuration of the JSON Parser. */
+    public static final JSONParserConfiguration ORIGINAL
+        = new JSONParserConfiguration();
+
+    /** Original configuration of the JSON Parser except that values are kept as strings. */
+    public static final JSONParserConfiguration KEEP_STRINGS
+        = new JSONParserConfiguration().withKeepStrings(true);
+
     /**
      * Used to indicate whether to overwrite duplicate key or not.
      */

--- a/src/main/java/org/json/JSONParserConfiguration.java
+++ b/src/main/java/org/json/JSONParserConfiguration.java
@@ -26,6 +26,11 @@ public class JSONParserConfiguration extends ParserConfiguration {
     private boolean strictMode;
 
     /**
+     * Allows Single Quotes when strictMode is true. Has no effect if strictMode is false.
+     */
+    private boolean allowSingleQuotes;
+
+    /**
      * Configuration with the default values.
      */
     public JSONParserConfiguration() {
@@ -93,6 +98,24 @@ public class JSONParserConfiguration extends ParserConfiguration {
     }
 
     /**
+     * Allows single quotes mode configuration for JSON parser when strictMode is on.
+     * <p>
+     * If this option is set to true when strict Mode is enabled, the parser will allow single quoted fields.
+     * <p>
+     * This option is false by default.
+     *
+     * @param mode a boolean value indicating whether single quotes should be allowed or not
+     * @return a new JSONParserConfiguration instance with the updated strict mode setting
+     */
+    public JSONParserConfiguration allowSingleQuotes(final boolean mode) {
+        JSONParserConfiguration clone = this.clone();
+        clone.strictMode = this.strictMode;
+        clone.allowSingleQuotes = mode;
+
+        return clone;
+    }
+
+    /**
      * The parser's behavior when meeting duplicate keys, controls whether the parser should
      * overwrite duplicate keys or not.
      *
@@ -115,4 +138,14 @@ public class JSONParserConfiguration extends ParserConfiguration {
     public boolean isStrictMode() {
         return this.strictMode;
     }
+
+    /**
+     * Retrieves the allow single quotes option.
+     * <p>
+     * Allow Single Quotes, when enabled during strict mode, instructs the parser to allow single quoted JSON fields.
+     * The parser will not throw a JSONException if compliant single quoted fields are found in the JSON structure.
+     *
+     * @return the current allow single quotes setting.
+     */
+    public boolean isAllowSingleQuotes() {return this.allowSingleQuotes;}
 }

--- a/src/main/java/org/json/JSONParserConfiguration.java
+++ b/src/main/java/org/json/JSONParserConfiguration.java
@@ -4,7 +4,6 @@ package org.json;
  * Configuration object for the JSON parser. The configuration is immutable.
  */
 public class JSONParserConfiguration extends ParserConfiguration {
-
     /**
      * Used to indicate whether to overwrite duplicate key or not.
      */
@@ -34,9 +33,10 @@ public class JSONParserConfiguration extends ParserConfiguration {
     }
 
     /**
-     * Defines the maximum nesting depth that the parser will descend before throwing an exception when parsing a map
-     * into JSONObject or parsing a {@link java.util.Collection} instance into JSONArray. The default max nesting depth
-     * is 512, which means the parser will throw a JsonException if the maximum depth is reached.
+     * Defines the maximum nesting depth that the parser will descend before throwing an exception
+     * when parsing a map into JSONObject or parsing a {@link java.util.Collection} instance into
+     * JSONArray. The default max nesting depth is 512, which means the parser will throw a JsonException
+     * if the maximum depth is reached.
      *
      * @param maxNestingDepth the maximum nesting depth allowed to the JSON parser
      * @return The existing configuration will not be modified. A new configuration is returned.
@@ -51,8 +51,9 @@ public class JSONParserConfiguration extends ParserConfiguration {
     }
 
     /**
-     * Controls the parser's behavior when meeting duplicate keys. If set to false, the parser will throw a
-     * JSONException when meeting a duplicate key. Or the duplicate key's value will be overwritten.
+     * Controls the parser's behavior when meeting duplicate keys.
+     * If set to false, the parser will throw a JSONException when meeting a duplicate key.
+     * Or the duplicate key's value will be overwritten.
      *
      * @param overwriteDuplicateKey defines should the parser overwrite duplicate keys.
      * @return The existing configuration will not be modified. A new configuration is returned.
@@ -83,8 +84,8 @@ public class JSONParserConfiguration extends ParserConfiguration {
     }
 
     /**
-     * The parser's behavior when meeting duplicate keys, controls whether the parser should overwrite duplicate keys or
-     * not.
+     * The parser's behavior when meeting duplicate keys, controls whether the parser should
+     * overwrite duplicate keys or not.
      *
      * @return The <code>overwriteDuplicateKey</code> configuration value.
      */

--- a/src/main/java/org/json/JSONTokener.java
+++ b/src/main/java/org/json/JSONTokener.java
@@ -311,7 +311,7 @@ public class JSONTokener {
     public String nextString(char quote) throws JSONException {
         char c;
         StringBuilder sb = new StringBuilder();
-        for (; ; ) {
+        for (;;) {
             c = this.next();
             switch (c) {
                 case 0:
@@ -542,6 +542,8 @@ public class JSONTokener {
     }
 
     Object nextSimpleValue(char c, boolean strictMode) {
+        String string;
+
         if (c == '"' || c == '\'') {
             String str = this.nextString(c);
             if (strictMode) {
@@ -550,19 +552,6 @@ public class JSONTokener {
             return str;
         }
 
-        return parsedUnquotedText(c);
-    }
-
-    /**
-     * Parses unquoted text from the JSON input. This could be the values true, false, or null, or it can be a number.
-     * Non-standard forms are also accepted. Characters are accumulated until the end of the text or a formatting
-     * character is reached.
-     *
-     * @param c The starting character.
-     * @return The parsed object.
-     * @throws JSONException If the parsed string is empty.
-     */
-    private Object parsedUnquotedText(char c) {
         StringBuilder sb = new StringBuilder();
         while (c >= ' ' && ",:]}/\\\"[{;=#".indexOf(c) < 0) {
             sb.append(c);
@@ -572,8 +561,8 @@ public class JSONTokener {
             this.back();
         }
 
-        String string = sb.toString().trim();
-        if (string.isEmpty()) {
+        string = sb.toString().trim();
+        if ("".equals(string)) {
             throw this.syntaxError("Missing value");
         }
         return JSONObject.stringToValue(string);

--- a/src/main/java/org/json/JSONTokener.java
+++ b/src/main/java/org/json/JSONTokener.java
@@ -472,9 +472,8 @@ public class JSONTokener {
 
     Object nextSimpleValue(char c, JSONParserConfiguration jsonParserConfiguration) {
         boolean strictMode = jsonParserConfiguration.isStrictMode();
-        boolean allowSingleQuotes = jsonParserConfiguration.isAllowSingleQuotes();
 
-        if(strictMode && !allowSingleQuotes && c == '\''){
+        if(strictMode && c == '\''){
             throw this.syntaxError("Single quote wrap not allowed in strict mode");
         }
 

--- a/src/main/java/org/json/JSONTokener.java
+++ b/src/main/java/org/json/JSONTokener.java
@@ -396,7 +396,7 @@ public class JSONTokener {
     public String nextTo(String delimiters) throws JSONException {
         char c;
         StringBuilder sb = new StringBuilder();
-        for (;;) {
+        for (; ; ) {
             c = this.next();
             if (delimiters.indexOf(c) >= 0 || c == 0 ||
                 c == '\n' || c == '\r') {
@@ -457,9 +457,9 @@ public class JSONTokener {
         if (strictMode) {
             Object valueToValidate = nextSimpleValue(c, true);
 
-            boolean isNumeric = valueToValidate.toString().chars().allMatch( Character::isDigit );
+            boolean isNumeric = checkIfValueIsNumeric(valueToValidate);
 
-            if(isNumeric){
+            if (isNumeric) {
                 return valueToValidate;
             }
 
@@ -473,6 +473,15 @@ public class JSONTokener {
         }
 
         return nextSimpleValue(c);
+    }
+
+    private boolean checkIfValueIsNumeric(Object valueToValidate) {
+        for (char c : valueToValidate.toString().toCharArray()) {
+            if (!Character.isDigit(c)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/src/main/java/org/json/JSONTokener.java
+++ b/src/main/java/org/json/JSONTokener.java
@@ -422,7 +422,7 @@ public class JSONTokener {
      * Get the next value. The value can be a Boolean, Double, Integer, JSONArray, JSONObject, Long, or String, or the
      * JSONObject.NULL object. The strictMode parameter controls the behavior of the method when parsing the value.
      *
-     * @param jsonParserConfiguration which carries options such as strictMode and allowSingleQuotes, these methods will
+     * @param jsonParserConfiguration which carries options such as strictMode, these methods will
      *                                strictly adhere to the JSON syntax, throwing a JSONException for any deviations.
      * @return An object.
      * @throws JSONException If syntax error.
@@ -432,10 +432,18 @@ public class JSONTokener {
         switch (c) {
             case '{':
                 this.back();
-                return getJsonObject(jsonParserConfiguration);
+                try {
+                    return new JSONObject(this, jsonParserConfiguration);
+                } catch (StackOverflowError e) {
+                    throw new JSONException("JSON Array or Object depth too large to process.", e);
+                }
             case '[':
                 this.back();
-                return getJsonArray();
+                try {
+                    return new JSONArray(this);
+                } catch (StackOverflowError e) {
+                    throw new JSONException("JSON Array or Object depth too large to process.", e);
+                }
             default:
                 return nextSimpleValue(c, jsonParserConfiguration);
         }
@@ -445,7 +453,7 @@ public class JSONTokener {
      * This method is used to get a JSONObject from the JSONTokener. The strictMode parameter controls the behavior of
      * the method when parsing the JSONObject.
      *
-     * @param jsonParserConfiguration which carries options such as strictMode and allowSingleQuotes, these methods will
+     * @param jsonParserConfiguration which carries options such as strictMode, these methods will
      *                                strictly adhere to the JSON syntax, throwing a JSONException for any deviations.
      *                                deviations.
      * @return A JSONObject which is the next value in the JSONTokener.

--- a/src/main/java/org/json/JSONTokener.java
+++ b/src/main/java/org/json/JSONTokener.java
@@ -8,57 +8,40 @@ Public Domain.
  */
 
 /**
- * A JSONTokener takes a source string and extracts characters and tokens from it. It is used by the JSONObject and
- * JSONArray constructors to parse JSON source strings.
- *
+ * A JSONTokener takes a source string and extracts characters and tokens from
+ * it. It is used by the JSONObject and JSONArray constructors to parse
+ * JSON source strings.
  * @author JSON.org
  * @version 2014-05-03
  */
 public class JSONTokener {
-
-    /**
-     * current read character position on the current line.
-     */
+    /** current read character position on the current line. */
     private long character;
-    /**
-     * flag to indicate if the end of the input has been found.
-     */
+    /** flag to indicate if the end of the input has been found. */
     private boolean eof;
-    /**
-     * current read index of the input.
-     */
+    /** current read index of the input. */
     private long index;
-    /**
-     * current line of the input.
-     */
+    /** current line of the input. */
     private long line;
-    /**
-     * previous character read from the input.
-     */
+    /** previous character read from the input. */
     private char previous;
-    /**
-     * Reader for the input.
-     */
+    /** Reader for the input. */
     private final Reader reader;
-    /**
-     * flag to indicate that a previous character was requested.
-     */
+    /** flag to indicate that a previous character was requested. */
     private boolean usePrevious;
-    /**
-     * the number of characters read in the previous line.
-     */
+    /** the number of characters read in the previous line. */
     private long characterPreviousLine;
 
 
     /**
      * Construct a JSONTokener from a Reader. The caller must close the Reader.
      *
-     * @param reader A reader.
+     * @param reader     A reader.
      */
     public JSONTokener(Reader reader) {
         this.reader = reader.markSupported()
-            ? reader
-            : new BufferedReader(reader);
+                ? reader
+                        : new BufferedReader(reader);
         this.eof = false;
         this.usePrevious = false;
         this.previous = 0;
@@ -71,7 +54,6 @@ public class JSONTokener {
 
     /**
      * Construct a JSONTokener from an InputStream. The caller must close the input stream.
-     *
      * @param inputStream The source.
      */
     public JSONTokener(InputStream inputStream) {
@@ -82,7 +64,7 @@ public class JSONTokener {
     /**
      * Construct a JSONTokener from a string.
      *
-     * @param s A source string.
+     * @param s     A source string.
      */
     public JSONTokener(String s) {
         this(new StringReader(s));
@@ -90,10 +72,11 @@ public class JSONTokener {
 
 
     /**
-     * Back up one character. This provides a sort of lookahead capability, so that you can test for a digit or letter
-     * before attempting to parse the next number or identifier.
-     *
-     * @throws JSONException Thrown if trying to step back more than 1 step or if already at the start of the string
+     * Back up one character. This provides a sort of lookahead capability,
+     * so that you can test for a digit or letter before attempting to parse
+     * the next number or identifier.
+     * @throws JSONException Thrown if trying to step back more than 1 step
+     *  or if already at the start of the string
      */
     public void back() throws JSONException {
         if (this.usePrevious || this.index <= 0) {
@@ -109,19 +92,19 @@ public class JSONTokener {
      */
     private void decrementIndexes() {
         this.index--;
-        if (this.previous == '\r' || this.previous == '\n') {
+        if(this.previous=='\r' || this.previous == '\n') {
             this.line--;
-            this.character = this.characterPreviousLine;
-        } else if (this.character > 0) {
+            this.character=this.characterPreviousLine ;
+        } else if(this.character > 0){
             this.character--;
         }
     }
 
     /**
      * Get the hex value of a character (base16).
-     *
-     * @param c A character between '0' and '9' or between 'A' and 'F' or between 'a' and 'f'.
-     * @return An int between 0 and 15, or -1 if c was not a hex digit.
+     * @param c A character between '0' and '9' or between 'A' and 'F' or
+     * between 'a' and 'f'.
+     * @return  An int between 0 and 15, or -1 if c was not a hex digit.
      */
     public static int dehexchar(char c) {
         if (c >= '0' && c <= '9') {
@@ -147,13 +130,14 @@ public class JSONTokener {
 
 
     /**
-     * Determine if the source string still contains characters that next() can consume.
-     *
+     * Determine if the source string still contains characters that next()
+     * can consume.
      * @return true if not yet at the end of the source.
-     * @throws JSONException thrown if there is an error stepping forward or backward while checking for more data.
+     * @throws JSONException thrown if there is an error stepping forward
+     *  or backward while checking for more data.
      */
     public boolean more() throws JSONException {
-        if (this.usePrevious) {
+        if(this.usePrevious) {
             return true;
         }
         try {
@@ -163,7 +147,7 @@ public class JSONTokener {
         }
         try {
             // -1 is EOF, but next() can not consume the null character '\0'
-            if (this.reader.read() <= 0) {
+            if(this.reader.read() <= 0) {
                 this.eof = true;
                 return false;
             }
@@ -204,32 +188,28 @@ public class JSONTokener {
 
     /**
      * Get the last character read from the input or '\0' if nothing has been read yet.
-     *
      * @return the last character read from the input.
      */
-    protected char getPrevious() {
-        return this.previous;
-    }
+    protected char getPrevious() { return this.previous;}
 
     /**
-     * Increments the internal indexes according to the previous character read and the character passed as the current
-     * character.
-     *
+     * Increments the internal indexes according to the previous character
+     * read and the character passed as the current character.
      * @param c the current character read.
      */
     private void incrementIndexes(int c) {
-        if (c > 0) {
+        if(c > 0) {
             this.index++;
-            if (c == '\r') {
+            if(c=='\r') {
                 this.line++;
                 this.characterPreviousLine = this.character;
-                this.character = 0;
-            } else if (c == '\n') {
-                if (this.previous != '\r') {
+                this.character=0;
+            }else if (c=='\n') {
+                if(this.previous != '\r') {
                     this.line++;
                     this.characterPreviousLine = this.character;
                 }
-                this.character = 0;
+                this.character=0;
             } else {
                 this.character++;
             }
@@ -237,8 +217,8 @@ public class JSONTokener {
     }
 
     /**
-     * Consume the next character, and check that it matches a specified character.
-     *
+     * Consume the next character, and check that it matches a specified
+     * character.
      * @param c The character to match.
      * @return The character.
      * @throws JSONException if the character does not match.
@@ -246,9 +226,9 @@ public class JSONTokener {
     public char next(char c) throws JSONException {
         char n = this.next();
         if (n != c) {
-            if (n > 0) {
+            if(n > 0) {
                 throw this.syntaxError("Expected '" + c + "' and instead saw '" +
-                    n + "'");
+                        n + "'");
             }
             throw this.syntaxError("Expected '" + c + "' and instead saw ''");
         }
@@ -259,9 +239,11 @@ public class JSONTokener {
     /**
      * Get the next n characters.
      *
-     * @param n The number of characters to take.
-     * @return A string of n characters.
-     * @throws JSONException Substring bounds error if there are not n characters remaining in the source string.
+     * @param n     The number of characters to take.
+     * @return      A string of n characters.
+     * @throws JSONException
+     *   Substring bounds error if there are not
+     *   n characters remaining in the source string.
      */
     public String next(int n) throws JSONException {
         if (n == 0) {
@@ -284,12 +266,11 @@ public class JSONTokener {
 
     /**
      * Get the next char in the string, skipping whitespace.
-     *
-     * @return A character, or 0 if there are no more characters.
      * @throws JSONException Thrown if there is an error reading the source string.
+     * @return  A character, or 0 if there are no more characters.
      */
     public char nextClean() throws JSONException {
-        for (; ; ) {
+        for (;;) {
             char c = this.next();
             if (c == 0 || c > ' ') {
                 return c;
@@ -299,13 +280,14 @@ public class JSONTokener {
 
 
     /**
-     * Return the characters up to the next close quote character. Backslash processing is done. The formal JSON format
-     * does not allow strings in single quotes, but an implementation is allowed to accept them.
-     *
+     * Return the characters up to the next close quote character.
+     * Backslash processing is done. The formal JSON format does not
+     * allow strings in single quotes, but an implementation is allowed to
+     * accept them.
      * @param quote The quoting character, either
-     *              <code>"</code>&nbsp;<small>(double quote)</small> or
-     *              <code>'</code>&nbsp;<small>(single quote)</small>.
-     * @return A String.
+     *      <code>"</code>&nbsp;<small>(double quote)</small> or
+     *      <code>'</code>&nbsp;<small>(single quote)</small>.
+     * @return      A String.
      * @throws JSONException Unterminated string.
      */
     public String nextString(char quote) throws JSONException {
@@ -314,65 +296,66 @@ public class JSONTokener {
         for (;;) {
             c = this.next();
             switch (c) {
-                case 0:
-                case '\n':
-                case '\r':
-                    throw this.syntaxError("Unterminated string");
-                case '\\':
-                    c = this.next();
-                    switch (c) {
-                        case 'b':
-                            sb.append('\b');
-                            break;
-                        case 't':
-                            sb.append('\t');
-                            break;
-                        case 'n':
-                            sb.append('\n');
-                            break;
-                        case 'f':
-                            sb.append('\f');
-                            break;
-                        case 'r':
-                            sb.append('\r');
-                            break;
-                        case 'u':
-                            try {
-                                sb.append((char) Integer.parseInt(this.next(4), 16));
-                            } catch (NumberFormatException e) {
-                                throw this.syntaxError("Illegal escape.", e);
-                            }
-                            break;
-                        case '"':
-                        case '\'':
-                        case '\\':
-                        case '/':
-                            sb.append(c);
-                            break;
-                        default:
-                            throw this.syntaxError("Illegal escape.");
+            case 0:
+            case '\n':
+            case '\r':
+                throw this.syntaxError("Unterminated string");
+            case '\\':
+                c = this.next();
+                switch (c) {
+                case 'b':
+                    sb.append('\b');
+                    break;
+                case 't':
+                    sb.append('\t');
+                    break;
+                case 'n':
+                    sb.append('\n');
+                    break;
+                case 'f':
+                    sb.append('\f');
+                    break;
+                case 'r':
+                    sb.append('\r');
+                    break;
+                case 'u':
+                    try {
+                        sb.append((char)Integer.parseInt(this.next(4), 16));
+                    } catch (NumberFormatException e) {
+                        throw this.syntaxError("Illegal escape.", e);
                     }
                     break;
-                default:
-                    if (c == quote) {
-                        return sb.toString();
-                    }
+                case '"':
+                case '\'':
+                case '\\':
+                case '/':
                     sb.append(c);
+                    break;
+                default:
+                    throw this.syntaxError("Illegal escape.");
+                }
+                break;
+            default:
+                if (c == quote) {
+                    return sb.toString();
+                }
+                sb.append(c);
             }
         }
     }
 
 
     /**
-     * Get the text up but not including the specified character or the end of line, whichever comes first.
-     *
-     * @param delimiter A delimiter character.
-     * @return A string.
-     * @throws JSONException Thrown if there is an error while searching for the delimiter
+     * Get the text up but not including the specified character or the
+     * end of line, whichever comes first.
+     * @param  delimiter A delimiter character.
+     * @return   A string.
+     * @throws JSONException Thrown if there is an error while searching
+     *  for the delimiter
      */
     public String nextTo(char delimiter) throws JSONException {
         StringBuilder sb = new StringBuilder();
-        for (; ; ) {
+        for (;;) {
             char c = this.next();
             if (c == delimiter || c == 0 || c == '\n' || c == '\r') {
                 if (c != 0) {
@@ -386,20 +369,20 @@ public class JSONTokener {
 
 
     /**
-     * Get the text up but not including one of the specified delimiter characters or the end of line, whichever comes
-     * first.
-     *
+     * Get the text up but not including one of the specified delimiter
+     * characters or the end of line, whichever comes first.
      * @param delimiters A set of delimiter characters.
      * @return A string, trimmed.
-     * @throws JSONException Thrown if there is an error while searching for the delimiter
+     * @throws JSONException Thrown if there is an error while searching
+     *  for the delimiter
      */
     public String nextTo(String delimiters) throws JSONException {
         char c;
         StringBuilder sb = new StringBuilder();
-        for (; ; ) {
+        for (;;) {
             c = this.next();
             if (delimiters.indexOf(c) >= 0 || c == 0 ||
-                c == '\n' || c == '\r') {
+                    c == '\n' || c == '\r') {
                 if (c != 0) {
                     this.back();
                 }
@@ -542,8 +525,6 @@ public class JSONTokener {
     }
 
     Object nextSimpleValue(char c, boolean strictMode) {
-        String string;
-
         if (c == '"' || c == '\'') {
             String str = this.nextString(c);
             if (strictMode) {
@@ -552,6 +533,19 @@ public class JSONTokener {
             return str;
         }
 
+        return parsedUnquotedText(c);
+    }
+
+    /**
+     * Parses unquoted text from the JSON input. This could be the values true, false, or null, or it can be a number.
+     * Non-standard forms are also accepted. Characters are accumulated until the end of the text or a formatting
+     * character is reached.
+     *
+     * @param c The starting character.
+     * @return The parsed object.
+     * @throws JSONException If the parsed string is empty.
+     */
+    private Object parsedUnquotedText(char c) {
         StringBuilder sb = new StringBuilder();
         while (c >= ' ' && ",:]}/\\\"[{;=#".indexOf(c) < 0) {
             sb.append(c);
@@ -561,8 +555,8 @@ public class JSONTokener {
             this.back();
         }
 
-        string = sb.toString().trim();
-        if ("".equals(string)) {
+        String string = sb.toString().trim();
+        if (string.isEmpty()) {
             throw this.syntaxError("Missing value");
         }
         return JSONObject.stringToValue(string);
@@ -570,12 +564,13 @@ public class JSONTokener {
 
 
     /**
-     * Skip characters until the next character is the requested character. If the requested character is not found, no
-     * characters are skipped.
-     *
+     * Skip characters until the next character is the requested character.
+     * If the requested character is not found, no characters are skipped.
      * @param to A character to skip to.
-     * @return The requested character, or zero if the requested character is not found.
-     * @throws JSONException Thrown if there is an error while searching for the to character
+     * @return The requested character, or zero if the requested character
+     * is not found.
+     * @throws JSONException Thrown if there is an error while searching
+     *  for the to character
      */
     public char skipTo(char to) throws JSONException {
         char c;
@@ -609,7 +604,7 @@ public class JSONTokener {
      * Make a JSONException to signal a syntax error.
      *
      * @param message The error message.
-     * @return A JSONException object, suitable for throwing
+     * @return  A JSONException object, suitable for throwing
      */
     public JSONException syntaxError(String message) {
         return new JSONException(message + this.toString());
@@ -618,9 +613,9 @@ public class JSONTokener {
     /**
      * Make a JSONException to signal a syntax error.
      *
-     * @param message  The error message.
+     * @param message The error message.
      * @param causedBy The throwable that caused the error.
-     * @return A JSONException object, suitable for throwing
+     * @return  A JSONException object, suitable for throwing
      */
     public JSONException syntaxError(String message, Throwable causedBy) {
         return new JSONException(message + this.toString(), causedBy);
@@ -634,7 +629,7 @@ public class JSONTokener {
     @Override
     public String toString() {
         return " at " + this.index + " [character " + this.character + " line " +
-            this.line + "]";
+                this.line + "]";
     }
 
     /**
@@ -643,7 +638,7 @@ public class JSONTokener {
      * @throws IOException If an I/O error occurs while closing the reader.
      */
     public void close() throws IOException {
-        if (reader != null) {
+        if(reader!=null){
             reader.close();
         }
     }

--- a/src/main/java/org/json/JSONTokener.java
+++ b/src/main/java/org/json/JSONTokener.java
@@ -8,40 +8,57 @@ Public Domain.
  */
 
 /**
- * A JSONTokener takes a source string and extracts characters and tokens from
- * it. It is used by the JSONObject and JSONArray constructors to parse
- * JSON source strings.
+ * A JSONTokener takes a source string and extracts characters and tokens from it. It is used by the JSONObject and
+ * JSONArray constructors to parse JSON source strings.
+ *
  * @author JSON.org
  * @version 2014-05-03
  */
 public class JSONTokener {
-    /** current read character position on the current line. */
+
+    /**
+     * current read character position on the current line.
+     */
     private long character;
-    /** flag to indicate if the end of the input has been found. */
+    /**
+     * flag to indicate if the end of the input has been found.
+     */
     private boolean eof;
-    /** current read index of the input. */
+    /**
+     * current read index of the input.
+     */
     private long index;
-    /** current line of the input. */
+    /**
+     * current line of the input.
+     */
     private long line;
-    /** previous character read from the input. */
+    /**
+     * previous character read from the input.
+     */
     private char previous;
-    /** Reader for the input. */
+    /**
+     * Reader for the input.
+     */
     private final Reader reader;
-    /** flag to indicate that a previous character was requested. */
+    /**
+     * flag to indicate that a previous character was requested.
+     */
     private boolean usePrevious;
-    /** the number of characters read in the previous line. */
+    /**
+     * the number of characters read in the previous line.
+     */
     private long characterPreviousLine;
 
 
     /**
      * Construct a JSONTokener from a Reader. The caller must close the Reader.
      *
-     * @param reader     A reader.
+     * @param reader A reader.
      */
     public JSONTokener(Reader reader) {
         this.reader = reader.markSupported()
-                ? reader
-                        : new BufferedReader(reader);
+            ? reader
+            : new BufferedReader(reader);
         this.eof = false;
         this.usePrevious = false;
         this.previous = 0;
@@ -54,6 +71,7 @@ public class JSONTokener {
 
     /**
      * Construct a JSONTokener from an InputStream. The caller must close the input stream.
+     *
      * @param inputStream The source.
      */
     public JSONTokener(InputStream inputStream) {
@@ -64,7 +82,7 @@ public class JSONTokener {
     /**
      * Construct a JSONTokener from a string.
      *
-     * @param s     A source string.
+     * @param s A source string.
      */
     public JSONTokener(String s) {
         this(new StringReader(s));
@@ -72,11 +90,10 @@ public class JSONTokener {
 
 
     /**
-     * Back up one character. This provides a sort of lookahead capability,
-     * so that you can test for a digit or letter before attempting to parse
-     * the next number or identifier.
-     * @throws JSONException Thrown if trying to step back more than 1 step
-     *  or if already at the start of the string
+     * Back up one character. This provides a sort of lookahead capability, so that you can test for a digit or letter
+     * before attempting to parse the next number or identifier.
+     *
+     * @throws JSONException Thrown if trying to step back more than 1 step or if already at the start of the string
      */
     public void back() throws JSONException {
         if (this.usePrevious || this.index <= 0) {
@@ -92,19 +109,19 @@ public class JSONTokener {
      */
     private void decrementIndexes() {
         this.index--;
-        if(this.previous=='\r' || this.previous == '\n') {
+        if (this.previous == '\r' || this.previous == '\n') {
             this.line--;
-            this.character=this.characterPreviousLine ;
-        } else if(this.character > 0){
+            this.character = this.characterPreviousLine;
+        } else if (this.character > 0) {
             this.character--;
         }
     }
 
     /**
      * Get the hex value of a character (base16).
-     * @param c A character between '0' and '9' or between 'A' and 'F' or
-     * between 'a' and 'f'.
-     * @return  An int between 0 and 15, or -1 if c was not a hex digit.
+     *
+     * @param c A character between '0' and '9' or between 'A' and 'F' or between 'a' and 'f'.
+     * @return An int between 0 and 15, or -1 if c was not a hex digit.
      */
     public static int dehexchar(char c) {
         if (c >= '0' && c <= '9') {
@@ -130,14 +147,13 @@ public class JSONTokener {
 
 
     /**
-     * Determine if the source string still contains characters that next()
-     * can consume.
+     * Determine if the source string still contains characters that next() can consume.
+     *
      * @return true if not yet at the end of the source.
-     * @throws JSONException thrown if there is an error stepping forward
-     *  or backward while checking for more data.
+     * @throws JSONException thrown if there is an error stepping forward or backward while checking for more data.
      */
     public boolean more() throws JSONException {
-        if(this.usePrevious) {
+        if (this.usePrevious) {
             return true;
         }
         try {
@@ -147,7 +163,7 @@ public class JSONTokener {
         }
         try {
             // -1 is EOF, but next() can not consume the null character '\0'
-            if(this.reader.read() <= 0) {
+            if (this.reader.read() <= 0) {
                 this.eof = true;
                 return false;
             }
@@ -188,28 +204,32 @@ public class JSONTokener {
 
     /**
      * Get the last character read from the input or '\0' if nothing has been read yet.
+     *
      * @return the last character read from the input.
      */
-    protected char getPrevious() { return this.previous;}
+    protected char getPrevious() {
+        return this.previous;
+    }
 
     /**
-     * Increments the internal indexes according to the previous character
-     * read and the character passed as the current character.
+     * Increments the internal indexes according to the previous character read and the character passed as the current
+     * character.
+     *
      * @param c the current character read.
      */
     private void incrementIndexes(int c) {
-        if(c > 0) {
+        if (c > 0) {
             this.index++;
-            if(c=='\r') {
+            if (c == '\r') {
                 this.line++;
                 this.characterPreviousLine = this.character;
-                this.character=0;
-            }else if (c=='\n') {
-                if(this.previous != '\r') {
+                this.character = 0;
+            } else if (c == '\n') {
+                if (this.previous != '\r') {
                     this.line++;
                     this.characterPreviousLine = this.character;
                 }
-                this.character=0;
+                this.character = 0;
             } else {
                 this.character++;
             }
@@ -217,8 +237,8 @@ public class JSONTokener {
     }
 
     /**
-     * Consume the next character, and check that it matches a specified
-     * character.
+     * Consume the next character, and check that it matches a specified character.
+     *
      * @param c The character to match.
      * @return The character.
      * @throws JSONException if the character does not match.
@@ -226,9 +246,9 @@ public class JSONTokener {
     public char next(char c) throws JSONException {
         char n = this.next();
         if (n != c) {
-            if(n > 0) {
+            if (n > 0) {
                 throw this.syntaxError("Expected '" + c + "' and instead saw '" +
-                        n + "'");
+                    n + "'");
             }
             throw this.syntaxError("Expected '" + c + "' and instead saw ''");
         }
@@ -239,11 +259,9 @@ public class JSONTokener {
     /**
      * Get the next n characters.
      *
-     * @param n     The number of characters to take.
-     * @return      A string of n characters.
-     * @throws JSONException
-     *   Substring bounds error if there are not
-     *   n characters remaining in the source string.
+     * @param n The number of characters to take.
+     * @return A string of n characters.
+     * @throws JSONException Substring bounds error if there are not n characters remaining in the source string.
      */
     public String next(int n) throws JSONException {
         if (n == 0) {
@@ -266,11 +284,12 @@ public class JSONTokener {
 
     /**
      * Get the next char in the string, skipping whitespace.
+     *
+     * @return A character, or 0 if there are no more characters.
      * @throws JSONException Thrown if there is an error reading the source string.
-     * @return  A character, or 0 if there are no more characters.
      */
     public char nextClean() throws JSONException {
-        for (;;) {
+        for (; ; ) {
             char c = this.next();
             if (c == 0 || c > ' ') {
                 return c;
@@ -280,82 +299,80 @@ public class JSONTokener {
 
 
     /**
-     * Return the characters up to the next close quote character.
-     * Backslash processing is done. The formal JSON format does not
-     * allow strings in single quotes, but an implementation is allowed to
-     * accept them.
+     * Return the characters up to the next close quote character. Backslash processing is done. The formal JSON format
+     * does not allow strings in single quotes, but an implementation is allowed to accept them.
+     *
      * @param quote The quoting character, either
-     *      <code>"</code>&nbsp;<small>(double quote)</small> or
-     *      <code>'</code>&nbsp;<small>(single quote)</small>.
-     * @return      A String.
+     *              <code>"</code>&nbsp;<small>(double quote)</small> or
+     *              <code>'</code>&nbsp;<small>(single quote)</small>.
+     * @return A String.
      * @throws JSONException Unterminated string.
      */
     public String nextString(char quote) throws JSONException {
         char c;
         StringBuilder sb = new StringBuilder();
-        for (;;) {
+        for (; ; ) {
             c = this.next();
             switch (c) {
-            case 0:
-            case '\n':
-            case '\r':
-                throw this.syntaxError("Unterminated string");
-            case '\\':
-                c = this.next();
-                switch (c) {
-                case 'b':
-                    sb.append('\b');
-                    break;
-                case 't':
-                    sb.append('\t');
-                    break;
-                case 'n':
-                    sb.append('\n');
-                    break;
-                case 'f':
-                    sb.append('\f');
-                    break;
-                case 'r':
-                    sb.append('\r');
-                    break;
-                case 'u':
-                    try {
-                        sb.append((char)Integer.parseInt(this.next(4), 16));
-                    } catch (NumberFormatException e) {
-                        throw this.syntaxError("Illegal escape.", e);
+                case 0:
+                case '\n':
+                case '\r':
+                    throw this.syntaxError("Unterminated string");
+                case '\\':
+                    c = this.next();
+                    switch (c) {
+                        case 'b':
+                            sb.append('\b');
+                            break;
+                        case 't':
+                            sb.append('\t');
+                            break;
+                        case 'n':
+                            sb.append('\n');
+                            break;
+                        case 'f':
+                            sb.append('\f');
+                            break;
+                        case 'r':
+                            sb.append('\r');
+                            break;
+                        case 'u':
+                            try {
+                                sb.append((char) Integer.parseInt(this.next(4), 16));
+                            } catch (NumberFormatException e) {
+                                throw this.syntaxError("Illegal escape.", e);
+                            }
+                            break;
+                        case '"':
+                        case '\'':
+                        case '\\':
+                        case '/':
+                            sb.append(c);
+                            break;
+                        default:
+                            throw this.syntaxError("Illegal escape.");
                     }
                     break;
-                case '"':
-                case '\'':
-                case '\\':
-                case '/':
-                    sb.append(c);
-                    break;
                 default:
-                    throw this.syntaxError("Illegal escape.");
-                }
-                break;
-            default:
-                if (c == quote) {
-                    return sb.toString();
-                }
-                sb.append(c);
+                    if (c == quote) {
+                        return sb.toString();
+                    }
+                    sb.append(c);
             }
         }
     }
 
 
     /**
-     * Get the text up but not including the specified character or the
-     * end of line, whichever comes first.
-     * @param  delimiter A delimiter character.
-     * @return   A string.
-     * @throws JSONException Thrown if there is an error while searching
-     *  for the delimiter
+     * Get the text up but not including the specified character or the end of line, whichever comes first.
+     *
+     * @param delimiter A delimiter character.
+     * @return A string.
+     * @throws JSONException Thrown if there is an error while searching for the delimiter
      */
     public String nextTo(char delimiter) throws JSONException {
         StringBuilder sb = new StringBuilder();
-        for (;;) {
+        for (; ; ) {
             char c = this.next();
             if (c == delimiter || c == 0 || c == '\n' || c == '\r') {
                 if (c != 0) {
@@ -369,12 +386,12 @@ public class JSONTokener {
 
 
     /**
-     * Get the text up but not including one of the specified delimiter
-     * characters or the end of line, whichever comes first.
+     * Get the text up but not including one of the specified delimiter characters or the end of line, whichever comes
+     * first.
+     *
      * @param delimiters A set of delimiter characters.
      * @return A string, trimmed.
-     * @throws JSONException Thrown if there is an error while searching
-     *  for the delimiter
+     * @throws JSONException Thrown if there is an error while searching for the delimiter
      */
     public String nextTo(String delimiters) throws JSONException {
         char c;
@@ -382,7 +399,7 @@ public class JSONTokener {
         for (;;) {
             c = this.next();
             if (delimiters.indexOf(c) >= 0 || c == 0 ||
-                    c == '\n' || c == '\r') {
+                c == '\n' || c == '\r') {
                 if (c != 0) {
                     this.back();
                 }
@@ -394,51 +411,149 @@ public class JSONTokener {
 
 
     /**
-     * Get the next value. The value can be a Boolean, Double, Integer,
-     * JSONArray, JSONObject, Long, or String, or the JSONObject.NULL object.
-     * @throws JSONException If syntax error.
+     * Get the next value. The value can be a Boolean, Double, Integer, JSONArray, JSONObject, Long, or String, or the
+     * JSONObject.NULL object.
      *
      * @return An object.
+     * @throws JSONException If syntax error.
      */
     public Object nextValue() throws JSONException {
+        return nextValue(false);
+    }
+
+    /**
+     * Get the next value. The value can be a Boolean, Double, Integer, JSONArray, JSONObject, Long, or String, or the
+     * JSONObject.NULL object. The strictMode parameter controls the behavior of the method when parsing the value.
+     *
+     * @param strictMode If true, the method will strictly adhere to the JSON syntax, throwing a JSONException for any
+     *                   deviations.
+     * @return An object.
+     * @throws JSONException If syntax error.
+     */
+    public Object nextValue(boolean strictMode) throws JSONException {
         char c = this.nextClean();
         switch (c) {
-        case '{':
-            this.back();
-            try {
-                return new JSONObject(this);
-            } catch (StackOverflowError e) {
-                throw new JSONException("JSON Array or Object depth too large to process.", e);
-            }
-        case '[':
-            this.back();
-            try {
-                return new JSONArray(this);
-            } catch (StackOverflowError e) {
-                throw new JSONException("JSON Array or Object depth too large to process.", e);
-            }
+            case '{':
+                this.back();
+                return getJsonObject(strictMode);
+            case '[':
+                this.back();
+                return getJsonArray();
+            default:
+                return getValue(c, strictMode);
         }
+    }
+
+    /**
+     * This method is used to get the next value.
+     *
+     * @param c          The next character in the JSONTokener.
+     * @param strictMode If true, the method will strictly adhere to the JSON syntax, throwing a JSONException if the
+     *                   value is not surrounded by quotes.
+     * @return An object which is the next value in the JSONTokener.
+     * @throws JSONException If the value is not surrounded by quotes when strictMode is true.
+     */
+    private Object getValue(char c, boolean strictMode) {
+        if (strictMode) {
+            Object valueToValidate = nextSimpleValue(c, true);
+
+            boolean isNumeric = valueToValidate.toString().chars().allMatch( Character::isDigit );
+
+            if(isNumeric){
+                return valueToValidate;
+            }
+
+            boolean hasQuotes = valueIsWrappedByQuotes(valueToValidate);
+
+            if (!hasQuotes) {
+                throw new JSONException("Value is not surrounded by quotes: " + valueToValidate);
+            }
+
+            return valueToValidate;
+        }
+
         return nextSimpleValue(c);
     }
 
-    Object nextSimpleValue(char c) {
-        String string;
+    /**
+     * This method is used to get a JSONObject from the JSONTokener. The strictMode parameter controls the behavior of
+     * the method when parsing the JSONObject.
+     *
+     * @param strictMode If true, the method will strictly adhere to the JSON syntax, throwing a JSONException for any
+     *                   deviations.
+     * @return A JSONObject which is the next value in the JSONTokener.
+     * @throws JSONException If the JSONObject or JSONArray depth is too large to process.
+     */
+    private JSONObject getJsonObject(boolean strictMode) {
+        try {
+            if (strictMode) {
+                return new JSONObject(this, new JSONParserConfiguration().withStrictMode(true));
+            }
 
-        switch (c) {
-        case '"':
-        case '\'':
-            return this.nextString(c);
+            return new JSONObject(this);
+        } catch (StackOverflowError e) {
+            throw new JSONException("JSON Array or Object depth too large to process.", e);
+        }
+    }
+
+    /**
+     * This method is used to get a JSONArray from the JSONTokener.
+     *
+     * @return A JSONArray which is the next value in the JSONTokener.
+     * @throws JSONException If the JSONArray depth is too large to process.
+     */
+    private JSONArray getJsonArray() {
+        try {
+            return new JSONArray(this);
+        } catch (StackOverflowError e) {
+            throw new JSONException("JSON Array or Object depth too large to process.", e);
+        }
+    }
+
+    /**
+     * This method checks if the provided value is wrapped by quotes.
+     *
+     * @param valueToValidate The value to be checked. It is converted to a string before checking.
+     * @return A boolean indicating whether the value is wrapped by quotes. It returns true if the value is wrapped by
+     * either single or double quotes.
+     */
+    private boolean valueIsWrappedByQuotes(Object valueToValidate) {
+        String stringToValidate = valueToValidate.toString();
+        boolean isWrappedByDoubleQuotes = isWrappedByQuotes(stringToValidate, "\"");
+        boolean isWrappedBySingleQuotes = isWrappedByQuotes(stringToValidate, "'");
+        return isWrappedByDoubleQuotes || isWrappedBySingleQuotes;
+    }
+
+    private boolean isWrappedByQuotes(String valueToValidate, String quoteType) {
+        return valueToValidate.startsWith(quoteType) && valueToValidate.endsWith(quoteType);
+    }
+
+    Object nextSimpleValue(char c) {
+        return nextSimpleValue(c, false);
+    }
+
+    Object nextSimpleValue(char c, boolean strictMode) {
+        if (c == '"' || c == '\'') {
+            String str = this.nextString(c);
+            if (strictMode) {
+                return String.format("\"%s\"", str);
+            }
+            return str;
         }
 
-        /*
-         * Handle unquoted text. This could be the values true, false, or
-         * null, or it can be a number. An implementation (such as this one)
-         * is allowed to also accept non-standard forms.
-         *
-         * Accumulate characters until we reach the end of the text or a
-         * formatting character.
-         */
+        return parsedUnquotedText(c);
+    }
 
+    /**
+     * Parses unquoted text from the JSON input. This could be the values true, false, or null, or it can be a number.
+     * Non-standard forms are also accepted. Characters are accumulated until the end of the text or a formatting
+     * character is reached.
+     *
+     * @param c The starting character.
+     * @return The parsed object.
+     * @throws JSONException If the parsed string is empty.
+     */
+    private Object parsedUnquotedText(char c) {
         StringBuilder sb = new StringBuilder();
         while (c >= ' ' && ",:]}/\\\"[{;=#".indexOf(c) < 0) {
             sb.append(c);
@@ -448,8 +563,8 @@ public class JSONTokener {
             this.back();
         }
 
-        string = sb.toString().trim();
-        if ("".equals(string)) {
+        String string = sb.toString().trim();
+        if (string.isEmpty()) {
             throw this.syntaxError("Missing value");
         }
         return JSONObject.stringToValue(string);
@@ -457,13 +572,12 @@ public class JSONTokener {
 
 
     /**
-     * Skip characters until the next character is the requested character.
-     * If the requested character is not found, no characters are skipped.
+     * Skip characters until the next character is the requested character. If the requested character is not found, no
+     * characters are skipped.
+     *
      * @param to A character to skip to.
-     * @return The requested character, or zero if the requested character
-     * is not found.
-     * @throws JSONException Thrown if there is an error while searching
-     *  for the to character
+     * @return The requested character, or zero if the requested character is not found.
+     * @throws JSONException Thrown if there is an error while searching for the to character
      */
     public char skipTo(char to) throws JSONException {
         char c;
@@ -497,7 +611,7 @@ public class JSONTokener {
      * Make a JSONException to signal a syntax error.
      *
      * @param message The error message.
-     * @return  A JSONException object, suitable for throwing
+     * @return A JSONException object, suitable for throwing
      */
     public JSONException syntaxError(String message) {
         return new JSONException(message + this.toString());
@@ -506,9 +620,9 @@ public class JSONTokener {
     /**
      * Make a JSONException to signal a syntax error.
      *
-     * @param message The error message.
+     * @param message  The error message.
      * @param causedBy The throwable that caused the error.
-     * @return  A JSONException object, suitable for throwing
+     * @return A JSONException object, suitable for throwing
      */
     public JSONException syntaxError(String message, Throwable causedBy) {
         return new JSONException(message + this.toString(), causedBy);
@@ -522,7 +636,7 @@ public class JSONTokener {
     @Override
     public String toString() {
         return " at " + this.index + " [character " + this.character + " line " +
-                this.line + "]";
+            this.line + "]";
     }
 
     /**
@@ -531,7 +645,7 @@ public class JSONTokener {
      * @throws IOException If an I/O error occurs while closing the reader.
      */
     public void close() throws IOException {
-        if(reader!=null){
+        if (reader != null) {
             reader.close();
         }
     }

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -2,6 +2,7 @@ package org.json.junit;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -31,25 +32,23 @@ public class JSONParserConfigurationTest {
 
     @Test
     public void givenInvalidInputArrays_testStrictModeTrue_shouldThrowJsonException() {
-        List<String> strictModeInputTestCases = Arrays.asList("[1,2];[3,4]", "", "[1, 2,3]:[4,5]", "[{test: implied}]");
+        List<String> strictModeInputTestCases = getNonCompliantJSONList();
         JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
             .withStrictMode(true);
 
         strictModeInputTestCases.forEach(testCase -> {
-            System.out.println("Test case: " + testCase);
             assertThrows("expected non-compliant array but got instead: " + testCase, JSONException.class,
                 () -> new JSONArray(testCase, jsonParserConfiguration));
-            System.out.println("Passed");
         });
     }
 
     @Test
     public void givenInvalidInputArrays_testStrictModeFalse_shouldNotThrowAnyException() {
-        List<String> strictModeInputTestCases = Arrays.asList("[1,2];[3,4]", "[1, 2,3]:[4,5]", "[{test: implied}]");
+        List<String> strictModeInputTestCases = getNonCompliantJSONList();
         JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
             .withStrictMode(false);
 
-        strictModeInputTestCases.stream().peek(System.out::println).forEach(testCase -> new JSONArray(testCase, jsonParserConfiguration));
+        strictModeInputTestCases.forEach(testCase -> new JSONArray(testCase, jsonParserConfiguration));
     }
 
     @Test
@@ -70,5 +69,15 @@ public class JSONParserConfigurationTest {
 
         assertTrue(jsonParserConfiguration.isOverwriteDuplicateKey());
         assertEquals(42, jsonParserConfiguration.getMaxNestingDepth());
+    }
+
+    private List<String> getNonCompliantJSONList() {
+        return Arrays.asList(
+            "[1,2];[3,4]",
+            "[1, 2,3]:[4,5]",
+            "[{test: implied}]",
+            "[{\"test\": implied}]",
+            "[{\"number\":\"7990154836330\",\"color\":'c'},{\"number\":8784148854580,\"color\":RosyBrown},{\"number\":\"5875770107113\",\"color\":\"DarkSeaGreen\"}]",
+            "[{test: \"implied\"}]");
     }
 }

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -23,7 +23,7 @@ public class JSONParserConfigurationTest {
     @Test
     public void testOverwrite() {
         JSONObject jsonObject = new JSONObject(TEST_SOURCE,
-            new JSONParserConfiguration().withOverwriteDuplicateKey(true));
+                new JSONParserConfiguration().withOverwriteDuplicateKey(true));
 
         assertEquals("duplicate key should be overwritten", "value2", jsonObject.getString("key"));
     }

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -23,7 +23,7 @@ public class JSONParserConfigurationTest {
     @Test
     public void testOverwrite() {
         JSONObject jsonObject = new JSONObject(TEST_SOURCE,
-                new JSONParserConfiguration().withOverwriteDuplicateKey(true));
+            new JSONParserConfiguration().withOverwriteDuplicateKey(true));
 
         assertEquals("duplicate key should be overwritten", "value2", jsonObject.getString("key"));
     }
@@ -46,6 +46,42 @@ public class JSONParserConfigurationTest {
             .withStrictMode(false);
 
         strictModeInputTestCases.forEach(testCase -> new JSONArray(testCase, jsonParserConfiguration));
+    }
+
+    @Test
+    public void givenInvalidInputArray_testStrictModeTrue_shouldThrowInvalidCharacterErrorMessage() {
+        JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
+            .withStrictMode(true);
+
+        String testCase = "[1,2];[3,4]";
+        JSONException je = assertThrows("expected non-compliant array but got instead: " + testCase,
+            JSONException.class, () -> new JSONArray(testCase, jsonParserConfiguration));
+
+        assertEquals("invalid character found after end of array: ; at 6 [character 7 line 1]", je.getMessage());
+    }
+
+    @Test
+    public void givenInvalidInputArray_testStrictModeTrue_shouldThrowValueNotSurroundedByQuotesErrorMessage() {
+        JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
+            .withStrictMode(true);
+
+        String testCase = "[{\"test\": implied}]";
+        JSONException je = assertThrows("expected non-compliant array but got instead: " + testCase,
+            JSONException.class, () -> new JSONArray(testCase, jsonParserConfiguration));
+
+        assertEquals("Value is not surrounded by quotes: implied", je.getMessage());
+    }
+
+    @Test
+    public void givenInvalidInputArray_testStrictModeTrue_shouldThrowKeyNotSurroundedByQuotesErrorMessage() {
+        JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
+            .withStrictMode(true);
+
+        String testCase = "[{test: implied}]";
+        JSONException je = assertThrows("expected non-compliant array but got instead: " + testCase,
+            JSONException.class, () -> new JSONArray(testCase, jsonParserConfiguration));
+
+        assertEquals("Key is not surrounded by quotes: test", je.getMessage());
     }
 
     @Test

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -118,24 +118,36 @@ public class JSONParserConfigurationTest {
     }
 
     @Test
-    public void givenUnbalancedQuotes_testStrictModeTrueAndAllowSingleQuotes_shouldThrowJsonExceptionWtihConcreteErrorDescription() {
+    public void givenNonCompliantQuotes_testStrictModeTrue_shouldThrowJsonExceptionWithConcreteErrorDescription() {
         JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
-            .withStrictMode(true).allowSingleQuotes(true);
+            .withStrictMode(true);
 
         String testCaseOne = "[\"abc', \"test\"]";
         String testCaseTwo = "['abc\", \"test\"]";
+        String testCaseThree = "['abc']";
+        String testCaseFour = "[{'testField': \"testValue\"}]";
 
         JSONException jeOne = assertThrows(JSONException.class,
             () -> new JSONArray(testCaseOne, jsonParserConfiguration));
         JSONException jeTwo = assertThrows(JSONException.class,
             () -> new JSONArray(testCaseTwo, jsonParserConfiguration));
+        JSONException jeThree = assertThrows(JSONException.class,
+            () -> new JSONArray(testCaseThree, jsonParserConfiguration));
+        JSONException jeFour = assertThrows(JSONException.class,
+            () -> new JSONArray(testCaseFour, jsonParserConfiguration));
 
         assertEquals(
             "Field contains unbalanced quotes. Starts with \" but ends with single quote. at 6 [character 7 line 1]",
             jeOne.getMessage());
         assertEquals(
-            "Field contains unbalanced quotes. Starts with ' but ends with double quote. at 6 [character 7 line 1]",
+            "Single quote wrap not allowed in strict mode at 2 [character 3 line 1]",
             jeTwo.getMessage());
+        assertEquals(
+            "Single quote wrap not allowed in strict mode at 2 [character 3 line 1]",
+            jeThree.getMessage());
+        assertEquals(
+            "Single quote wrap not allowed in strict mode at 3 [character 4 line 1]",
+            jeFour.getMessage());
     }
 
     @Test

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -2,7 +2,6 @@ package org.json.junit;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -14,7 +13,6 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class JSONParserConfigurationTest {
-
     private static final String TEST_SOURCE = "{\"key\": \"value1\", \"key\": \"value2\"}";
 
     @Test(expected = JSONException.class)
@@ -25,7 +23,7 @@ public class JSONParserConfigurationTest {
     @Test
     public void testOverwrite() {
         JSONObject jsonObject = new JSONObject(TEST_SOURCE,
-            new JSONParserConfiguration().withOverwriteDuplicateKey(true));
+                new JSONParserConfiguration().withOverwriteDuplicateKey(true));
 
         assertEquals("duplicate key should be overwritten", "value2", jsonObject.getString("key"));
     }
@@ -53,8 +51,8 @@ public class JSONParserConfigurationTest {
     @Test
     public void verifyDuplicateKeyThenMaxDepth() {
         JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
-            .withOverwriteDuplicateKey(true)
-            .withMaxNestingDepth(42);
+                .withOverwriteDuplicateKey(true)
+                .withMaxNestingDepth(42);
 
         assertEquals(42, jsonParserConfiguration.getMaxNestingDepth());
         assertTrue(jsonParserConfiguration.isOverwriteDuplicateKey());
@@ -63,8 +61,8 @@ public class JSONParserConfigurationTest {
     @Test
     public void verifyMaxDepthThenDuplicateKey() {
         JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
-            .withMaxNestingDepth(42)
-            .withOverwriteDuplicateKey(true);
+                .withMaxNestingDepth(42)
+                .withOverwriteDuplicateKey(true);
 
         assertTrue(jsonParserConfiguration.isOverwriteDuplicateKey());
         assertEquals(42, jsonParserConfiguration.getMaxNestingDepth());

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -31,7 +31,7 @@ public class JSONParserConfigurationTest {
 
     @Test
     public void givenInvalidInputArrays_testStrictModeTrue_shouldThrowJsonException() {
-        List<String> strictModeInputTestCases = Arrays.asList("[1,2];[3,4]", "", "[1, 2,3]:[4,5]"/*, "[{test: implied}]"*/);
+        List<String> strictModeInputTestCases = Arrays.asList("[1,2];[3,4]", "", "[1, 2,3]:[4,5]", "[{test: implied}]");
         JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
             .withStrictMode(true);
 
@@ -41,6 +41,15 @@ public class JSONParserConfigurationTest {
                 () -> new JSONArray(testCase, jsonParserConfiguration));
             System.out.println("Passed");
         });
+    }
+
+    @Test
+    public void givenInvalidInputArrays_testStrictModeFalse_shouldNotThrowAnyException() {
+        List<String> strictModeInputTestCases = Arrays.asList("[1,2];[3,4]", "[1, 2,3]:[4,5]", "[{test: implied}]");
+        JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
+            .withStrictMode(false);
+
+        strictModeInputTestCases.stream().peek(System.out::println).forEach(testCase -> new JSONArray(testCase, jsonParserConfiguration));
     }
 
     @Test

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -118,9 +118,9 @@ public class JSONParserConfigurationTest {
     }
 
     @Test
-    public void givenUnbalancedQuotes_testStrictModeTrue_shouldThrowJsonExceptionWtihConcreteErrorDescription() {
+    public void givenUnbalancedQuotes_testStrictModeTrueAndAllowSingleQuotes_shouldThrowJsonExceptionWtihConcreteErrorDescription() {
         JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
-            .withStrictMode(true);
+            .withStrictMode(true).allowSingleQuotes(true);
 
         String testCaseOne = "[\"abc', \"test\"]";
         String testCaseTwo = "['abc\", \"test\"]";
@@ -198,6 +198,7 @@ public class JSONParserConfigurationTest {
         return Arrays.asList(
             "[1,2];[3,4]",
             "[test]",
+            "[{'testSingleQuote': 'testSingleQuote'}]",
             "[1, 2,3]:[4,5]",
             "[{test: implied}]",
             "[{\"test\": implied}]",

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -36,10 +36,9 @@ public class JSONParserConfigurationTest {
         JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
             .withStrictMode(true);
 
-        strictModeInputTestCases.forEach(testCase -> {
-            assertThrows("expected non-compliant array but got instead: " + testCase, JSONException.class,
-                () -> new JSONArray(testCase, jsonParserConfiguration));
-        });
+        strictModeInputTestCases.forEach(
+            testCase -> assertThrows("expected non-compliant array but got instead: " + testCase, JSONException.class,
+                () -> new JSONArray(testCase, jsonParserConfiguration)));
     }
 
     @Test

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -1,14 +1,19 @@
 package org.json.junit;
 
+import java.util.Arrays;
+import java.util.List;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONParserConfiguration;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class JSONParserConfigurationTest {
+
     private static final String TEST_SOURCE = "{\"key\": \"value1\", \"key\": \"value2\"}";
 
     @Test(expected = JSONException.class)
@@ -19,16 +24,30 @@ public class JSONParserConfigurationTest {
     @Test
     public void testOverwrite() {
         JSONObject jsonObject = new JSONObject(TEST_SOURCE,
-                new JSONParserConfiguration().withOverwriteDuplicateKey(true));
+            new JSONParserConfiguration().withOverwriteDuplicateKey(true));
 
         assertEquals("duplicate key should be overwritten", "value2", jsonObject.getString("key"));
     }
 
     @Test
+    public void givenInvalidInputArrays_testStrictModeTrue_shouldThrowJsonException() {
+        List<String> strictModeInputTestCases = Arrays.asList("[1,2];[3,4]", "", "[1, 2,3]:[4,5]"/*, "[{test: implied}]"*/);
+        JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
+            .withStrictMode(true);
+
+        strictModeInputTestCases.forEach(testCase -> {
+            System.out.println("Test case: " + testCase);
+            assertThrows("expected non-compliant array but got instead: " + testCase, JSONException.class,
+                () -> new JSONArray(testCase, jsonParserConfiguration));
+            System.out.println("Passed");
+        });
+    }
+
+    @Test
     public void verifyDuplicateKeyThenMaxDepth() {
         JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
-                .withOverwriteDuplicateKey(true)
-                .withMaxNestingDepth(42);
+            .withOverwriteDuplicateKey(true)
+            .withMaxNestingDepth(42);
 
         assertEquals(42, jsonParserConfiguration.getMaxNestingDepth());
         assertTrue(jsonParserConfiguration.isOverwriteDuplicateKey());
@@ -37,8 +56,8 @@ public class JSONParserConfigurationTest {
     @Test
     public void verifyMaxDepthThenDuplicateKey() {
         JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
-                .withMaxNestingDepth(42)
-                .withOverwriteDuplicateKey(true);
+            .withMaxNestingDepth(42)
+            .withOverwriteDuplicateKey(true);
 
         assertTrue(jsonParserConfiguration.isOverwriteDuplicateKey());
         assertEquals(42, jsonParserConfiguration.getMaxNestingDepth());

--- a/src/test/resources/compliantJsonArray.json
+++ b/src/test/resources/compliantJsonArray.json
@@ -5,15 +5,15 @@
     "guid": "441331fb-84d1-4873-a649-3814621a0370",
     "isActive": true,
     "balance": "$2,691.63",
-    "picture": "http://placehold.it/32x32",
+    "picture": "http://example.abc/32x32",
     "age": 26,
     "eyeColor": "blue",
-    "name": "Susie Estes",
+    "name": "abc",
     "gender": "female",
-    "company": "ZENTURY",
-    "email": "susieestes@zentury.com",
-    "phone": "+1 (853) 428-2292",
-    "address": "424 Hewes Street, Grahamtown, Tennessee, 8138",
+    "company": "example",
+    "email": "abc@def.com",
+    "phone": "+1 (123) 456-7890",
+    "address": "123 Main St",
     "about": "Laborum magna tempor officia irure cillum nulla incididunt Lorem dolor veniam elit cupidatat amet. Veniam veniam exercitation nulla consectetur officia esse ex sunt nulla nisi ea cillum nisi reprehenderit. Qui aliquip reprehenderit aliqua aliquip aliquip anim sit magna nostrud dolore veniam velit elit aliquip.\r\n",
     "registered": "2016-07-22T03:18:11 -01:00",
     "latitude": -21.544934,
@@ -30,18 +30,18 @@
     "friends": [
       {
         "id": 0,
-        "name": "Simon Garrett"
+        "name": "abc def"
       },
       {
         "id": 1,
-        "name": "Conrad Moon"
+        "name": "ghi jkl"
       },
       {
         "id": 2,
-        "name": "Mccall Rosario"
+        "name": "mno pqr"
       }
     ],
-    "greeting": "Hello, Susie Estes! You have 10 unread messages.",
+    "greeting": "Hello, abc! You have 10 unread messages.",
     "favoriteFruit": "banana"
   },
   {
@@ -53,12 +53,12 @@
     "picture": "http://placehold.it/32x32",
     "age": 27,
     "eyeColor": "green",
-    "name": "Irma Greer",
+    "name": "def",
     "gender": "female",
-    "company": "ANIVET",
-    "email": "irmagreer@anivet.com",
-    "phone": "+1 (936) 539-2196",
-    "address": "285 Roebling Street, Hardyville, Hawaii, 8410",
+    "company": "sample",
+    "email": "def@abc.com",
+    "phone": "+1 (123) 456-78910",
+    "address": "1234 Main St",
     "about": "Ea id cupidatat eiusmod culpa. Nulla consequat esse elit enim et pariatur eiusmod ipsum. Consequat eu non reprehenderit in.\r\n",
     "registered": "2015-04-06T07:54:22 -01:00",
     "latitude": 83.512347,
@@ -75,18 +75,18 @@
     "friends": [
       {
         "id": 0,
-        "name": "Terri Morrison"
+        "name": "sample example"
       },
       {
         "id": 1,
-        "name": "Foley Turner"
+        "name": "test name"
       },
       {
         "id": 2,
-        "name": "Leila Brewer"
+        "name": "aaa aaaa"
       }
     ],
-    "greeting": "Hello, Irma Greer! You have 7 unread messages.",
+    "greeting": "Hello, test! You have 7 unread messages.",
     "favoriteFruit": "apple"
   },
   {
@@ -98,12 +98,12 @@
     "picture": "http://placehold.it/32x32",
     "age": 32,
     "eyeColor": "green",
-    "name": "Rebecca Garner",
+    "name": "test",
     "gender": "female",
-    "company": "OCEANICA",
-    "email": "rebeccagarner@oceanica.com",
-    "phone": "+1 (868) 551-3810",
-    "address": "425 Navy Walk, Spokane, Vermont, 7439",
+    "company": "test",
+    "email": "test@test.com",
+    "phone": "+1 (123) 456-7890",
+    "address": "123 Main St",
     "about": "Mollit officia adipisicing ex nisi non Lorem sunt quis est. Irure exercitation duis ipsum qui ullamco eu ea commodo occaecat minim proident. Incididunt nostrud ex cupidatat eiusmod mollit anim irure culpa. Labore voluptate voluptate labore nisi sit eu. Dolor sit proident velit dolor deserunt labore sit ipsum incididunt eiusmod reprehenderit voluptate. Duis anim velit officia laboris consequat officia dolor sint dolor nisi ex.\r\n",
     "registered": "2021-11-02T12:50:05 -00:00",
     "latitude": -82.969939,
@@ -120,18 +120,18 @@
     "friends": [
       {
         "id": 0,
-        "name": "Cox Trujillo"
+        "name": "test"
       },
       {
         "id": 1,
-        "name": "Stanton Wilcox"
+        "name": "sample"
       },
       {
         "id": 2,
-        "name": "Dolores Cooper"
+        "name": "example"
       }
     ],
-    "greeting": "Hello, Rebecca Garner! You have 1 unread messages.",
+    "greeting": "Hello, test! You have 1 unread messages.",
     "favoriteFruit": "strawberry"
   },
   {
@@ -143,12 +143,12 @@
     "picture": "http://placehold.it/32x32",
     "age": 35,
     "eyeColor": "brown",
-    "name": "Foster Pratt",
+    "name": "another test",
     "gender": "male",
-    "company": "COMTEST",
-    "email": "fosterpratt@comtest.com",
-    "phone": "+1 (829) 400-3497",
-    "address": "390 Montague Street, Sandston, Wyoming, 9116",
+    "company": "TEST",
+    "email": "anothertest@anothertest.com",
+    "phone": "+1 (321) 987-6543",
+    "address": "123 Example Main St",
     "about": "Do proident consectetur minim quis. In adipisicing culpa Lorem fugiat cillum exercitation velit velit. Non voluptate laboris deserunt veniam et sint consectetur irure aliqua quis eiusmod consectetur elit id. Ex sint do anim Lorem excepteur eu nulla.\r\n",
     "registered": "2020-06-25T04:55:25 -01:00",
     "latitude": 63.614955,
@@ -165,18 +165,18 @@
     "friends": [
       {
         "id": 0,
-        "name": "Savage Combs"
+        "name": "test"
       },
       {
         "id": 1,
-        "name": "Cecelia Kemp"
+        "name": "sample"
       },
       {
         "id": 2,
-        "name": "Priscilla Stephenson"
+        "name": "example"
       }
     ],
-    "greeting": "Hello, Foster Pratt! You have 5 unread messages.",
+    "greeting": "Hello, another test! You have 5 unread messages.",
     "favoriteFruit": "apple"
   },
   {
@@ -185,15 +185,15 @@
     "guid": "2c3e5115-758d-468e-99c5-c9afa26e1f9f",
     "isActive": true,
     "balance": "$1,047.20",
-    "picture": "http://placehold.it/32x32",
+    "picture": "http://test.it/32x32",
     "age": 30,
     "eyeColor": "green",
-    "name": "Willie Wallace",
+    "name": "Test Name",
     "gender": "female",
-    "company": "KNEEDLES",
-    "email": "williewallace@kneedles.com",
-    "phone": "+1 (816) 510-2695",
-    "address": "411 Dunne Place, Rosewood, Iowa, 283",
+    "company": "test",
+    "email": "testname@testname.com",
+    "phone": "+1 (999) 999-9999",
+    "address": "999 Test Main St",
     "about": "Voluptate exercitation tempor consectetur velit magna ea occaecat cupidatat consectetur anim aute. Aliquip est aute ipsum laboris non irure qui consectetur tempor quis do ea Lorem. Cupidatat exercitation ad culpa aliqua amet commodo mollit reprehenderit exercitation adipisicing amet et laborum pariatur.\r\n",
     "registered": "2023-01-19T02:43:18 -00:00",
     "latitude": 14.15208,
@@ -210,18 +210,18 @@
     "friends": [
       {
         "id": 0,
-        "name": "Burks Lowe"
+        "name": "test"
       },
       {
         "id": 1,
-        "name": "Ray Sanchez"
+        "name": "sample"
       },
       {
         "id": 2,
-        "name": "Tasha Weiss"
+        "name": "example"
       }
     ],
-    "greeting": "Hello, Willie Wallace! You have 6 unread messages.",
+    "greeting": "Hello, test! You have 6 unread messages.",
     "favoriteFruit": "apple"
   },
   {
@@ -230,15 +230,15 @@
     "guid": "816cda74-5d4b-498f-9724-20f340d5f5bf",
     "isActive": false,
     "balance": "$2,628.74",
-    "picture": "http://placehold.it/32x32",
+    "picture": "http://testing.it/32x32",
     "age": 28,
     "eyeColor": "green",
-    "name": "Pearl Aguilar",
+    "name": "Testing",
     "gender": "female",
-    "company": "TELEPARK",
-    "email": "pearlaguilar@telepark.com",
-    "phone": "+1 (801) 427-2087",
-    "address": "633 Highlawn Avenue, Defiance, Illinois, 2118",
+    "company": "test",
+    "email": "testing@testing.com",
+    "phone": "+1 (888) 888-8888",
+    "address": "123 Main St",
     "about": "Cupidatat non ut nulla qui excepteur in minim non et nulla fugiat. Dolor quis laborum occaecat veniam dolor ullamco deserunt amet veniam dolor quis proident tempor laboris. In cillum duis ut quis. Aliqua cupidatat magna proident velit tempor veniam et consequat laborum ex dolore qui. Incididunt deserunt magna minim Lorem consectetur.\r\n",
     "registered": "2017-10-14T11:14:08 -01:00",
     "latitude": -5.345728,
@@ -255,18 +255,18 @@
     "friends": [
       {
         "id": 0,
-        "name": "Edwards Wolf"
+        "name": "test"
       },
       {
         "id": 1,
-        "name": "Hunter Fitzgerald"
+        "name": "sample"
       },
       {
         "id": 2,
-        "name": "Valencia Norton"
+        "name": "example"
       }
     ],
-    "greeting": "Hello, Pearl Aguilar! You have 2 unread messages.",
+    "greeting": "Hello, testing! You have 2 unread messages.",
     "favoriteFruit": "strawberry"
   },
   {
@@ -275,15 +275,15 @@
     "guid": "4ee550bc-0920-4104-b3ce-ebf9db6a803f",
     "isActive": true,
     "balance": "$1,709.31",
-    "picture": "http://placehold.it/32x32",
+    "picture": "http://sample.it/32x32",
     "age": 31,
     "eyeColor": "blue",
-    "name": "Tanisha Pacheco",
+    "name": "Sample Name",
     "gender": "female",
-    "company": "VISUALIX",
-    "email": "tanishapacheco@visualix.com",
-    "phone": "+1 (867) 577-2549",
-    "address": "466 Coleridge Street, Dotsero, Delaware, 8574",
+    "company": "Sample",
+    "email": "sample@sample.com",
+    "phone": "+1 (777) 777-7777",
+    "address": "123 Main St",
     "about": "Lorem ex proident ipsum ullamco velit sit nisi eiusmod cillum. Id tempor irure culpa nisi sit non qui veniam non ut. Aliquip reprehenderit excepteur mollit quis excepteur ex sit. Quis do eu veniam do ullamco occaecat eu cupidatat nisi laborum tempor minim fugiat pariatur. Ex in nulla ex velit.\r\n",
     "registered": "2019-04-08T03:54:36 -01:00",
     "latitude": -70.660321,
@@ -300,18 +300,18 @@
     "friends": [
       {
         "id": 0,
-        "name": "Carter Galloway"
+        "name": "Test"
       },
       {
         "id": 1,
-        "name": "Moody Cameron"
+        "name": "Sample"
       },
       {
         "id": 2,
-        "name": "June Gillespie"
+        "name": "Example"
       }
     ],
-    "greeting": "Hello, Tanisha Pacheco! You have 6 unread messages.",
+    "greeting": "Hello, Sample! You have 6 unread messages.",
     "favoriteFruit": "apple"
   }
 ]

--- a/src/test/resources/compliantJsonArray.json
+++ b/src/test/resources/compliantJsonArray.json
@@ -1,0 +1,317 @@
+[
+  {
+    "_id": "6606c27d2ab4a0102d49420a",
+    "index": 0,
+    "guid": "441331fb-84d1-4873-a649-3814621a0370",
+    "isActive": true,
+    "balance": "$2,691.63",
+    "picture": "http://placehold.it/32x32",
+    "age": 26,
+    "eyeColor": "blue",
+    "name": "Susie Estes",
+    "gender": "female",
+    "company": "ZENTURY",
+    "email": "susieestes@zentury.com",
+    "phone": "+1 (853) 428-2292",
+    "address": "424 Hewes Street, Grahamtown, Tennessee, 8138",
+    "about": "Laborum magna tempor officia irure cillum nulla incididunt Lorem dolor veniam elit cupidatat amet. Veniam veniam exercitation nulla consectetur officia esse ex sunt nulla nisi ea cillum nisi reprehenderit. Qui aliquip reprehenderit aliqua aliquip aliquip anim sit magna nostrud dolore veniam velit elit aliquip.\r\n",
+    "registered": "2016-07-22T03:18:11 -01:00",
+    "latitude": -21.544934,
+    "longitude": 72.765495,
+    "tags": [
+      "consectetur",
+      "minim",
+      "sunt",
+      "in",
+      "ut",
+      "velit",
+      "anim"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Simon Garrett"
+      },
+      {
+        "id": 1,
+        "name": "Conrad Moon"
+      },
+      {
+        "id": 2,
+        "name": "Mccall Rosario"
+      }
+    ],
+    "greeting": "Hello, Susie Estes! You have 10 unread messages.",
+    "favoriteFruit": "banana"
+  },
+  {
+    "_id": "6606c27d0a45df5121fb765f",
+    "index": 1,
+    "guid": "fd774715-de85-44b9-b498-c214d8f68d9f",
+    "isActive": true,
+    "balance": "$2,713.96",
+    "picture": "http://placehold.it/32x32",
+    "age": 27,
+    "eyeColor": "green",
+    "name": "Irma Greer",
+    "gender": "female",
+    "company": "ANIVET",
+    "email": "irmagreer@anivet.com",
+    "phone": "+1 (936) 539-2196",
+    "address": "285 Roebling Street, Hardyville, Hawaii, 8410",
+    "about": "Ea id cupidatat eiusmod culpa. Nulla consequat esse elit enim et pariatur eiusmod ipsum. Consequat eu non reprehenderit in.\r\n",
+    "registered": "2015-04-06T07:54:22 -01:00",
+    "latitude": 83.512347,
+    "longitude": -9.368739,
+    "tags": [
+      "excepteur",
+      "non",
+      "nostrud",
+      "laboris",
+      "laboris",
+      "qui",
+      "aute"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Terri Morrison"
+      },
+      {
+        "id": 1,
+        "name": "Foley Turner"
+      },
+      {
+        "id": 2,
+        "name": "Leila Brewer"
+      }
+    ],
+    "greeting": "Hello, Irma Greer! You have 7 unread messages.",
+    "favoriteFruit": "apple"
+  },
+  {
+    "_id": "6606c27dfb3a0e4e7e7183d3",
+    "index": 2,
+    "guid": "688b0c36-98e0-4ee7-86b8-863638d79b5f",
+    "isActive": false,
+    "balance": "$3,514.35",
+    "picture": "http://placehold.it/32x32",
+    "age": 32,
+    "eyeColor": "green",
+    "name": "Rebecca Garner",
+    "gender": "female",
+    "company": "OCEANICA",
+    "email": "rebeccagarner@oceanica.com",
+    "phone": "+1 (868) 551-3810",
+    "address": "425 Navy Walk, Spokane, Vermont, 7439",
+    "about": "Mollit officia adipisicing ex nisi non Lorem sunt quis est. Irure exercitation duis ipsum qui ullamco eu ea commodo occaecat minim proident. Incididunt nostrud ex cupidatat eiusmod mollit anim irure culpa. Labore voluptate voluptate labore nisi sit eu. Dolor sit proident velit dolor deserunt labore sit ipsum incididunt eiusmod reprehenderit voluptate. Duis anim velit officia laboris consequat officia dolor sint dolor nisi ex.\r\n",
+    "registered": "2021-11-02T12:50:05 -00:00",
+    "latitude": -82.969939,
+    "longitude": 86.415645,
+    "tags": [
+      "aliquip",
+      "et",
+      "est",
+      "nulla",
+      "nulla",
+      "tempor",
+      "adipisicing"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Cox Trujillo"
+      },
+      {
+        "id": 1,
+        "name": "Stanton Wilcox"
+      },
+      {
+        "id": 2,
+        "name": "Dolores Cooper"
+      }
+    ],
+    "greeting": "Hello, Rebecca Garner! You have 1 unread messages.",
+    "favoriteFruit": "strawberry"
+  },
+  {
+    "_id": "6606c27d204bc2327fc9ba23",
+    "index": 3,
+    "guid": "be970cba-306e-4cbd-be08-c265a43a61fa",
+    "isActive": true,
+    "balance": "$3,691.63",
+    "picture": "http://placehold.it/32x32",
+    "age": 35,
+    "eyeColor": "brown",
+    "name": "Foster Pratt",
+    "gender": "male",
+    "company": "COMTEST",
+    "email": "fosterpratt@comtest.com",
+    "phone": "+1 (829) 400-3497",
+    "address": "390 Montague Street, Sandston, Wyoming, 9116",
+    "about": "Do proident consectetur minim quis. In adipisicing culpa Lorem fugiat cillum exercitation velit velit. Non voluptate laboris deserunt veniam et sint consectetur irure aliqua quis eiusmod consectetur elit id. Ex sint do anim Lorem excepteur eu nulla.\r\n",
+    "registered": "2020-06-25T04:55:25 -01:00",
+    "latitude": 63.614955,
+    "longitude": -109.299405,
+    "tags": [
+      "irure",
+      "esse",
+      "non",
+      "mollit",
+      "laborum",
+      "adipisicing",
+      "ad"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Savage Combs"
+      },
+      {
+        "id": 1,
+        "name": "Cecelia Kemp"
+      },
+      {
+        "id": 2,
+        "name": "Priscilla Stephenson"
+      }
+    ],
+    "greeting": "Hello, Foster Pratt! You have 5 unread messages.",
+    "favoriteFruit": "apple"
+  },
+  {
+    "_id": "6606c27df63eb5f390cb9989",
+    "index": 4,
+    "guid": "2c3e5115-758d-468e-99c5-c9afa26e1f9f",
+    "isActive": true,
+    "balance": "$1,047.20",
+    "picture": "http://placehold.it/32x32",
+    "age": 30,
+    "eyeColor": "green",
+    "name": "Willie Wallace",
+    "gender": "female",
+    "company": "KNEEDLES",
+    "email": "williewallace@kneedles.com",
+    "phone": "+1 (816) 510-2695",
+    "address": "411 Dunne Place, Rosewood, Iowa, 283",
+    "about": "Voluptate exercitation tempor consectetur velit magna ea occaecat cupidatat consectetur anim aute. Aliquip est aute ipsum laboris non irure qui consectetur tempor quis do ea Lorem. Cupidatat exercitation ad culpa aliqua amet commodo mollit reprehenderit exercitation adipisicing amet et laborum pariatur.\r\n",
+    "registered": "2023-01-19T02:43:18 -00:00",
+    "latitude": 14.15208,
+    "longitude": 170.411535,
+    "tags": [
+      "dolor",
+      "qui",
+      "cupidatat",
+      "aliqua",
+      "laboris",
+      "reprehenderit",
+      "sint"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Burks Lowe"
+      },
+      {
+        "id": 1,
+        "name": "Ray Sanchez"
+      },
+      {
+        "id": 2,
+        "name": "Tasha Weiss"
+      }
+    ],
+    "greeting": "Hello, Willie Wallace! You have 6 unread messages.",
+    "favoriteFruit": "apple"
+  },
+  {
+    "_id": "6606c27d01d19fa29853d59c",
+    "index": 5,
+    "guid": "816cda74-5d4b-498f-9724-20f340d5f5bf",
+    "isActive": false,
+    "balance": "$2,628.74",
+    "picture": "http://placehold.it/32x32",
+    "age": 28,
+    "eyeColor": "green",
+    "name": "Pearl Aguilar",
+    "gender": "female",
+    "company": "TELEPARK",
+    "email": "pearlaguilar@telepark.com",
+    "phone": "+1 (801) 427-2087",
+    "address": "633 Highlawn Avenue, Defiance, Illinois, 2118",
+    "about": "Cupidatat non ut nulla qui excepteur in minim non et nulla fugiat. Dolor quis laborum occaecat veniam dolor ullamco deserunt amet veniam dolor quis proident tempor laboris. In cillum duis ut quis. Aliqua cupidatat magna proident velit tempor veniam et consequat laborum ex dolore qui. Incididunt deserunt magna minim Lorem consectetur.\r\n",
+    "registered": "2017-10-14T11:14:08 -01:00",
+    "latitude": -5.345728,
+    "longitude": -9.706491,
+    "tags": [
+      "officia",
+      "velit",
+      "laboris",
+      "qui",
+      "cupidatat",
+      "cupidatat",
+      "ad"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Edwards Wolf"
+      },
+      {
+        "id": 1,
+        "name": "Hunter Fitzgerald"
+      },
+      {
+        "id": 2,
+        "name": "Valencia Norton"
+      }
+    ],
+    "greeting": "Hello, Pearl Aguilar! You have 2 unread messages.",
+    "favoriteFruit": "strawberry"
+  },
+  {
+    "_id": "6606c27d803003cede1d6deb",
+    "index": 6,
+    "guid": "4ee550bc-0920-4104-b3ce-ebf9db6a803f",
+    "isActive": true,
+    "balance": "$1,709.31",
+    "picture": "http://placehold.it/32x32",
+    "age": 31,
+    "eyeColor": "blue",
+    "name": "Tanisha Pacheco",
+    "gender": "female",
+    "company": "VISUALIX",
+    "email": "tanishapacheco@visualix.com",
+    "phone": "+1 (867) 577-2549",
+    "address": "466 Coleridge Street, Dotsero, Delaware, 8574",
+    "about": "Lorem ex proident ipsum ullamco velit sit nisi eiusmod cillum. Id tempor irure culpa nisi sit non qui veniam non ut. Aliquip reprehenderit excepteur mollit quis excepteur ex sit. Quis do eu veniam do ullamco occaecat eu cupidatat nisi laborum tempor minim fugiat pariatur. Ex in nulla ex velit.\r\n",
+    "registered": "2019-04-08T03:54:36 -01:00",
+    "latitude": -70.660321,
+    "longitude": 71.547525,
+    "tags": [
+      "consequat",
+      "veniam",
+      "pariatur",
+      "aliqua",
+      "cillum",
+      "eu",
+      "officia"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Carter Galloway"
+      },
+      {
+        "id": 1,
+        "name": "Moody Cameron"
+      },
+      {
+        "id": 2,
+        "name": "June Gillespie"
+      }
+    ],
+    "greeting": "Hello, Tanisha Pacheco! You have 6 unread messages.",
+    "favoriteFruit": "apple"
+  }
+]


### PR DESCRIPTION
This fixes issue #871 

# StrictMode Implementation for JSONArray

## JSONParserConfiguration

Followed the same pattern already in place in JSONParserConfiguration.

```java
public class JSONParserConfiguration extends ParserConfiguration {

    /**
     * This flag, when set to true, instructs the parser to throw a JSONException if it encounters an invalid character
     * immediately following the final ']' character in the input. This is useful for ensuring strict adherence to the
     * JSON syntax, as any characters after the final closing bracket of a JSON array are considered invalid.
     */
    private boolean strictMode;

    ( ... )

    /**
     * Sets the strict mode configuration for the JSON parser.
     * <p>
     * When strict mode is enabled, the parser will throw a JSONException if it encounters an invalid character
     * immediately following the final ']' character in the input. This is useful for ensuring strict adherence to the
     * JSON syntax, as any characters after the final closing bracket of a JSON array are considered invalid.
     *
     * @param mode a boolean value indicating whether strict mode should be enabled or not
     * @return a new JSONParserConfiguration instance with the updated strict mode setting
     */
    public JSONParserConfiguration withStrictMode(final boolean mode) {
        JSONParserConfiguration clone = this.clone();
        clone.strictMode = mode;

        return clone;
    }

    ( ... )

}
```

# Implementation Details

JSONArray main constructor now requires JSONParserConfiguration which controls the behaviour of the JSONArray.

```java
    /**
     * Constructs a JSONArray from a JSONTokener and a JSONParserConfiguration.
     * JSONParserConfiguration contains strictMode turned off (false) by default.
     *
     * @param x                       A JSONTokener instance from which the JSONArray is constructed.
     * @param jsonParserConfiguration A JSONParserConfiguration instance that controls the behavior of the parser.
     * @throws JSONException If a syntax error occurs during the construction of the JSONArray.
     */
    public JSONArray(JSONTokener x, JSONParserConfiguration jsonParserConfiguration) throws JSONException {
        this();
        if (x.nextClean() != '[') {
            throw x.syntaxError("A JSONArray text must start with '['");
        }

        char nextChar = x.nextClean();
        if (nextChar == 0) {
            // array is unclosed. No ']' found, instead EOF
            throw x.syntaxError("Expected a ',' or ']'");
        }
        if (nextChar != ']') {
            x.back();
            for (; ; ) { ... }
        }
    }
```

If no JSONParserConfiguration is provided, a default JSONParserConfiguration will be added maintaining all the previous functionality. **StrictMode** is false/off by default.

```java
    /**
     * Constructs a JSONArray from a JSONTokener.
     * <p>
     * This constructor reads the JSONTokener to parse a JSON array. It uses the default JSONParserConfiguration.
     *
     * @param x A JSONTokener
     * @throws JSONException If there is a syntax error.
     */
    public JSONArray(JSONTokener x) throws JSONException {
        this(x, new JSONParserConfiguration());
    }
```

## 2nd Part - Quotes Logic

You can find the quotes logic at the JSONTokener

```java
    /**
     * This method is used to get the next value.
     *
     * @param c          The next character in the JSONTokener.
     * @param strictMode If true, the method will strictly adhere to the JSON syntax, throwing a JSONException if the
     *                   value is not surrounded by quotes.
     * @return An object which is the next value in the JSONTokener.
     * @throws JSONException If the value is not surrounded by quotes when strictMode is true.
     */
    private Object getValue(char c, boolean strictMode) {
        if (strictMode) {
            Object valueToValidate = nextSimpleValue(c, true);

            boolean isNumeric = valueToValidate.toString().chars().allMatch( Character::isDigit );

            if(isNumeric){
                return valueToValidate;
            }

            boolean hasQuotes = valueIsWrappedByQuotes(valueToValidate);

            if (!hasQuotes) {
                throw new JSONException("Value is not surrounded by quotes: " + valueToValidate);
            }

            return valueToValidate;
        }

        return nextSimpleValue(c);
    }
```
# Unit Tests

You can find my test cases in JSONParserConfigurationTest

Every time a non-compliant case is found while in StrictMode, a JSONException is thrown at the exact position of where the conflict happened.

If a non-compliant case is found while StrictMode is **off**, then no exception will be thrown and the JSONArray will behave as before.

![image](https://github.com/stleary/JSON-java/assets/76500344/42205cc0-69cf-42bb-a4fc-f27e8e456e15)

I've added several test cases on the unit test and created a platform to add more easily, feel free to play with it and add more if I missed some case.

![image](https://github.com/stleary/JSON-java/assets/76500344/2384596c-f561-4f21-84ce-64fe3135668f)

# Non Compliant Test Cases Log
Bellow is how the errors will be shown to the user, depending on which type of error the user produced with StrictMode it will attempt to show exactly what happened.

![image](https://github.com/stleary/JSON-java/assets/76500344/9c6d2d09-1b0c-40eb-a02f-779f37f5cf77)

I hope this meets your requirements.
Feel free to contact me for any further clarification,

Ricardo Mendes - a fan of this lib
