### PR TITLE
Fixed non-idempotent unit tests in `JSONObjectTest`

### DIFF
--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -56,6 +56,7 @@ import org.json.junit.data.RecursiveBeanEquals;
 import org.json.junit.data.Singleton;
 import org.json.junit.data.SingletonEnum;
 import org.json.junit.data.WeirdList;
+import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -75,6 +76,14 @@ public class JSONObjectTest {
      */
     static final Pattern NUMBER_PATTERN = Pattern.compile("-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?");
 
+    @After
+    public void tearDown() {
+        SingletonEnum.getInstance().setSomeInt(0);
+        SingletonEnum.getInstance().setSomeString(null);
+        Singleton.getInstance().setSomeInt(0);
+        Singleton.getInstance().setSomeString(null);
+    }
+    
     /**
      * Tests that the similar method is working as expected.
      */


### PR DESCRIPTION
## Motivation:

A couple of tests in `JSONObjectTest` are not idempotent and fail in the second runs in the same JVM, because they pollute states reused by themselves. Specifically, these tests first assume that `SingletonEnum.getInstance()` or `Singleton.getInstance()` are in a clean state, and then modify them. However, these instances are not cleaned up after the tests, so the repeated runs fail in the initial sanity check.  It shall be good to clean the state pollution so that potential newly introduced tests do not fail in the future due to the shared state polluted by these tests.

Two non-idempotent tests are:
- `testSingletonEnumBean()`
- `testSingletonBean()`

## Error messages for both failed tests in the second run:
```
java.lang.AssertionError: [someString, someInt] expected:<1> but was:<2>
```

## Proposed Fix
Add a `tearDown()` method to restore the instances of `SingletonEnum` and `Singleton` to default states.
