### PR TITLE
update-jsonpath: update jsonpath from 2.4.0 to 2.9.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'com.jayway.jsonpath:json-path:2.4.0'
+    testImplementation 'com.jayway.jsonpath:json-path:2.9.0'
     testImplementation 'org.mockito:mockito-core:4.2.0'
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.4.0</version>
+            <version>2.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
**What problem does this code solve?**
Fixes #893 by updating jsonpath, which is only used for unit tests, from 2.4.0 to 2.9.0.

**Does the code still compile with Java6?**
Yes

**Risks**
Low

**Changes to the API?**
No

**Will this require a new release?**
No

**Should the documentation be updated?**
No

**Does it break the unit tests?**
No

**Was any code refactored in this commit?**
No executable code was changed

**Review status**
**APPROVED** - by myself

Starting 3-day comment window

