### PR TITLE
884: Strict Mode for JSONObject

### DIFF
--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -259,7 +259,7 @@ public class JSONObject {
                 case '}':
                     if (jsonParserConfiguration.isStrictMode()) {
                         c = x.nextClean();
-                        if (c != 0 && c != '}') {
+                        if (c != 0 && c != '}' && c != ',' && c != ']') {
                             throw x.syntaxError(String.format("Invalid char '%s' after '}'", c));
                         }
                         x.back();

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -19,42 +19,37 @@ import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
 /**
- * A JSONObject is an unordered collection of name/value pairs. Its external
- * form is a string wrapped in curly braces with colons between the names and
- * values, and commas between the values and names. The internal form is an
- * object having <code>get</code> and <code>opt</code> methods for accessing
- * the values by name, and <code>put</code> methods for adding or replacing
- * values by name. The values can be any of these types: <code>Boolean</code>,
+ * A JSONObject is an unordered collection of name/value pairs. Its external form is a string wrapped in curly braces
+ * with colons between the names and values, and commas between the values and names. The internal form is an object
+ * having <code>get</code> and <code>opt</code> methods for accessing the values by name, and <code>put</code> methods
+ * for adding or replacing values by name. The values can be any of these types: <code>Boolean</code>,
  * <code>JSONArray</code>, <code>JSONObject</code>, <code>Number</code>,
  * <code>String</code>, or the <code>JSONObject.NULL</code> object. A
- * JSONObject constructor can be used to convert an external form JSON text
- * into an internal form whose values can be retrieved with the
+ * JSONObject constructor can be used to convert an external form JSON text into an internal form whose values can be
+ * retrieved with the
  * <code>get</code> and <code>opt</code> methods, or to convert values into a
  * JSON text using the <code>put</code> and <code>toString</code> methods. A
  * <code>get</code> method returns a value if one can be found, and throws an
- * exception if one cannot be found. An <code>opt</code> method returns a
- * default value instead of throwing an exception, and so is useful for
- * obtaining optional values.
+ * exception if one cannot be found. An <code>opt</code> method returns a default value instead of throwing an
+ * exception, and so is useful for obtaining optional values.
  * <p>
- * The generic <code>get()</code> and <code>opt()</code> methods return an
- * object, which you can cast or query for type. There are also typed
+ * The generic <code>get()</code> and <code>opt()</code> methods return an object, which you can cast or query for type.
+ * There are also typed
  * <code>get</code> and <code>opt</code> methods that do type checking and type
- * coercion for you. The opt methods differ from the get methods in that they
- * do not throw. Instead, they return a specified value, such as null.
+ * coercion for you. The opt methods differ from the get methods in that they do not throw. Instead, they return a
+ * specified value, such as null.
  * <p>
- * The <code>put</code> methods add or replace values in an object. For
- * example,
+ * The <code>put</code> methods add or replace values in an object. For example,
  *
  * <pre>
  * myString = new JSONObject()
  *         .put(&quot;JSON&quot;, &quot;Hello, World!&quot;).toString();
  * </pre>
- *
+ * <p>
  * produces the string <code>{"JSON": "Hello, World"}</code>.
  * <p>
- * The texts produced by the <code>toString</code> methods strictly conform to
- * the JSON syntax rules. The constructors are more forgiving in the texts they
- * will accept:
+ * The texts produced by the <code>toString</code> methods strictly conform to the JSON syntax rules. The constructors
+ * are more forgiving in the texts they will accept:
  * <ul>
  * <li>An extra <code>,</code>&nbsp;<small>(comma)</small> may appear just
  * before the closing brace.</li>
@@ -72,16 +67,15 @@ import java.util.regex.Pattern;
  * @version 2016-08-15
  */
 public class JSONObject {
+
     /**
-     * JSONObject.NULL is equivalent to the value that JavaScript calls null,
-     * whilst Java's null is equivalent to the value that JavaScript calls
-     * undefined.
+     * JSONObject.NULL is equivalent to the value that JavaScript calls null, whilst Java's null is equivalent to the
+     * value that JavaScript calls undefined.
      */
     private static final class Null {
 
         /**
-         * There is only intended to be a single instance of the NULL object,
-         * so the clone method returns itself.
+         * There is only intended to be a single instance of the NULL object, so the clone method returns itself.
          *
          * @return NULL.
          */
@@ -93,16 +87,15 @@ public class JSONObject {
         /**
          * A Null object is equal to the null value and to itself.
          *
-         * @param object
-         *            An object to test for nullness.
-         * @return true if the object parameter is the JSONObject.NULL object or
-         *         null.
+         * @param object An object to test for nullness.
+         * @return true if the object parameter is the JSONObject.NULL object or null.
          */
         @Override
         @SuppressWarnings("lgtm[java/unchecked-cast-in-equals]")
         public boolean equals(Object object) {
             return object == null || object == this;
         }
+
         /**
          * A Null object is equal to the null value and to itself.
          *
@@ -125,8 +118,8 @@ public class JSONObject {
     }
 
     /**
-     *  Regular Expression Pattern that matches JSON Numbers. This is primarily used for
-     *  output to guarantee that we are always writing valid JSON.
+     * Regular Expression Pattern that matches JSON Numbers. This is primarily used for output to guarantee that we are
+     * always writing valid JSON.
      */
     static final Pattern NUMBER_PATTERN = Pattern.compile("-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?");
 
@@ -166,16 +159,13 @@ public class JSONObject {
     }
 
     /**
-     * Construct a JSONObject from a subset of another JSONObject. An array of
-     * strings is used to identify the keys that should be copied. Missing keys
-     * are ignored.
+     * Construct a JSONObject from a subset of another JSONObject. An array of strings is used to identify the keys that
+     * should be copied. Missing keys are ignored.
      *
-     * @param jo
-     *            A JSONObject.
-     * @param names
-     *            An array of strings.
+     * @param jo    A JSONObject.
+     * @param names An array of strings.
      */
-    public JSONObject(JSONObject jo, String ... names) {
+    public JSONObject(JSONObject jo, String... names) {
         this(names.length);
         for (int i = 0; i < names.length; i += 1) {
             try {
@@ -188,11 +178,8 @@ public class JSONObject {
     /**
      * Construct a JSONObject from a JSONTokener.
      *
-     * @param x
-     *            A JSONTokener object containing the source string.
-     * @throws JSONException
-     *             If there is a syntax error in the source string or a
-     *             duplicated key.
+     * @param x A JSONTokener object containing the source string.
+     * @throws JSONException If there is a syntax error in the source string or a duplicated key.
      */
     public JSONObject(JSONTokener x) throws JSONException {
         this(x, new JSONParserConfiguration());
@@ -201,13 +188,9 @@ public class JSONObject {
     /**
      * Construct a JSONObject from a JSONTokener with custom json parse configurations.
      *
-     * @param x
-     *            A JSONTokener object containing the source string.
-     * @param jsonParserConfiguration
-     *            Variable to pass parser custom configuration for json parsing.
-     * @throws JSONException
-     *             If there is a syntax error in the source string or a
-     *             duplicated key.
+     * @param x                       A JSONTokener object containing the source string.
+     * @param jsonParserConfiguration Variable to pass parser custom configuration for json parsing.
+     * @throws JSONException If there is a syntax error in the source string or a duplicated key.
      */
     public JSONObject(JSONTokener x, JSONParserConfiguration jsonParserConfiguration) throws JSONException {
         this();
@@ -217,12 +200,22 @@ public class JSONObject {
         if (x.nextClean() != '{') {
             throw x.syntaxError("A JSONObject text must begin with '{'");
         }
+
         for (;;) {
             c = x.nextClean();
             switch (c) {
                 case 0:
                     throw x.syntaxError("A JSONObject text must end with '}'");
                 case '}':
+                    if (jsonParserConfiguration.isStrictMode()) {
+                        c = x.nextClean();
+                        System.out.println(c);
+                        if (c != 0) {
+                            System.out.println("yes");
+                            throw x.syntaxError(String.format("Invalid char '%s' after '}'", c));
+                        }
+                        x.back();
+                    }
                     return;
                 default:
                     key = x.nextSimpleValue(c, jsonParserConfiguration).toString();
@@ -231,6 +224,7 @@ public class JSONObject {
             // The key is followed by ':'.
 
             c = x.nextClean();
+
             if (c != ':') {
                 throw x.syntaxError("Expected a ':' after a key");
             }
@@ -254,20 +248,27 @@ public class JSONObject {
             // Pairs are separated by ','.
 
             switch (x.nextClean()) {
-            case ';':
-            case ',':
-                if (x.nextClean() == '}') {
+                case ';':
+                case ',':
+                    if (x.nextClean() == '}') {
+                        return;
+                    }
+                    if (x.end()) {
+                        throw x.syntaxError("A JSONObject text must end with '}'");
+                    }
+                    x.back();
+                    break;
+                case '}':
+                    if (jsonParserConfiguration.isStrictMode()) {
+                        c = x.nextClean();
+                        if (c != 0 && c != '}') {
+                            throw x.syntaxError(String.format("Invalid char '%s' after '}'", c));
+                        }
+                        x.back();
+                    }
                     return;
-                }
-                if (x.end()) {
-                    throw x.syntaxError("A JSONObject text must end with '}'");
-                }
-                x.back();
-                break;
-            case '}':
-                return;
-            default:
-                throw x.syntaxError("Expected a ',' or '}'");
+                default:
+                    throw x.syntaxError("Expected a ',' or '}'");
             }
         }
     }
@@ -275,26 +276,19 @@ public class JSONObject {
     /**
      * Construct a JSONObject from a Map.
      *
-     * @param m
-     *            A map object that can be used to initialize the contents of
-     *            the JSONObject.
-     * @throws JSONException
-     *            If a value in the map is non-finite number.
-     * @throws NullPointerException
-     *            If a key in the map is <code>null</code>
+     * @param m A map object that can be used to initialize the contents of the JSONObject.
+     * @throws JSONException        If a value in the map is non-finite number.
+     * @throws NullPointerException If a key in the map is <code>null</code>
      */
     public JSONObject(Map<?, ?> m) {
-      this(m, 0, new JSONParserConfiguration());
+        this(m, 0, new JSONParserConfiguration());
     }
 
     /**
      * Construct a JSONObject from a Map with custom json parse configurations.
      *
-     * @param m
-     *            A map object that can be used to initialize the contents of
-     *            the JSONObject.
-     * @param jsonParserConfiguration
-     *            Variable to pass parser custom configuration for json parsing.
+     * @param m                       A map object that can be used to initialize the contents of the JSONObject.
+     * @param jsonParserConfiguration Variable to pass parser custom configuration for json parsing.
      */
     public JSONObject(Map<?, ?> m, JSONParserConfiguration jsonParserConfiguration) {
         this(m, 0, jsonParserConfiguration);
@@ -305,16 +299,17 @@ public class JSONObject {
      */
     private JSONObject(Map<?, ?> m, int recursionDepth, JSONParserConfiguration jsonParserConfiguration) {
         if (recursionDepth > jsonParserConfiguration.getMaxNestingDepth()) {
-          throw new JSONException("JSONObject has reached recursion depth limit of " + jsonParserConfiguration.getMaxNestingDepth());
+            throw new JSONException(
+                "JSONObject has reached recursion depth limit of " + jsonParserConfiguration.getMaxNestingDepth());
         }
         if (m == null) {
             this.map = new HashMap<String, Object>();
         } else {
             this.map = new HashMap<String, Object>(m.size());
-        	for (final Entry<?, ?> e : m.entrySet()) {
-        	    if(e.getKey() == null) {
-        	        throw new NullPointerException("Null key.");
-        	    }
+            for (final Entry<?, ?> e : m.entrySet()) {
+                if (e.getKey() == null) {
+                    throw new NullPointerException("Null key.");
+                }
                 final Object value = e.getValue();
                 if (value != null) {
                     testValidity(value);
@@ -325,28 +320,24 @@ public class JSONObject {
     }
 
     /**
-     * Construct a JSONObject from an Object using bean getters. It reflects on
-     * all of the public methods of the object. For each of the methods with no
-     * parameters and a name starting with <code>"get"</code> or
+     * Construct a JSONObject from an Object using bean getters. It reflects on all of the public methods of the object.
+     * For each of the methods with no parameters and a name starting with <code>"get"</code> or
      * <code>"is"</code> followed by an uppercase letter, the method is invoked,
-     * and a key and the value returned from the getter method are put into the
-     * new JSONObject.
+     * and a key and the value returned from the getter method are put into the new JSONObject.
      * <p>
-     * The key is formed by removing the <code>"get"</code> or <code>"is"</code>
-     * prefix. If the second remaining character is not upper case, then the
-     * first character is converted to lower case.
+     * The key is formed by removing the <code>"get"</code> or <code>"is"</code> prefix. If the second remaining
+     * character is not upper case, then the first character is converted to lower case.
      * <p>
-     * Methods that are <code>static</code>, return <code>void</code>,
-     * have parameters, or are "bridge" methods, are ignored.
+     * Methods that are <code>static</code>, return <code>void</code>, have parameters, or are "bridge" methods, are
+     * ignored.
      * <p>
-     * For example, if an object has a method named <code>"getName"</code>, and
-     * if the result of calling <code>object.getName()</code> is
+     * For example, if an object has a method named <code>"getName"</code>, and if the result of calling
+     * <code>object.getName()</code> is
      * <code>"Larry Fine"</code>, then the JSONObject will contain
      * <code>"name": "Larry Fine"</code>.
      * <p>
-     * The {@link JSONPropertyName} annotation can be used on a bean getter to
-     * override key name used in the JSONObject. For example, using the object
-     * above with the <code>getName</code> method, if we annotated it with:
+     * The {@link JSONPropertyName} annotation can be used on a bean getter to override key name used in the JSONObject.
+     * For example, using the object above with the <code>getName</code> method, if we annotated it with:
      * <pre>
      * &#64;JSONPropertyName("FullName")
      * public String getName() { return this.name; }
@@ -355,33 +346,27 @@ public class JSONObject {
      * <p>
      * Similarly, the {@link JSONPropertyName} annotation can be used on non-
      * <code>get</code> and <code>is</code> methods. We can also override key
-     * name used in the JSONObject as seen below even though the field would normally
-     * be ignored:
+     * name used in the JSONObject as seen below even though the field would normally be ignored:
      * <pre>
      * &#64;JSONPropertyName("FullName")
      * public String fullName() { return this.name; }
      * </pre>
      * The resulting JSON object would contain <code>"FullName": "Larry Fine"</code>
      * <p>
-     * The {@link JSONPropertyIgnore} annotation can be used to force the bean property
-     * to not be serialized into JSON. If both {@link JSONPropertyIgnore} and
-     * {@link JSONPropertyName} are defined on the same method, a depth comparison is
-     * performed and the one closest to the concrete class being serialized is used.
-     * If both annotations are at the same level, then the {@link JSONPropertyIgnore}
-     * annotation takes precedent and the field is not serialized.
-     * For example, the following declaration would prevent the <code>getName</code>
-     * method from being serialized:
+     * The {@link JSONPropertyIgnore} annotation can be used to force the bean property to not be serialized into JSON.
+     * If both {@link JSONPropertyIgnore} and {@link JSONPropertyName} are defined on the same method, a depth
+     * comparison is performed and the one closest to the concrete class being serialized is used. If both annotations
+     * are at the same level, then the {@link JSONPropertyIgnore} annotation takes precedent and the field is not
+     * serialized. For example, the following declaration would prevent the <code>getName</code> method from being
+     * serialized:
      * <pre>
      * &#64;JSONPropertyName("FullName")
      * &#64;JSONPropertyIgnore
      * public String getName() { return this.name; }
      * </pre>
      *
-     * @param bean
-     *            An object that has getter methods that should be used to make
-     *            a JSONObject.
-     * @throws JSONException
-     *            If a getter returned a non-finite number.
+     * @param bean An object that has getter methods that should be used to make a JSONObject.
+     * @throws JSONException If a getter returned a non-finite number.
      */
     public JSONObject(Object bean) {
         this();
@@ -394,20 +379,14 @@ public class JSONObject {
     }
 
     /**
-     * Construct a JSONObject from an Object, using reflection to find the
-     * public members. The resulting JSONObject's keys will be the strings from
-     * the names array, and the values will be the field values associated with
-     * those keys in the object. If a key is not found or not visible, then it
-     * will not be copied into the new JSONObject.
+     * Construct a JSONObject from an Object, using reflection to find the public members. The resulting JSONObject's
+     * keys will be the strings from the names array, and the values will be the field values associated with those keys
+     * in the object. If a key is not found or not visible, then it will not be copied into the new JSONObject.
      *
-     * @param object
-     *            An object that has fields that should be used to make a
-     *            JSONObject.
-     * @param names
-     *            An array of strings, the names of the fields to be obtained
-     *            from the object.
+     * @param object An object that has fields that should be used to make a JSONObject.
+     * @param names  An array of strings, the names of the fields to be obtained from the object.
      */
-    public JSONObject(Object object, String ... names) {
+    public JSONObject(Object object, String... names) {
         this(names.length);
         Class<?> c = object.getClass();
         for (int i = 0; i < names.length; i += 1) {
@@ -420,34 +399,24 @@ public class JSONObject {
     }
 
     /**
-     * Construct a JSONObject from a source JSON text string. This is the most
-     * commonly used JSONObject constructor.
+     * Construct a JSONObject from a source JSON text string. This is the most commonly used JSONObject constructor.
      *
-     * @param source
-     *            A string beginning with <code>{</code>&nbsp;<small>(left
-     *            brace)</small> and ending with <code>}</code>
-     *            &nbsp;<small>(right brace)</small>.
-     * @exception JSONException
-     *                If there is a syntax error in the source string or a
-     *                duplicated key.
+     * @param source A string beginning with <code>{</code>&nbsp;<small>(left brace)</small> and ending with
+     *               <code>}</code> &nbsp;<small>(right brace)</small>.
+     * @throws JSONException If there is a syntax error in the source string or a duplicated key.
      */
     public JSONObject(String source) throws JSONException {
         this(source, new JSONParserConfiguration());
     }
 
     /**
-     * Construct a JSONObject from a source JSON text string with custom json parse configurations.
-     * This is the most commonly used JSONObject constructor.
+     * Construct a JSONObject from a source JSON text string with custom json parse configurations. This is the most
+     * commonly used JSONObject constructor.
      *
-     * @param source
-     *            A string beginning with <code>{</code>&nbsp;<small>(left
-     *            brace)</small> and ending with <code>}</code>
-     *            &nbsp;<small>(right brace)</small>.
-     * @param jsonParserConfiguration
-     *            Variable to pass parser custom configuration for json parsing.
-     * @exception JSONException
-     *                If there is a syntax error in the source string or a
-     *                duplicated key.
+     * @param source                  A string beginning with <code>{</code>&nbsp;<small>(left brace)</small> and ending
+     *                                with <code>}</code> &nbsp;<small>(right brace)</small>.
+     * @param jsonParserConfiguration Variable to pass parser custom configuration for json parsing.
+     * @throws JSONException If there is a syntax error in the source string or a duplicated key.
      */
     public JSONObject(String source, JSONParserConfiguration jsonParserConfiguration) throws JSONException {
         this(new JSONTokener(source), jsonParserConfiguration);
@@ -456,17 +425,14 @@ public class JSONObject {
     /**
      * Construct a JSONObject from a ResourceBundle.
      *
-     * @param baseName
-     *            The ResourceBundle base name.
-     * @param locale
-     *            The Locale to load the ResourceBundle for.
-     * @throws JSONException
-     *             If any JSONExceptions are detected.
+     * @param baseName The ResourceBundle base name.
+     * @param locale   The Locale to load the ResourceBundle for.
+     * @throws JSONException If any JSONExceptions are detected.
      */
     public JSONObject(String baseName, Locale locale) throws JSONException {
         this();
         ResourceBundle bundle = ResourceBundle.getBundle(baseName, locale,
-                Thread.currentThread().getContextClassLoader());
+            Thread.currentThread().getContextClassLoader());
 
 // Iterate through the keys in the bundle.
 
@@ -497,44 +463,36 @@ public class JSONObject {
     }
 
     /**
-     * Constructor to specify an initial capacity of the internal map. Useful for library
-     * internal calls where we know, or at least can best guess, how big this JSONObject
-     * will be.
+     * Constructor to specify an initial capacity of the internal map. Useful for library internal calls where we know,
+     * or at least can best guess, how big this JSONObject will be.
      *
      * @param initialCapacity initial capacity of the internal map.
      */
-    protected JSONObject(int initialCapacity){
+    protected JSONObject(int initialCapacity) {
         this.map = new HashMap<String, Object>(initialCapacity);
     }
 
     /**
-     * Accumulate values under a key. It is similar to the put method except
-     * that if there is already an object stored under the key then a JSONArray
-     * is stored under the key to hold all of the accumulated values. If there
-     * is already a JSONArray, then the new value is appended to it. In
-     * contrast, the put method replaces the previous value.
+     * Accumulate values under a key. It is similar to the put method except that if there is already an object stored
+     * under the key then a JSONArray is stored under the key to hold all of the accumulated values. If there is already
+     * a JSONArray, then the new value is appended to it. In contrast, the put method replaces the previous value.
+     * <p>
+     * If only one value is accumulated that is not a JSONArray, then the result will be the same as using put. But if
+     * multiple values are accumulated, then the result will be like append.
      *
-     * If only one value is accumulated that is not a JSONArray, then the result
-     * will be the same as using put. But if multiple values are accumulated,
-     * then the result will be like append.
-     *
-     * @param key
-     *            A key string.
-     * @param value
-     *            An object to be accumulated under the key.
+     * @param key   A key string.
+     * @param value An object to be accumulated under the key.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject accumulate(String key, Object value) throws JSONException {
         testValidity(value);
         Object object = this.opt(key);
         if (object == null) {
             this.put(key,
-                    value instanceof JSONArray ? new JSONArray().put(value)
-                            : value);
+                value instanceof JSONArray ? new JSONArray().put(value)
+                    : value);
         } else if (object instanceof JSONArray) {
             ((JSONArray) object).put(value);
         } else {
@@ -544,21 +502,16 @@ public class JSONObject {
     }
 
     /**
-     * Append values to the array under a key. If the key does not exist in the
-     * JSONObject, then the key is put in the JSONObject with its value being a
-     * JSONArray containing the value parameter. If the key was already
-     * associated with a JSONArray, then the value parameter is appended to it.
+     * Append values to the array under a key. If the key does not exist in the JSONObject, then the key is put in the
+     * JSONObject with its value being a JSONArray containing the value parameter. If the key was already associated
+     * with a JSONArray, then the value parameter is appended to it.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            An object to be accumulated under the key.
+     * @param key   A key string.
+     * @param value An object to be accumulated under the key.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number or if the current value associated with
-     *             the key is not a JSONArray.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number or if the current value associated with the key is
+     *                              not a JSONArray.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject append(String key, Object value) throws JSONException {
         testValidity(value);
@@ -574,11 +527,9 @@ public class JSONObject {
     }
 
     /**
-     * Produce a string from a double. The string "null" will be returned if the
-     * number is not finite.
+     * Produce a string from a double. The string "null" will be returned if the number is not finite.
      *
-     * @param d
-     *            A double.
+     * @param d A double.
      * @return A String.
      */
     public static String doubleToString(double d) {
@@ -590,7 +541,7 @@ public class JSONObject {
 
         String string = Double.toString(d);
         if (string.indexOf('.') > 0 && string.indexOf('e') < 0
-                && string.indexOf('E') < 0) {
+            && string.indexOf('E') < 0) {
             while (string.endsWith("0")) {
                 string = string.substring(0, string.length() - 1);
             }
@@ -604,11 +555,9 @@ public class JSONObject {
     /**
      * Get the value object associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The object associated with the key.
-     * @throws JSONException
-     *             if the key is not found.
+     * @throws JSONException if the key is not found.
      */
     public Object get(String key) throws JSONException {
         if (key == null) {
@@ -624,20 +573,15 @@ public class JSONObject {
     /**
      * Get the enum value associated with a key.
      *
-     * @param <E>
-     *            Enum Type
-     * @param clazz
-     *           The type of enum to retrieve.
-     * @param key
-     *           A key string.
+     * @param <E>   Enum Type
+     * @param clazz The type of enum to retrieve.
+     * @param key   A key string.
      * @return The enum value associated with the key
-     * @throws JSONException
-     *             if the key is not found or if the value cannot be converted
-     *             to an enum.
+     * @throws JSONException if the key is not found or if the value cannot be converted to an enum.
      */
     public <E extends Enum<E>> E getEnum(Class<E> clazz, String key) throws JSONException {
         E val = optEnum(clazz, key);
-        if(val==null) {
+        if (val == null) {
             // JSONException should really take a throwable argument.
             // If it did, I would re-implement this with the Enum.valueOf
             // method and place any thrown exception in the JSONException
@@ -649,22 +593,19 @@ public class JSONObject {
     /**
      * Get the boolean value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The truth.
-     * @throws JSONException
-     *             if the value is not a Boolean or the String "true" or
-     *             "false".
+     * @throws JSONException if the value is not a Boolean or the String "true" or "false".
      */
     public boolean getBoolean(String key) throws JSONException {
         Object object = this.get(key);
         if (object.equals(Boolean.FALSE)
-                || (object instanceof String && ((String) object)
-                        .equalsIgnoreCase("false"))) {
+            || (object instanceof String && ((String) object)
+            .equalsIgnoreCase("false"))) {
             return false;
         } else if (object.equals(Boolean.TRUE)
-                || (object instanceof String && ((String) object)
-                        .equalsIgnoreCase("true"))) {
+            || (object instanceof String && ((String) object)
+            .equalsIgnoreCase("true"))) {
             return true;
         }
         throw wrongValueFormatException(key, "Boolean", object, null);
@@ -673,12 +614,9 @@ public class JSONObject {
     /**
      * Get the BigInteger value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value cannot
-     *             be converted to BigInteger.
+     * @throws JSONException if the key is not found or if the value cannot be converted to BigInteger.
      */
     public BigInteger getBigInteger(String key) throws JSONException {
         Object object = this.get(key);
@@ -690,17 +628,13 @@ public class JSONObject {
     }
 
     /**
-     * Get the BigDecimal value associated with a key. If the value is float or
-     * double, the {@link BigDecimal#BigDecimal(double)} constructor will
-     * be used. See notes on the constructor for conversion issues that may
-     * arise.
+     * Get the BigDecimal value associated with a key. If the value is float or double, the
+     * {@link BigDecimal#BigDecimal(double)} constructor will be used. See notes on the constructor for conversion
+     * issues that may arise.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value
-     *             cannot be converted to BigDecimal.
+     * @throws JSONException if the key is not found or if the value cannot be converted to BigDecimal.
      */
     public BigDecimal getBigDecimal(String key) throws JSONException {
         Object object = this.get(key);
@@ -714,17 +648,15 @@ public class JSONObject {
     /**
      * Get the double value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a Number
-     *             object and cannot be converted to a number.
+     * @throws JSONException if the key is not found or if the value is not a Number object and cannot be converted to a
+     *                       number.
      */
     public double getDouble(String key) throws JSONException {
         final Object object = this.get(key);
-        if(object instanceof Number) {
-            return ((Number)object).doubleValue();
+        if (object instanceof Number) {
+            return ((Number) object).doubleValue();
         }
         try {
             return Double.parseDouble(object.toString());
@@ -736,17 +668,15 @@ public class JSONObject {
     /**
      * Get the float value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a Number
-     *             object and cannot be converted to a number.
+     * @throws JSONException if the key is not found or if the value is not a Number object and cannot be converted to a
+     *                       number.
      */
     public float getFloat(String key) throws JSONException {
         final Object object = this.get(key);
-        if(object instanceof Number) {
-            return ((Number)object).floatValue();
+        if (object instanceof Number) {
+            return ((Number) object).floatValue();
         }
         try {
             return Float.parseFloat(object.toString());
@@ -758,18 +688,16 @@ public class JSONObject {
     /**
      * Get the Number value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a Number
-     *             object and cannot be converted to a number.
+     * @throws JSONException if the key is not found or if the value is not a Number object and cannot be converted to a
+     *                       number.
      */
     public Number getNumber(String key) throws JSONException {
         Object object = this.get(key);
         try {
             if (object instanceof Number) {
-                return (Number)object;
+                return (Number) object;
             }
             return stringToNumber(object.toString());
         } catch (Exception e) {
@@ -780,17 +708,14 @@ public class JSONObject {
     /**
      * Get the int value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The integer value.
-     * @throws JSONException
-     *             if the key is not found or if the value cannot be converted
-     *             to an integer.
+     * @throws JSONException if the key is not found or if the value cannot be converted to an integer.
      */
     public int getInt(String key) throws JSONException {
         final Object object = this.get(key);
-        if(object instanceof Number) {
-            return ((Number)object).intValue();
+        if (object instanceof Number) {
+            return ((Number) object).intValue();
         }
         try {
             return Integer.parseInt(object.toString());
@@ -802,11 +727,9 @@ public class JSONObject {
     /**
      * Get the JSONArray value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return A JSONArray which is the value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a JSONArray.
+     * @throws JSONException if the key is not found or if the value is not a JSONArray.
      */
     public JSONArray getJSONArray(String key) throws JSONException {
         Object object = this.get(key);
@@ -819,11 +742,9 @@ public class JSONObject {
     /**
      * Get the JSONObject value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return A JSONObject which is the value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a JSONObject.
+     * @throws JSONException if the key is not found or if the value is not a JSONObject.
      */
     public JSONObject getJSONObject(String key) throws JSONException {
         Object object = this.get(key);
@@ -836,17 +757,14 @@ public class JSONObject {
     /**
      * Get the long value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The long value.
-     * @throws JSONException
-     *             if the key is not found or if the value cannot be converted
-     *             to a long.
+     * @throws JSONException if the key is not found or if the value cannot be converted to a long.
      */
     public long getLong(String key) throws JSONException {
         final Object object = this.get(key);
-        if(object instanceof Number) {
-            return ((Number)object).longValue();
+        if (object instanceof Number) {
+            return ((Number) object).longValue();
         }
         try {
             return Long.parseLong(object.toString());
@@ -858,8 +776,7 @@ public class JSONObject {
     /**
      * Get an array of field names from a JSONObject.
      *
-     * @param jo
-     *            JSON object
+     * @param jo JSON object
      * @return An array of field names, or null if there are no names.
      */
     public static String[] getNames(JSONObject jo) {
@@ -872,8 +789,7 @@ public class JSONObject {
     /**
      * Get an array of public field names from an Object.
      *
-     * @param object
-     *            object to read
+     * @param object object to read
      * @return An array of field names, or null if there are no names.
      */
     public static String[] getNames(Object object) {
@@ -896,11 +812,9 @@ public class JSONObject {
     /**
      * Get the string associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return A string which is the value.
-     * @throws JSONException
-     *             if there is no string value for the key.
+     * @throws JSONException if there is no string value for the key.
      */
     public String getString(String key) throws JSONException {
         Object object = this.get(key);
@@ -913,8 +827,7 @@ public class JSONObject {
     /**
      * Determine if the JSONObject contains a specific key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return true if the key exists in the JSONObject.
      */
     public boolean has(String key) {
@@ -922,19 +835,15 @@ public class JSONObject {
     }
 
     /**
-     * Increment a property of a JSONObject. If there is no such property,
-     * create one with a value of 1 (Integer). If there is such a property, and if it is
-     * an Integer, Long, Double, Float, BigInteger, or BigDecimal then add one to it.
-     * No overflow bounds checking is performed, so callers should initialize the key
-     * prior to this call with an appropriate type that can handle the maximum expected
-     * value.
+     * Increment a property of a JSONObject. If there is no such property, create one with a value of 1 (Integer). If
+     * there is such a property, and if it is an Integer, Long, Double, Float, BigInteger, or BigDecimal then add one to
+     * it. No overflow bounds checking is performed, so callers should initialize the key prior to this call with an
+     * appropriate type that can handle the maximum expected value.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return this.
-     * @throws JSONException
-     *             If there is already a property with this name that is not an
-     *             Integer, Long, Double, or Float.
+     * @throws JSONException If there is already a property with this name that is not an Integer, Long, Double, or
+     *                       Float.
      */
     public JSONObject increment(String key) throws JSONException {
         Object value = this.opt(key);
@@ -945,13 +854,13 @@ public class JSONObject {
         } else if (value instanceof Long) {
             this.put(key, ((Long) value).longValue() + 1L);
         } else if (value instanceof BigInteger) {
-            this.put(key, ((BigInteger)value).add(BigInteger.ONE));
+            this.put(key, ((BigInteger) value).add(BigInteger.ONE));
         } else if (value instanceof Float) {
             this.put(key, ((Float) value).floatValue() + 1.0f);
         } else if (value instanceof Double) {
             this.put(key, ((Double) value).doubleValue() + 1.0d);
         } else if (value instanceof BigDecimal) {
-            this.put(key, ((BigDecimal)value).add(BigDecimal.ONE));
+            this.put(key, ((BigDecimal) value).add(BigDecimal.ONE));
         } else {
             throw new JSONException("Unable to increment [" + quote(key) + "].");
         }
@@ -959,53 +868,45 @@ public class JSONObject {
     }
 
     /**
-     * Determine if the value associated with the key is <code>null</code> or if there is no
-     * value.
+     * Determine if the value associated with the key is <code>null</code> or if there is no value.
      *
-     * @param key
-     *            A key string.
-     * @return true if there is no value associated with the key or if the value
-     *        is the JSONObject.NULL object.
+     * @param key A key string.
+     * @return true if there is no value associated with the key or if the value is the JSONObject.NULL object.
      */
     public boolean isNull(String key) {
         return JSONObject.NULL.equals(this.opt(key));
     }
 
     /**
-     * Get an enumeration of the keys of the JSONObject. Modifying this key Set will also
-     * modify the JSONObject. Use with caution.
-     *
-     * @see Set#iterator()
+     * Get an enumeration of the keys of the JSONObject. Modifying this key Set will also modify the JSONObject. Use
+     * with caution.
      *
      * @return An iterator of the keys.
+     * @see Set#iterator()
      */
     public Iterator<String> keys() {
         return this.keySet().iterator();
     }
 
     /**
-     * Get a set of keys of the JSONObject. Modifying this key Set will also modify the
-     * JSONObject. Use with caution.
-     *
-     * @see Map#keySet()
+     * Get a set of keys of the JSONObject. Modifying this key Set will also modify the JSONObject. Use with caution.
      *
      * @return A keySet.
+     * @see Map#keySet()
      */
     public Set<String> keySet() {
         return this.map.keySet();
     }
 
     /**
-     * Get a set of entries of the JSONObject. These are raw values and may not
-     * match what is returned by the JSONObject get* and opt* functions. Modifying
-     * the returned EntrySet or the Entry objects contained therein will modify the
+     * Get a set of entries of the JSONObject. These are raw values and may not match what is returned by the JSONObject
+     * get* and opt* functions. Modifying the returned EntrySet or the Entry objects contained therein will modify the
      * backing JSONObject. This does not return a clone or a read-only view.
-     *
+     * <p>
      * Use with caution.
      *
-     * @see Map#entrySet()
-     *
      * @return An Entry Set
+     * @see Map#entrySet()
      */
     protected Set<Entry<String, Object>> entrySet() {
         return this.map.entrySet();
@@ -1021,8 +922,7 @@ public class JSONObject {
     }
 
     /**
-     * Removes all of the elements from this JSONObject.
-     * The JSONObject will be empty after this call returns.
+     * Removes all of the elements from this JSONObject. The JSONObject will be empty after this call returns.
      */
     public void clear() {
         this.map.clear();
@@ -1038,27 +938,23 @@ public class JSONObject {
     }
 
     /**
-     * Produce a JSONArray containing the names of the elements of this
-     * JSONObject.
+     * Produce a JSONArray containing the names of the elements of this JSONObject.
      *
-     * @return A JSONArray containing the key strings, or null if the JSONObject
-     *        is empty.
+     * @return A JSONArray containing the key strings, or null if the JSONObject is empty.
      */
     public JSONArray names() {
-    	if(this.map.isEmpty()) {
-    		return null;
-    	}
+        if (this.map.isEmpty()) {
+            return null;
+        }
         return new JSONArray(this.map.keySet());
     }
 
     /**
      * Produce a string from a Number.
      *
-     * @param number
-     *            A Number
+     * @param number A Number
      * @return A String.
-     * @throws JSONException
-     *             If n is a non-finite number.
+     * @throws JSONException If n is a non-finite number.
      */
     public static String numberToString(Number number) throws JSONException {
         if (number == null) {
@@ -1070,7 +966,7 @@ public class JSONObject {
 
         String string = number.toString();
         if (string.indexOf('.') > 0 && string.indexOf('e') < 0
-                && string.indexOf('E') < 0) {
+            && string.indexOf('E') < 0) {
             while (string.endsWith("0")) {
                 string = string.substring(0, string.length() - 1);
             }
@@ -1084,8 +980,7 @@ public class JSONObject {
     /**
      * Get an optional value associated with a key.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return An object which is the value, or null if there is no value.
      */
     public Object opt(String key) {
@@ -1095,12 +990,9 @@ public class JSONObject {
     /**
      * Get the enum value associated with a key.
      *
-     * @param <E>
-     *            Enum Type
-     * @param clazz
-     *            The type of enum to retrieve.
-     * @param key
-     *            A key string.
+     * @param <E>   Enum Type
+     * @param clazz The type of enum to retrieve.
+     * @param key   A key string.
      * @return The enum value associated with the key or null if not found
      */
     public <E extends Enum<E>> E optEnum(Class<E> clazz, String key) {
@@ -1110,16 +1002,12 @@ public class JSONObject {
     /**
      * Get the enum value associated with a key.
      *
-     * @param <E>
-     *            Enum Type
-     * @param clazz
-     *            The type of enum to retrieve.
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default in case the value is not found
-     * @return The enum value associated with the key or defaultValue
-     *            if the value is not found or cannot be assigned to <code>clazz</code>
+     * @param <E>          Enum Type
+     * @param clazz        The type of enum to retrieve.
+     * @param key          A key string.
+     * @param defaultValue The default in case the value is not found
+     * @return The enum value associated with the key or defaultValue if the value is not found or cannot be assigned to
+     * <code>clazz</code>
      */
     public <E extends Enum<E>> E optEnum(Class<E> clazz, String key, E defaultValue) {
         try {
@@ -1142,11 +1030,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional boolean associated with a key. It returns false if there
-     * is no such key, or if the value is not Boolean.TRUE or the String "true".
+     * Get an optional boolean associated with a key. It returns false if there is no such key, or if the value is not
+     * Boolean.TRUE or the String "true".
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The truth.
      */
     public boolean optBoolean(String key) {
@@ -1154,14 +1041,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional boolean associated with a key. It returns the
-     * defaultValue if there is no such key, or if it is not a Boolean or the
-     * String "true" or "false" (case insensitive).
+     * Get an optional boolean associated with a key. It returns the defaultValue if there is no such key, or if it is
+     * not a Boolean or the String "true" or "false" (case insensitive).
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return The truth.
      */
     public boolean optBoolean(String key, boolean defaultValue) {
@@ -1169,7 +1053,7 @@ public class JSONObject {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof Boolean){
+        if (val instanceof Boolean) {
             return ((Boolean) val).booleanValue();
         }
         try {
@@ -1181,11 +1065,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional boolean object associated with a key. It returns false if there
-     * is no such key, or if the value is not Boolean.TRUE or the String "true".
+     * Get an optional boolean object associated with a key. It returns false if there is no such key, or if the value
+     * is not Boolean.TRUE or the String "true".
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The truth.
      */
     public Boolean optBooleanObject(String key) {
@@ -1193,14 +1076,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional boolean object associated with a key. It returns the
-     * defaultValue if there is no such key, or if it is not a Boolean or the
-     * String "true" or "false" (case insensitive).
+     * Get an optional boolean object associated with a key. It returns the defaultValue if there is no such key, or if
+     * it is not a Boolean or the String "true" or "false" (case insensitive).
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return The truth.
      */
     public Boolean optBooleanObject(String key, Boolean defaultValue) {
@@ -1208,7 +1088,7 @@ public class JSONObject {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof Boolean){
+        if (val instanceof Boolean) {
             return ((Boolean) val).booleanValue();
         }
         try {
@@ -1220,17 +1100,13 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional BigDecimal associated with a key, or the defaultValue if
-     * there is no such key or if its value is not a number. If the value is a
-     * string, an attempt will be made to evaluate it as a number. If the value
-     * is float or double, then the {@link BigDecimal#BigDecimal(double)}
-     * constructor will be used. See notes on the constructor for conversion
-     * issues that may arise.
+     * Get an optional BigDecimal associated with a key, or the defaultValue if there is no such key or if its value is
+     * not a number. If the value is a string, an attempt will be made to evaluate it as a number. If the value is float
+     * or double, then the {@link BigDecimal#BigDecimal(double)} constructor will be used. See notes on the constructor
+     * for conversion issues that may arise.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public BigDecimal optBigDecimal(String key, BigDecimal defaultValue) {
@@ -1239,39 +1115,38 @@ public class JSONObject {
     }
 
     /**
-     * @param val value to convert
+     * @param val          value to convert
      * @param defaultValue default value to return is the conversion doesn't work or is null.
-     * @return BigDecimal conversion of the original value, or the defaultValue if unable
-     *          to convert.
+     * @return BigDecimal conversion of the original value, or the defaultValue if unable to convert.
      */
     static BigDecimal objectToBigDecimal(Object val, BigDecimal defaultValue) {
         return objectToBigDecimal(val, defaultValue, true);
     }
 
     /**
-     * @param val value to convert
+     * @param val          value to convert
      * @param defaultValue default value to return is the conversion doesn't work or is null.
-     * @param exact When <code>true</code>, then {@link Double} and {@link Float} values will be converted exactly.
-     *      When <code>false</code>, they will be converted to {@link String} values before converting to {@link BigDecimal}.
-     * @return BigDecimal conversion of the original value, or the defaultValue if unable
-     *          to convert.
+     * @param exact        When <code>true</code>, then {@link Double} and {@link Float} values will be converted
+     *                     exactly. When <code>false</code>, they will be converted to {@link String} values before
+     *                     converting to {@link BigDecimal}.
+     * @return BigDecimal conversion of the original value, or the defaultValue if unable to convert.
      */
     static BigDecimal objectToBigDecimal(Object val, BigDecimal defaultValue, boolean exact) {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof BigDecimal){
+        if (val instanceof BigDecimal) {
             return (BigDecimal) val;
         }
-        if (val instanceof BigInteger){
+        if (val instanceof BigInteger) {
             return new BigDecimal((BigInteger) val);
         }
-        if (val instanceof Double || val instanceof Float){
-            if (!numberIsFinite((Number)val)) {
+        if (val instanceof Double || val instanceof Float) {
+            if (!numberIsFinite((Number) val)) {
                 return defaultValue;
             }
             if (exact) {
-                return new BigDecimal(((Number)val).doubleValue());
+                return new BigDecimal(((Number) val).doubleValue());
             }
             // use the string constructor so that we maintain "nice" values for doubles and floats
             // the double constructor will translate doubles to "exact" values instead of the likely
@@ -1279,7 +1154,7 @@ public class JSONObject {
             return new BigDecimal(val.toString());
         }
         if (val instanceof Long || val instanceof Integer
-                || val instanceof Short || val instanceof Byte){
+            || val instanceof Short || val instanceof Byte) {
             return new BigDecimal(((Number) val).longValue());
         }
         // don't check if it's a string in case of unchecked Number subclasses
@@ -1291,14 +1166,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional BigInteger associated with a key, or the defaultValue if
-     * there is no such key or if its value is not a number. If the value is a
-     * string, an attempt will be made to evaluate it as a number.
+     * Get an optional BigInteger associated with a key, or the defaultValue if there is no such key or if its value is
+     * not a number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public BigInteger optBigInteger(String key, BigInteger defaultValue) {
@@ -1307,29 +1179,28 @@ public class JSONObject {
     }
 
     /**
-     * @param val value to convert
+     * @param val          value to convert
      * @param defaultValue default value to return is the conversion doesn't work or is null.
-     * @return BigInteger conversion of the original value, or the defaultValue if unable
-     *          to convert.
+     * @return BigInteger conversion of the original value, or the defaultValue if unable to convert.
      */
     static BigInteger objectToBigInteger(Object val, BigInteger defaultValue) {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof BigInteger){
+        if (val instanceof BigInteger) {
             return (BigInteger) val;
         }
-        if (val instanceof BigDecimal){
+        if (val instanceof BigDecimal) {
             return ((BigDecimal) val).toBigInteger();
         }
-        if (val instanceof Double || val instanceof Float){
-            if (!numberIsFinite((Number)val)) {
+        if (val instanceof Double || val instanceof Float) {
+            if (!numberIsFinite((Number) val)) {
                 return defaultValue;
             }
             return new BigDecimal(((Number) val).doubleValue()).toBigInteger();
         }
         if (val instanceof Long || val instanceof Integer
-                || val instanceof Short || val instanceof Byte){
+            || val instanceof Short || val instanceof Byte) {
             return BigInteger.valueOf(((Number) val).longValue());
         }
         // don't check if it's a string in case of unchecked Number subclasses
@@ -1340,7 +1211,7 @@ public class JSONObject {
             // this conversion to BigDecimal then to BigInteger is to maintain
             // that type cast support that may truncate the decimal.
             final String valStr = val.toString();
-            if(isDecimalNotation(valStr)) {
+            if (isDecimalNotation(valStr)) {
                 return new BigDecimal(valStr).toBigInteger();
             }
             return new BigInteger(valStr);
@@ -1350,12 +1221,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional double associated with a key, or NaN if there is no such
-     * key or if its value is not a number. If the value is a string, an attempt
-     * will be made to evaluate it as a number.
+     * Get an optional double associated with a key, or NaN if there is no such key or if its value is not a number. If
+     * the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A string which is the key.
+     * @param key A string which is the key.
      * @return An object which is the value.
      */
     public double optDouble(String key) {
@@ -1363,14 +1232,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional double associated with a key, or the defaultValue if
-     * there is no such key or if its value is not a number. If the value is a
-     * string, an attempt will be made to evaluate it as a number.
+     * Get an optional double associated with a key, or the defaultValue if there is no such key or if its value is not
+     * a number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public double optDouble(String key, double defaultValue) {
@@ -1382,12 +1248,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Double object associated with a key, or NaN if there is no such
-     * key or if its value is not a number. If the value is a string, an attempt
-     * will be made to evaluate it as a number.
+     * Get an optional Double object associated with a key, or NaN if there is no such key or if its value is not a
+     * number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A string which is the key.
+     * @param key A string which is the key.
      * @return An object which is the value.
      */
     public Double optDoubleObject(String key) {
@@ -1395,14 +1259,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Double object associated with a key, or the defaultValue if
-     * there is no such key or if its value is not a number. If the value is a
-     * string, an attempt will be made to evaluate it as a number.
+     * Get an optional Double object associated with a key, or the defaultValue if there is no such key or if its value
+     * is not a number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public Double optDoubleObject(String key, Double defaultValue) {
@@ -1414,12 +1275,10 @@ public class JSONObject {
     }
 
     /**
-     * Get the optional float value associated with an index. NaN is returned
-     * if there is no value for the index, or if the value is not a number and
-     * cannot be converted to a number.
+     * Get the optional float value associated with an index. NaN is returned if there is no value for the index, or if
+     * the value is not a number and cannot be converted to a number.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The value.
      */
     public float optFloat(String key) {
@@ -1427,14 +1286,11 @@ public class JSONObject {
     }
 
     /**
-     * Get the optional float value associated with an index. The defaultValue
-     * is returned if there is no value for the index, or if the value is not a
-     * number and cannot be converted to a number.
+     * Get the optional float value associated with an index. The defaultValue is returned if there is no value for the
+     * index, or if the value is not a number and cannot be converted to a number.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default value.
+     * @param key          A key string.
+     * @param defaultValue The default value.
      * @return The value.
      */
     public float optFloat(String key, float defaultValue) {
@@ -1450,12 +1306,10 @@ public class JSONObject {
     }
 
     /**
-     * Get the optional Float object associated with an index. NaN is returned
-     * if there is no value for the index, or if the value is not a number and
-     * cannot be converted to a number.
+     * Get the optional Float object associated with an index. NaN is returned if there is no value for the index, or if
+     * the value is not a number and cannot be converted to a number.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return The object.
      */
     public Float optFloatObject(String key) {
@@ -1463,14 +1317,11 @@ public class JSONObject {
     }
 
     /**
-     * Get the optional Float object associated with an index. The defaultValue
-     * is returned if there is no value for the index, or if the value is not a
-     * number and cannot be converted to a number.
+     * Get the optional Float object associated with an index. The defaultValue is returned if there is no value for the
+     * index, or if the value is not a number and cannot be converted to a number.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default object.
+     * @param key          A key string.
+     * @param defaultValue The default object.
      * @return The object.
      */
     public Float optFloatObject(String key, Float defaultValue) {
@@ -1486,12 +1337,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional int value associated with a key, or zero if there is no
-     * such key or if the value is not a number. If the value is a string, an
-     * attempt will be made to evaluate it as a number.
+     * Get an optional int value associated with a key, or zero if there is no such key or if the value is not a number.
+     * If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return An object which is the value.
      */
     public int optInt(String key) {
@@ -1499,14 +1348,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional int value associated with a key, or the default if there
-     * is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number.
+     * Get an optional int value associated with a key, or the default if there is no such key or if the value is not a
+     * number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public int optInt(String key, int defaultValue) {
@@ -1518,12 +1364,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Integer object associated with a key, or zero if there is no
-     * such key or if the value is not a number. If the value is a string, an
-     * attempt will be made to evaluate it as a number.
+     * Get an optional Integer object associated with a key, or zero if there is no such key or if the value is not a
+     * number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return An object which is the value.
      */
     public Integer optIntegerObject(String key) {
@@ -1531,14 +1375,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Integer object associated with a key, or the default if there
-     * is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number.
+     * Get an optional Integer object associated with a key, or the default if there is no such key or if the value is
+     * not a number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public Integer optIntegerObject(String key, Integer defaultValue) {
@@ -1550,11 +1391,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional JSONArray associated with a key. It returns null if there
-     * is no such key, or if its value is not a JSONArray.
+     * Get an optional JSONArray associated with a key. It returns null if there is no such key, or if its value is not
+     * a JSONArray.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return A JSONArray which is the value.
      */
     public JSONArray optJSONArray(String key) {
@@ -1562,13 +1402,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional JSONArray associated with a key, or the default if there
-     * is no such key, or if its value is not a JSONArray.
+     * Get an optional JSONArray associated with a key, or the default if there is no such key, or if its value is not a
+     * JSONArray.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return A JSONArray which is the value.
      */
     public JSONArray optJSONArray(String key, JSONArray defaultValue) {
@@ -1577,23 +1415,22 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional JSONObject associated with a key. It returns null if
-     * there is no such key, or if its value is not a JSONObject.
+     * Get an optional JSONObject associated with a key. It returns null if there is no such key, or if its value is not
+     * a JSONObject.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return A JSONObject which is the value.
      */
-    public JSONObject optJSONObject(String key) { return this.optJSONObject(key, null); }
+    public JSONObject optJSONObject(String key) {
+        return this.optJSONObject(key, null);
+    }
 
     /**
-     * Get an optional JSONObject associated with a key, or the default if there
-     * is no such key or if the value is not a JSONObject.
+     * Get an optional JSONObject associated with a key, or the default if there is no such key or if the value is not a
+     * JSONObject.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An JSONObject which is the value.
      */
     public JSONObject optJSONObject(String key, JSONObject defaultValue) {
@@ -1602,12 +1439,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional long value associated with a key, or zero if there is no
-     * such key or if the value is not a number. If the value is a string, an
-     * attempt will be made to evaluate it as a number.
+     * Get an optional long value associated with a key, or zero if there is no such key or if the value is not a
+     * number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return An object which is the value.
      */
     public long optLong(String key) {
@@ -1615,14 +1450,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional long value associated with a key, or the default if there
-     * is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number.
+     * Get an optional long value associated with a key, or the default if there is no such key or if the value is not a
+     * number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public long optLong(String key, long defaultValue) {
@@ -1635,12 +1467,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Long object associated with a key, or zero if there is no
-     * such key or if the value is not a number. If the value is a string, an
-     * attempt will be made to evaluate it as a number.
+     * Get an optional Long object associated with a key, or zero if there is no such key or if the value is not a
+     * number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return An object which is the value.
      */
     public Long optLongObject(String key) {
@@ -1648,14 +1478,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Long object associated with a key, or the default if there
-     * is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number.
+     * Get an optional Long object associated with a key, or the default if there is no such key or if the value is not
+     * a number. If the value is a string, an attempt will be made to evaluate it as a number.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public Long optLongObject(String key, Long defaultValue) {
@@ -1668,13 +1495,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional {@link Number} value associated with a key, or <code>null</code>
-     * if there is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number ({@link BigDecimal}). This method
-     * would be used in cases where type coercion of the number value is unwanted.
+     * Get an optional {@link Number} value associated with a key, or <code>null</code> if there is no such key or if
+     * the value is not a number. If the value is a string, an attempt will be made to evaluate it as a number
+     * ({@link BigDecimal}). This method would be used in cases where type coercion of the number value is unwanted.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return An object which is the value.
      */
     public Number optNumber(String key) {
@@ -1682,15 +1507,12 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional {@link Number} value associated with a key, or the default if there
-     * is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number. This method
+     * Get an optional {@link Number} value associated with a key, or the default if there is no such key or if the
+     * value is not a number. If the value is a string, an attempt will be made to evaluate it as a number. This method
      * would be used in cases where type coercion of the number value is unwanted.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return An object which is the value.
      */
     public Number optNumber(String key, Number defaultValue) {
@@ -1698,7 +1520,7 @@ public class JSONObject {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof Number){
+        if (val instanceof Number) {
             return (Number) val;
         }
 
@@ -1710,12 +1532,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional string associated with a key. It returns an empty string
-     * if there is no such key. If the value is not a string and is not null,
-     * then it is converted to a string.
+     * Get an optional string associated with a key. It returns an empty string if there is no such key. If the value is
+     * not a string and is not null, then it is converted to a string.
      *
-     * @param key
-     *            A key string.
+     * @param key A key string.
      * @return A string which is the value.
      */
     public String optString(String key) {
@@ -1723,13 +1543,10 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional string associated with a key. It returns the defaultValue
-     * if there is no such key.
+     * Get an optional string associated with a key. It returns the defaultValue if there is no such key.
      *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
+     * @param key          A key string.
+     * @param defaultValue The default.
      * @return A string which is the value.
      */
     public String optString(String key, String defaultValue) {
@@ -1738,15 +1555,11 @@ public class JSONObject {
     }
 
     /**
-     * Populates the internal map of the JSONObject with the bean properties. The
-     * bean can not be recursive.
+     * Populates the internal map of the JSONObject with the bean properties. The bean can not be recursive.
      *
+     * @param bean the bean
+     * @throws JSONException If a getter returned a non-finite number.
      * @see JSONObject#JSONObject(Object)
-     *
-     * @param bean
-     *            the bean
-     * @throws JSONException
-     *            If a getter returned a non-finite number.
      */
     private void populateMap(Object bean) {
         populateMap(bean, Collections.newSetFromMap(new IdentityHashMap<Object, Boolean>()));
@@ -1763,11 +1576,11 @@ public class JSONObject {
         for (final Method method : methods) {
             final int modifiers = method.getModifiers();
             if (Modifier.isPublic(modifiers)
-                    && !Modifier.isStatic(modifiers)
-                    && method.getParameterTypes().length == 0
-                    && !method.isBridge()
-                    && method.getReturnType() != Void.TYPE
-                    && isValidMethodName(method.getName())) {
+                && !Modifier.isStatic(modifiers)
+                && method.getParameterTypes().length == 0
+                && !method.isBridge()
+                && method.getReturnType() != Void.TYPE
+                && isValidMethodName(method.getName())) {
                 final String key = getKeyNameFromMethod(method);
                 if (key != null && !key.isEmpty()) {
                     try {
@@ -1848,18 +1661,14 @@ public class JSONObject {
     }
 
     /**
-     * Searches the class hierarchy to see if the method or it's super
-     * implementations and interfaces has the annotation.
+     * Searches the class hierarchy to see if the method or it's super implementations and interfaces has the
+     * annotation.
      *
-     * @param <A>
-     *            type of the annotation
-     *
-     * @param m
-     *            method to check
-     * @param annotationClass
-     *            annotation to look for
-     * @return the {@link Annotation} if the annotation exists on the current method
-     *         or one of its super class definitions
+     * @param <A>             type of the annotation
+     * @param m               method to check
+     * @param annotationClass annotation to look for
+     * @return the {@link Annotation} if the annotation exists on the current method or one of its super class
+     * definitions
      */
     private static <A extends Annotation> A getAnnotation(final Method m, final Class<A> annotationClass) {
         // if we have invalid data the result is null
@@ -1890,13 +1699,14 @@ public class JSONObject {
         }
 
         //If the superclass is Object, no annotations will be found any more
-        if (c.getSuperclass().equals(Object.class))
+        if (c.getSuperclass().equals(Object.class)) {
             return null;
+        }
 
         try {
             return getAnnotation(
-                    c.getSuperclass().getMethod(m.getName(), m.getParameterTypes()),
-                    annotationClass);
+                c.getSuperclass().getMethod(m.getName(), m.getParameterTypes()),
+                annotationClass);
         } catch (final SecurityException ex) {
             return null;
         } catch (final NoSuchMethodException ex) {
@@ -1905,14 +1715,11 @@ public class JSONObject {
     }
 
     /**
-     * Searches the class hierarchy to see if the method or it's super
-     * implementations and interfaces has the annotation. Returns the depth of the
-     * annotation in the hierarchy.
+     * Searches the class hierarchy to see if the method or it's super implementations and interfaces has the
+     * annotation. Returns the depth of the annotation in the hierarchy.
      *
-     * @param m
-     *            method to check
-     * @param annotationClass
-     *            annotation to look for
+     * @param m               method to check
+     * @param annotationClass annotation to look for
      * @return Depth of the annotation or -1 if the annotation is not on the method.
      */
     private static int getAnnotationDepth(final Method m, final Class<? extends Annotation> annotationClass) {
@@ -1948,13 +1755,14 @@ public class JSONObject {
         }
 
         //If the superclass is Object, no annotations will be found any more
-        if (c.getSuperclass().equals(Object.class))
+        if (c.getSuperclass().equals(Object.class)) {
             return -1;
+        }
 
         try {
             int d = getAnnotationDepth(
-                    c.getSuperclass().getMethod(m.getName(), m.getParameterTypes()),
-                    annotationClass);
+                c.getSuperclass().getMethod(m.getName(), m.getParameterTypes()),
+                annotationClass);
             if (d > 0) {
                 // since the annotation was on the superclass, add 1
                 return d + 1;
@@ -1970,33 +1778,24 @@ public class JSONObject {
     /**
      * Put a key/boolean pair in the JSONObject.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            A boolean which is the value.
+     * @param key   A key string.
+     * @param value A boolean which is the value.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject put(String key, boolean value) throws JSONException {
         return this.put(key, value ? Boolean.TRUE : Boolean.FALSE);
     }
 
     /**
-     * Put a key/value pair in the JSONObject, where the value will be a
-     * JSONArray which is produced from a Collection.
+     * Put a key/value pair in the JSONObject, where the value will be a JSONArray which is produced from a Collection.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            A Collection value.
+     * @param key   A key string.
+     * @param value A Collection value.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject put(String key, Collection<?> value) throws JSONException {
         return this.put(key, new JSONArray(value));
@@ -2005,15 +1804,11 @@ public class JSONObject {
     /**
      * Put a key/double pair in the JSONObject.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            A double which is the value.
+     * @param key   A key string.
+     * @param value A double which is the value.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject put(String key, double value) throws JSONException {
         return this.put(key, Double.valueOf(value));
@@ -2022,15 +1817,11 @@ public class JSONObject {
     /**
      * Put a key/float pair in the JSONObject.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            A float which is the value.
+     * @param key   A key string.
+     * @param value A float which is the value.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject put(String key, float value) throws JSONException {
         return this.put(key, Float.valueOf(value));
@@ -2039,15 +1830,11 @@ public class JSONObject {
     /**
      * Put a key/int pair in the JSONObject.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            An int which is the value.
+     * @param key   A key string.
+     * @param value An int which is the value.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject put(String key, int value) throws JSONException {
         return this.put(key, Integer.valueOf(value));
@@ -2056,53 +1843,39 @@ public class JSONObject {
     /**
      * Put a key/long pair in the JSONObject.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            A long which is the value.
+     * @param key   A key string.
+     * @param value A long which is the value.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject put(String key, long value) throws JSONException {
         return this.put(key, Long.valueOf(value));
     }
 
     /**
-     * Put a key/value pair in the JSONObject, where the value will be a
-     * JSONObject which is produced from a Map.
+     * Put a key/value pair in the JSONObject, where the value will be a JSONObject which is produced from a Map.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            A Map value.
+     * @param key   A key string.
+     * @param value A Map value.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject put(String key, Map<?, ?> value) throws JSONException {
         return this.put(key, new JSONObject(value));
     }
 
     /**
-     * Put a key/value pair in the JSONObject. If the value is <code>null</code>, then the
-     * key will be removed from the JSONObject if it is present.
+     * Put a key/value pair in the JSONObject. If the value is <code>null</code>, then the key will be removed from the
+     * JSONObject if it is present.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            An object which is the value. It should be of one of these
-     *            types: Boolean, Double, Integer, JSONArray, JSONObject, Long,
-     *            String, or the JSONObject.NULL object.
+     * @param key   A key string.
+     * @param value An object which is the value. It should be of one of these types: Boolean, Double, Integer,
+     *              JSONArray, JSONObject, Long, String, or the JSONObject.NULL object.
      * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
+     * @throws JSONException        If the value is non-finite number.
+     * @throws NullPointerException If the key is <code>null</code>.
      */
     public JSONObject put(String key, Object value) throws JSONException {
         if (key == null) {
@@ -2118,17 +1891,13 @@ public class JSONObject {
     }
 
     /**
-     * Put a key/value pair in the JSONObject, but only if the key and the value
-     * are both non-null, and only if there is not already a member with that
-     * name.
+     * Put a key/value pair in the JSONObject, but only if the key and the value are both non-null, and only if there is
+     * not already a member with that name.
      *
-     * @param key
-     *            key to insert into
-     * @param value
-     *            value to insert
+     * @param key   key to insert into
+     * @param value value to insert
      * @return this.
-     * @throws JSONException
-     *             if the key is a duplicate
+     * @throws JSONException if the key is a duplicate
      */
     public JSONObject putOnce(String key, Object value) throws JSONException {
         if (key != null && value != null) {
@@ -2141,18 +1910,13 @@ public class JSONObject {
     }
 
     /**
-     * Put a key/value pair in the JSONObject, but only if the key and the value
-     * are both non-null.
+     * Put a key/value pair in the JSONObject, but only if the key and the value are both non-null.
      *
-     * @param key
-     *            A key string.
-     * @param value
-     *            An object which is the value. It should be of one of these
-     *            types: Boolean, Double, Integer, JSONArray, JSONObject, Long,
-     *            String, or the JSONObject.NULL object.
+     * @param key   A key string.
+     * @param value An object which is the value. It should be of one of these types: Boolean, Double, Integer,
+     *              JSONArray, JSONObject, Long, String, or the JSONObject.NULL object.
      * @return this.
-     * @throws JSONException
-     *             If the value is a non-finite number.
+     * @throws JSONException If the value is a non-finite number.
      */
     public JSONObject putOpt(String key, Object value) throws JSONException {
         if (key != null && value != null) {
@@ -2162,9 +1926,8 @@ public class JSONObject {
     }
 
     /**
-     * Creates a JSONPointer using an initialization string and tries to
-     * match it to an item within this JSONObject. For example, given a
-     * JSONObject initialized with this document:
+     * Creates a JSONPointer using an initialization string and tries to match it to an item within this JSONObject. For
+     * example, given a JSONObject initialized with this document:
      * <pre>
      * {
      *     "a":{"b":"c"}
@@ -2174,8 +1937,8 @@ public class JSONObject {
      * <pre>
      * "/a/b"
      * </pre>
-     * Then this method will return the String "c".
-     * A JSONPointerException may be thrown from code called by this method.
+     * Then this method will return the String "c". A JSONPointerException may be thrown from code called by this
+     * method.
      *
      * @param jsonPointer string that can be used to create a JSONPointer
      * @return the item matched by the JSONPointer, otherwise null
@@ -2183,10 +1946,10 @@ public class JSONObject {
     public Object query(String jsonPointer) {
         return query(new JSONPointer(jsonPointer));
     }
+
     /**
-     * Uses a user initialized JSONPointer  and tries to
-     * match it to an item within this JSONObject. For example, given a
-     * JSONObject initialized with this document:
+     * Uses a user initialized JSONPointer  and tries to match it to an item within this JSONObject. For example, given
+     * a JSONObject initialized with this document:
      * <pre>
      * {
      *     "a":{"b":"c"}
@@ -2196,8 +1959,8 @@ public class JSONObject {
      * <pre>
      * "/a/b"
      * </pre>
-     * Then this method will return the String "c".
-     * A JSONPointerException may be thrown from code called by this method.
+     * Then this method will return the String "c". A JSONPointerException may be thrown from code called by this
+     * method.
      *
      * @param jsonPointer string that can be used to create a JSONPointer
      * @return the item matched by the JSONPointer, otherwise null
@@ -2207,20 +1970,20 @@ public class JSONObject {
     }
 
     /**
-     * Queries and returns a value from this object using {@code jsonPointer}, or
-     * returns null if the query fails due to a missing key.
+     * Queries and returns a value from this object using {@code jsonPointer}, or returns null if the query fails due to
+     * a missing key.
      *
      * @param jsonPointer the string representation of the JSON pointer
      * @return the queried value or {@code null}
      * @throws IllegalArgumentException if {@code jsonPointer} has invalid syntax
      */
     public Object optQuery(String jsonPointer) {
-    	return optQuery(new JSONPointer(jsonPointer));
+        return optQuery(new JSONPointer(jsonPointer));
     }
 
     /**
-     * Queries and returns a value from this object using {@code jsonPointer}, or
-     * returns null if the query fails due to a missing key.
+     * Queries and returns a value from this object using {@code jsonPointer}, or returns null if the query fails due to
+     * a missing key.
      *
      * @param jsonPointer The JSON pointer
      * @return the queried value or {@code null}
@@ -2235,14 +1998,11 @@ public class JSONObject {
     }
 
     /**
-     * Produce a string in double quotes with backslash sequences in all the
-     * right places. A backslash will be inserted within &lt;/, producing
-     * &lt;\/, allowing JSON text to be delivered in HTML. In JSON text, a
-     * string cannot contain a control character or an unescaped quote or
-     * backslash.
+     * Produce a string in double quotes with backslash sequences in all the right places. A backslash will be inserted
+     * within &lt;/, producing &lt;\/, allowing JSON text to be delivered in HTML. In JSON text, a string cannot contain
+     * a control character or an unescaped quote or backslash.
      *
-     * @param string
-     *            A String
+     * @param string A String
      * @return A String correctly formatted for insertion in a JSON text.
      */
     @SuppressWarnings("resource")
@@ -2284,42 +2044,42 @@ public class JSONObject {
             b = c;
             c = string.charAt(i);
             switch (c) {
-            case '\\':
-            case '"':
-                w.write('\\');
-                w.write(c);
-                break;
-            case '/':
-                if (b == '<') {
+                case '\\':
+                case '"':
                     w.write('\\');
-                }
-                w.write(c);
-                break;
-            case '\b':
-                w.write("\\b");
-                break;
-            case '\t':
-                w.write("\\t");
-                break;
-            case '\n':
-                w.write("\\n");
-                break;
-            case '\f':
-                w.write("\\f");
-                break;
-            case '\r':
-                w.write("\\r");
-                break;
-            default:
-                if (c < ' ' || (c >= '\u0080' && c < '\u00a0')
-                        || (c >= '\u2000' && c < '\u2100')) {
-                    w.write("\\u");
-                    hhhh = Integer.toHexString(c);
-                    w.write("0000", 0, 4 - hhhh.length());
-                    w.write(hhhh);
-                } else {
                     w.write(c);
-                }
+                    break;
+                case '/':
+                    if (b == '<') {
+                        w.write('\\');
+                    }
+                    w.write(c);
+                    break;
+                case '\b':
+                    w.write("\\b");
+                    break;
+                case '\t':
+                    w.write("\\t");
+                    break;
+                case '\n':
+                    w.write("\\n");
+                    break;
+                case '\f':
+                    w.write("\\f");
+                    break;
+                case '\r':
+                    w.write("\\r");
+                    break;
+                default:
+                    if (c < ' ' || (c >= '\u0080' && c < '\u00a0')
+                        || (c >= '\u2000' && c < '\u2100')) {
+                        w.write("\\u");
+                        hhhh = Integer.toHexString(c);
+                        w.write("0000", 0, 4 - hhhh.length());
+                        w.write(hhhh);
+                    } else {
+                        w.write(c);
+                    }
             }
         }
         w.write('"');
@@ -2329,18 +2089,15 @@ public class JSONObject {
     /**
      * Remove a name and its value, if present.
      *
-     * @param key
-     *            The name to be removed.
-     * @return The value that was associated with the name, or null if there was
-     *         no value.
+     * @param key The name to be removed.
+     * @return The value that was associated with the name, or null if there was no value.
      */
     public Object remove(String key) {
         return this.map.remove(key);
     }
 
     /**
-     * Determine if two JSONObjects are similar.
-     * They must contain the same set of names which must be associated with
+     * Determine if two JSONObjects are similar. They must contain the same set of names which must be associated with
      * similar values.
      *
      * @param other The other JSONObject
@@ -2351,34 +2108,34 @@ public class JSONObject {
             if (!(other instanceof JSONObject)) {
                 return false;
             }
-            if (!this.keySet().equals(((JSONObject)other).keySet())) {
+            if (!this.keySet().equals(((JSONObject) other).keySet())) {
                 return false;
             }
-            for (final Entry<String,?> entry : this.entrySet()) {
+            for (final Entry<String, ?> entry : this.entrySet()) {
                 String name = entry.getKey();
                 Object valueThis = entry.getValue();
-                Object valueOther = ((JSONObject)other).get(name);
-                if(valueThis == valueOther) {
-                	continue;
+                Object valueOther = ((JSONObject) other).get(name);
+                if (valueThis == valueOther) {
+                    continue;
                 }
-                if(valueThis == null) {
-                	return false;
+                if (valueThis == null) {
+                    return false;
                 }
                 if (valueThis instanceof JSONObject) {
-                    if (!((JSONObject)valueThis).similar(valueOther)) {
+                    if (!((JSONObject) valueThis).similar(valueOther)) {
                         return false;
                     }
                 } else if (valueThis instanceof JSONArray) {
-                    if (!((JSONArray)valueThis).similar(valueOther)) {
+                    if (!((JSONArray) valueThis).similar(valueOther)) {
                         return false;
                     }
                 } else if (valueThis instanceof Number && valueOther instanceof Number) {
-                    if (!isNumberSimilar((Number)valueThis, (Number)valueOther)) {
-                    	return false;
+                    if (!isNumberSimilar((Number) valueThis, (Number) valueOther)) {
+                        return false;
                     }
                 } else if (valueThis instanceof JSONString && valueOther instanceof JSONString) {
                     if (!((JSONString) valueThis).toJSONString().equals(((JSONString) valueOther).toJSONString())) {
-                    	return false;
+                        return false;
                     }
                 } else if (!valueThis.equals(valueOther)) {
                     return false;
@@ -2392,14 +2149,13 @@ public class JSONObject {
 
     /**
      * Compares two numbers to see if they are similar.
-     *
-     * If either of the numbers are Double or Float instances, then they are checked to have
-     * a finite value. If either value is not finite (NaN or &#177;infinity), then this
-     * function will always return false. If both numbers are finite, they are first checked
-     * to be the same type and implement {@link Comparable}. If they do, then the actual
-     * {@link Comparable#compareTo(Object)} is called. If they are not the same type, or don't
-     * implement Comparable, then they are converted to {@link BigDecimal}s. Finally the
-     * BigDecimal values are compared using {@link BigDecimal#compareTo(BigDecimal)}.
+     * <p>
+     * If either of the numbers are Double or Float instances, then they are checked to have a finite value. If either
+     * value is not finite (NaN or &#177;infinity), then this function will always return false. If both numbers are
+     * finite, they are first checked to be the same type and implement {@link Comparable}. If they do, then the actual
+     * {@link Comparable#compareTo(Object)} is called. If they are not the same type, or don't implement Comparable,
+     * then they are converted to {@link BigDecimal}s. Finally the BigDecimal values are compared using
+     * {@link BigDecimal#compareTo(BigDecimal)}.
      *
      * @param l the Left value to compare. Can not be <code>null</code>.
      * @param r the right value to compare. Can not be <code>null</code>.
@@ -2413,10 +2169,10 @@ public class JSONObject {
 
         // if the classes are the same and implement Comparable
         // then use the built in compare first.
-        if(l.getClass().equals(r.getClass()) && l instanceof Comparable) {
-            @SuppressWarnings({ "rawtypes", "unchecked" })
-            int compareTo = ((Comparable)l).compareTo(r);
-            return compareTo==0;
+        if (l.getClass().equals(r.getClass()) && l instanceof Comparable) {
+            @SuppressWarnings({"rawtypes", "unchecked"})
+            int compareTo = ((Comparable) l).compareTo(r);
+            return compareTo == 0;
         }
 
         // BigDecimal should be able to handle all of our number types that we support through
@@ -2447,18 +2203,15 @@ public class JSONObject {
      */
     protected static boolean isDecimalNotation(final String val) {
         return val.indexOf('.') > -1 || val.indexOf('e') > -1
-                || val.indexOf('E') > -1 || "-0".equals(val);
+            || val.indexOf('E') > -1 || "-0".equals(val);
     }
 
     /**
-     * Try to convert a string into a number, boolean, or null. If the string
-     * can't be converted, return the string.
+     * Try to convert a string into a number, boolean, or null. If the string can't be converted, return the string.
      *
-     * @param string
-     *            A String. can not be null.
+     * @param string A String. can not be null.
      * @return A simple JSON value.
-     * @throws NullPointerException
-     *             Thrown if the string is null.
+     * @throws NullPointerException Thrown if the string is null.
      */
     // Changes to this method must be copied to the corresponding method in
     // the XML class to keep full support for Android
@@ -2494,14 +2247,14 @@ public class JSONObject {
     }
 
     /**
-     * Converts a string to a number using the narrowest possible type. Possible
-     * returns for this function are BigDecimal, Double, BigInteger, Long, and Integer.
-     * When a Double is returned, it should always be a valid Double and not NaN or +-infinity.
+     * Converts a string to a number using the narrowest possible type. Possible returns for this function are
+     * BigDecimal, Double, BigInteger, Long, and Integer. When a Double is returned, it should always be a valid Double
+     * and not NaN or +-infinity.
      *
      * @param val value to convert
      * @return Number representation of the value.
-     * @throws NumberFormatException thrown if the value is not a valid number. A public
-     *      caller should catch this and wrap it in a {@link JSONException} if applicable.
+     * @throws NumberFormatException thrown if the value is not a valid number. A public caller should catch this and
+     *                               wrap it in a {@link JSONException} if applicable.
      */
     protected static Number stringToNumber(final String val) throws NumberFormatException {
         char initial = val.charAt(0);
@@ -2513,7 +2266,7 @@ public class JSONObject {
                 // keep that by forcing a decimal.
                 try {
                     BigDecimal bd = new BigDecimal(val);
-                    if(initial == '-' && BigDecimal.ZERO.compareTo(bd)==0) {
+                    if (initial == '-' && BigDecimal.ZERO.compareTo(bd) == 0) {
                         return Double.valueOf(-0.0);
                     }
                     return bd;
@@ -2521,26 +2274,26 @@ public class JSONObject {
                     // this is to support "Hex Floats" like this: 0x1.0P-1074
                     try {
                         Double d = Double.valueOf(val);
-                        if(d.isNaN() || d.isInfinite()) {
-                            throw new NumberFormatException("val ["+val+"] is not a valid number.");
+                        if (d.isNaN() || d.isInfinite()) {
+                            throw new NumberFormatException("val [" + val + "] is not a valid number.");
                         }
                         return d;
                     } catch (NumberFormatException ignore) {
-                        throw new NumberFormatException("val ["+val+"] is not a valid number.");
+                        throw new NumberFormatException("val [" + val + "] is not a valid number.");
                     }
                 }
             }
             // block items like 00 01 etc. Java number parsers treat these as Octal.
-            if(initial == '0' && val.length() > 1) {
+            if (initial == '0' && val.length() > 1) {
                 char at1 = val.charAt(1);
-                if(at1 >= '0' && at1 <= '9') {
-                    throw new NumberFormatException("val ["+val+"] is not a valid number.");
+                if (at1 >= '0' && at1 <= '9') {
+                    throw new NumberFormatException("val [" + val + "] is not a valid number.");
                 }
             } else if (initial == '-' && val.length() > 2) {
                 char at1 = val.charAt(1);
                 char at2 = val.charAt(2);
-                if(at1 == '0' && at2 >= '0' && at2 <= '9') {
-                    throw new NumberFormatException("val ["+val+"] is not a valid number.");
+                if (at1 == '0' && at2 >= '0' && at2 <= '9') {
+                    throw new NumberFormatException("val [" + val + "] is not a valid number.");
                 }
             }
             // integer representation.
@@ -2552,24 +2305,22 @@ public class JSONObject {
             // only what they need. i.e. Less runtime overhead if the value is
             // long lived.
             BigInteger bi = new BigInteger(val);
-            if(bi.bitLength() <= 31){
+            if (bi.bitLength() <= 31) {
                 return Integer.valueOf(bi.intValue());
             }
-            if(bi.bitLength() <= 63){
+            if (bi.bitLength() <= 63) {
                 return Long.valueOf(bi.longValue());
             }
             return bi;
         }
-        throw new NumberFormatException("val ["+val+"] is not a valid number.");
+        throw new NumberFormatException("val [" + val + "] is not a valid number.");
     }
 
     /**
      * Throw an exception if the object is a NaN or infinite number.
      *
-     * @param o
-     *            The object to test.
-     * @throws JSONException
-     *             If o is a non-finite number.
+     * @param o The object to test.
+     * @throws JSONException If o is a non-finite number.
      */
     public static void testValidity(Object o) throws JSONException {
         if (o instanceof Number && !numberIsFinite((Number) o)) {
@@ -2578,15 +2329,12 @@ public class JSONObject {
     }
 
     /**
-     * Produce a JSONArray containing the values of the members of this
-     * JSONObject.
+     * Produce a JSONArray containing the values of the members of this JSONObject.
      *
-     * @param names
-     *            A JSONArray containing a list of key strings. This determines
-     *            the sequence of the values in the result.
+     * @param names A JSONArray containing a list of key strings. This determines the sequence of the values in the
+     *              result.
      * @return A JSONArray of values.
-     * @throws JSONException
-     *             If any of the values are non-finite numbers.
+     * @throws JSONException If any of the values are non-finite numbers.
      */
     public JSONArray toJSONArray(JSONArray names) throws JSONException {
         if (names == null || names.isEmpty()) {
@@ -2600,17 +2348,15 @@ public class JSONObject {
     }
 
     /**
-     * Make a JSON text of this JSONObject. For compactness, no whitespace is
-     * added. If this would not result in a syntactically correct JSON text,
-     * then null will be returned instead.
+     * Make a JSON text of this JSONObject. For compactness, no whitespace is added. If this would not result in a
+     * syntactically correct JSON text, then null will be returned instead.
      * <p><b>
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
      *
-     * @return a printable, displayable, portable, transmittable representation
-     *         of the object, beginning with <code>{</code>&nbsp;<small>(left
-     *         brace)</small> and ending with <code>}</code>&nbsp;<small>(right
-     *         brace)</small>.
+     * @return a printable, displayable, portable, transmittable representation of the object, beginning with
+     * <code>{</code>&nbsp;<small>(left brace)</small> and ending with <code>}</code>&nbsp;<small>(right
+     * brace)</small>.
      */
     @Override
     public String toString() {
@@ -2638,14 +2384,11 @@ public class JSONObject {
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
      *
-     * @param indentFactor
-     *            The number of spaces to add to each level of indentation.
-     * @return a printable, displayable, portable, transmittable representation
-     *         of the object, beginning with <code>{</code>&nbsp;<small>(left
-     *         brace)</small> and ending with <code>}</code>&nbsp;<small>(right
-     *         brace)</small>.
-     * @throws JSONException
-     *             If the object contains an invalid number.
+     * @param indentFactor The number of spaces to add to each level of indentation.
+     * @return a printable, displayable, portable, transmittable representation of the object, beginning with
+     * <code>{</code>&nbsp;<small>(left brace)</small> and ending with <code>}</code>&nbsp;<small>(right
+     * brace)</small>.
+     * @throws JSONException If the object contains an invalid number.
      */
     @SuppressWarnings("resource")
     public String toString(int indentFactor) throws JSONException {
@@ -2657,47 +2400,37 @@ public class JSONObject {
     }
 
     /**
-     * Make a JSON text of an Object value. If the object has an
-     * value.toJSONString() method, then that method will be used to produce the
-     * JSON text. The method is required to produce a strictly conforming text.
-     * If the object does not contain a toJSONString method (which is the most
-     * common case), then a text will be produced by other means. If the value
-     * is an array or Collection, then a JSONArray will be made from it and its
-     * toJSONString method will be called. If the value is a MAP, then a
-     * JSONObject will be made from it and its toJSONString method will be
-     * called. Otherwise, the value's toString method will be called, and the
-     * result will be quoted.
+     * Make a JSON text of an Object value. If the object has an value.toJSONString() method, then that method will be
+     * used to produce the JSON text. The method is required to produce a strictly conforming text. If the object does
+     * not contain a toJSONString method (which is the most common case), then a text will be produced by other means.
+     * If the value is an array or Collection, then a JSONArray will be made from it and its toJSONString method will be
+     * called. If the value is a MAP, then a JSONObject will be made from it and its toJSONString method will be called.
+     * Otherwise, the value's toString method will be called, and the result will be quoted.
      *
      * <p>
      * Warning: This method assumes that the data structure is acyclical.
      *
-     * @param value
-     *            The value to be serialized.
-     * @return a printable, displayable, transmittable representation of the
-     *         object, beginning with <code>{</code>&nbsp;<small>(left
-     *         brace)</small> and ending with <code>}</code>&nbsp;<small>(right
-     *         brace)</small>.
-     * @throws JSONException
-     *             If the value is or contains an invalid number.
+     * @param value The value to be serialized.
+     * @return a printable, displayable, transmittable representation of the object, beginning with
+     * <code>{</code>&nbsp;<small>(left brace)</small> and ending with <code>}</code>&nbsp;<small>(right
+     * brace)</small>.
+     * @throws JSONException If the value is or contains an invalid number.
      */
     public static String valueToString(Object value) throws JSONException {
-    	// moves the implementation to JSONWriter as:
-    	// 1. It makes more sense to be part of the writer class
-    	// 2. For Android support this method is not available. By implementing it in the Writer
-    	//    Android users can use the writer with the built in Android JSONObject implementation.
+        // moves the implementation to JSONWriter as:
+        // 1. It makes more sense to be part of the writer class
+        // 2. For Android support this method is not available. By implementing it in the Writer
+        //    Android users can use the writer with the built in Android JSONObject implementation.
         return JSONWriter.valueToString(value);
     }
 
     /**
-     * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL
-     * object. If it is an array or collection, wrap it in a JSONArray. If it is
-     * a map, wrap it in a JSONObject. If it is a standard property (Double,
-     * String, et al) then it is already wrapped. Otherwise, if it comes from
-     * one of the java packages, turn it into a string. And if it doesn't, try
-     * to wrap it in a JSONObject. If the wrapping fails, then null is returned.
+     * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL object. If it is an array or
+     * collection, wrap it in a JSONArray. If it is a map, wrap it in a JSONObject. If it is a standard property
+     * (Double, String, et al) then it is already wrapped. Otherwise, if it comes from one of the java packages, turn it
+     * into a string. And if it doesn't, try to wrap it in a JSONObject. If the wrapping fails, then null is returned.
      *
-     * @param object
-     *            The object to wrap
+     * @param object The object to wrap
      * @return The wrapped value
      */
     public static Object wrap(Object object) {
@@ -2705,42 +2438,38 @@ public class JSONObject {
     }
 
     /**
-     * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL
-     * object. If it is an array or collection, wrap it in a JSONArray. If it is
-     * a map, wrap it in a JSONObject. If it is a standard property (Double,
-     * String, et al) then it is already wrapped. Otherwise, if it comes from
-     * one of the java packages, turn it into a string. And if it doesn't, try
-     * to wrap it in a JSONObject. If the wrapping fails, then null is returned.
+     * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL object. If it is an array or
+     * collection, wrap it in a JSONArray. If it is a map, wrap it in a JSONObject. If it is a standard property
+     * (Double, String, et al) then it is already wrapped. Otherwise, if it comes from one of the java packages, turn it
+     * into a string. And if it doesn't, try to wrap it in a JSONObject. If the wrapping fails, then null is returned.
      *
-     * @param object
-     *            The object to wrap
-     * @param recursionDepth
-     *            Variable for tracking the count of nested object creations.
-     * @param jsonParserConfiguration
-     *            Variable to pass parser custom configuration for json parsing.
+     * @param object                  The object to wrap
+     * @param recursionDepth          Variable for tracking the count of nested object creations.
+     * @param jsonParserConfiguration Variable to pass parser custom configuration for json parsing.
      * @return The wrapped value
      */
     static Object wrap(Object object, int recursionDepth, JSONParserConfiguration jsonParserConfiguration) {
-      return wrap(object, null, recursionDepth, jsonParserConfiguration);
+        return wrap(object, null, recursionDepth, jsonParserConfiguration);
     }
 
     private static Object wrap(Object object, Set<Object> objectsRecord) {
-      return wrap(object, objectsRecord, 0, new JSONParserConfiguration());
+        return wrap(object, objectsRecord, 0, new JSONParserConfiguration());
     }
 
-    private static Object wrap(Object object, Set<Object> objectsRecord, int recursionDepth, JSONParserConfiguration jsonParserConfiguration) {
+    private static Object wrap(Object object, Set<Object> objectsRecord, int recursionDepth,
+        JSONParserConfiguration jsonParserConfiguration) {
         try {
             if (NULL.equals(object)) {
                 return NULL;
             }
             if (object instanceof JSONObject || object instanceof JSONArray
-                    || NULL.equals(object) || object instanceof JSONString
-                    || object instanceof Byte || object instanceof Character
-                    || object instanceof Short || object instanceof Integer
-                    || object instanceof Long || object instanceof Boolean
-                    || object instanceof Float || object instanceof Double
-                    || object instanceof String || object instanceof BigInteger
-                    || object instanceof BigDecimal || object instanceof Enum) {
+                || NULL.equals(object) || object instanceof JSONString
+                || object instanceof Byte || object instanceof Character
+                || object instanceof Short || object instanceof Integer
+                || object instanceof Long || object instanceof Boolean
+                || object instanceof Float || object instanceof Double
+                || object instanceof String || object instanceof BigInteger
+                || object instanceof BigDecimal || object instanceof Enum) {
                 return object;
             }
 
@@ -2757,18 +2486,17 @@ public class JSONObject {
             }
             Package objectPackage = object.getClass().getPackage();
             String objectPackageName = objectPackage != null ? objectPackage
-                    .getName() : "";
+                .getName() : "";
             if (objectPackageName.startsWith("java.")
-                    || objectPackageName.startsWith("javax.")
-                    || object.getClass().getClassLoader() == null) {
+                || objectPackageName.startsWith("javax.")
+                || object.getClass().getClassLoader() == null) {
                 return object.toString();
             }
             if (objectsRecord != null) {
                 return new JSONObject(object, objectsRecord);
             }
             return new JSONObject(object);
-        }
-        catch (JSONException exception) {
+        } catch (JSONException exception) {
             throw exception;
         } catch (Exception exception) {
             return null;
@@ -2776,11 +2504,11 @@ public class JSONObject {
     }
 
     /**
-     * Write the contents of the JSONObject as JSON text to a writer. For
-     * compactness, no whitespace is added.
+     * Write the contents of the JSONObject as JSON text to a writer. For compactness, no whitespace is added.
      * <p><b>
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
+     *
      * @param writer the writer object
      * @return The writer.
      * @throws JSONException if a called function has an error
@@ -2791,7 +2519,7 @@ public class JSONObject {
 
     @SuppressWarnings("resource")
     static final Writer writeValue(Writer writer, Object value,
-            int indentFactor, int indent) throws JSONException, IOException {
+        int indentFactor, int indent) throws JSONException, IOException {
         if (value == null || value.equals(null)) {
             writer.write("null");
         } else if (value instanceof JSONString) {
@@ -2810,7 +2538,7 @@ public class JSONObject {
         } else if (value instanceof Number) {
             // not all Numbers may match actual JSON Numbers. i.e. fractions or Imaginary
             final String numberAsString = numberToString((Number) value);
-            if(NUMBER_PATTERN.matcher(numberAsString).matches()) {
+            if (NUMBER_PATTERN.matcher(numberAsString).matches()) {
                 writer.write(numberAsString);
             } else {
                 // The Number value is not a valid JSON number.
@@ -2820,7 +2548,7 @@ public class JSONObject {
         } else if (value instanceof Boolean) {
             writer.write(value.toString());
         } else if (value instanceof Enum<?>) {
-            writer.write(quote(((Enum<?>)value).name()));
+            writer.write(quote(((Enum<?>) value).name()));
         } else if (value instanceof JSONObject) {
             ((JSONObject) value).write(writer, indentFactor, indent);
         } else if (value instanceof JSONArray) {
@@ -2862,40 +2590,36 @@ public class JSONObject {
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
      *
-     * @param writer
-     *            Writes the serialized JSON
-     * @param indentFactor
-     *            The number of spaces to add to each level of indentation.
-     * @param indent
-     *            The indentation of the top level.
+     * @param writer       Writes the serialized JSON
+     * @param indentFactor The number of spaces to add to each level of indentation.
+     * @param indent       The indentation of the top level.
      * @return The writer.
-     * @throws JSONException if a called function has an error or a write error
-     * occurs
+     * @throws JSONException if a called function has an error or a write error occurs
      */
     @SuppressWarnings("resource")
     public Writer write(Writer writer, int indentFactor, int indent)
-            throws JSONException {
+        throws JSONException {
         try {
             boolean needsComma = false;
             final int length = this.length();
             writer.write('{');
 
             if (length == 1) {
-            	final Entry<String,?> entry = this.entrySet().iterator().next();
+                final Entry<String, ?> entry = this.entrySet().iterator().next();
                 final String key = entry.getKey();
                 writer.write(quote(key));
                 writer.write(':');
                 if (indentFactor > 0) {
                     writer.write(' ');
                 }
-                try{
+                try {
                     writeValue(writer, entry.getValue(), indentFactor, indent);
                 } catch (Exception e) {
                     throw new JSONException("Unable to write JSONObject value for key: " + key, e);
                 }
             } else if (length != 0) {
                 final int newIndent = indent + indentFactor;
-                for (final Entry<String,?> entry : this.entrySet()) {
+                for (final Entry<String, ?> entry : this.entrySet()) {
                     if (needsComma) {
                         writer.write(',');
                     }
@@ -2929,9 +2653,8 @@ public class JSONObject {
     }
 
     /**
-     * Returns a java.util.Map containing all of the entries in this object.
-     * If an entry in the object is a JSONArray or JSONObject it will also
-     * be converted.
+     * Returns a java.util.Map containing all of the entries in this object. If an entry in the object is a JSONArray or
+     * JSONObject it will also be converted.
      * <p>
      * Warning: This method assumes that the data structure is acyclical.
      *
@@ -2957,35 +2680,37 @@ public class JSONObject {
 
     /**
      * Create a new JSONException in a common format for incorrect conversions.
-     * @param key name of the key
+     *
+     * @param key       name of the key
      * @param valueType the type of value being coerced to
-     * @param cause optional cause of the coercion failure
+     * @param cause     optional cause of the coercion failure
      * @return JSONException that can be thrown.
      */
     private static JSONException wrongValueFormatException(
-            String key,
-            String valueType,
-            Object value,
-            Throwable cause) {
-        if(value == null) {
+        String key,
+        String valueType,
+        Object value,
+        Throwable cause) {
+        if (value == null) {
 
             return new JSONException(
-                    "JSONObject[" + quote(key) + "] is not a " + valueType + " (null)."
-                    , cause);
+                "JSONObject[" + quote(key) + "] is not a " + valueType + " (null)."
+                , cause);
         }
         // don't try to toString collections or known object types that could be large.
-        if(value instanceof Map || value instanceof Iterable || value instanceof JSONObject) {
+        if (value instanceof Map || value instanceof Iterable || value instanceof JSONObject) {
             return new JSONException(
-                    "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + ")."
-                    , cause);
+                "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + ")."
+                , cause);
         }
         return new JSONException(
-                "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + " : " + value + ")."
-                , cause);
+            "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + " : " + value + ")."
+            , cause);
     }
 
     /**
      * Create a new JSONException in a common format for recursive object definition.
+     *
      * @param key name of the key
      * @return JSONException that can be thrown.
      */
@@ -2997,21 +2722,28 @@ public class JSONObject {
 
     /**
      * For a prospective number, remove the leading zeros
+     *
      * @param value prospective number
      * @return number without leading zeros
      */
-    private static String removeLeadingZerosOfNumber(String value){
-        if (value.equals("-")){return value;}
+    private static String removeLeadingZerosOfNumber(String value) {
+        if (value.equals("-")) {
+            return value;
+        }
         boolean negativeFirstChar = (value.charAt(0) == '-');
-        int counter = negativeFirstChar ? 1:0;
-        while (counter < value.length()){
-            if (value.charAt(counter) != '0'){
-                if (negativeFirstChar) {return "-".concat(value.substring(counter));}
+        int counter = negativeFirstChar ? 1 : 0;
+        while (counter < value.length()) {
+            if (value.charAt(counter) != '0') {
+                if (negativeFirstChar) {
+                    return "-".concat(value.substring(counter));
+                }
                 return value.substring(counter);
             }
             ++counter;
         }
-        if (negativeFirstChar) {return "-0";}
+        if (negativeFirstChar) {
+            return "-0";
+        }
         return "0";
     }
 }

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -209,9 +209,7 @@ public class JSONObject {
                 case '}':
                     if (jsonParserConfiguration.isStrictMode()) {
                         c = x.nextClean();
-                        System.out.println(c);
                         if (c != 0) {
-                            System.out.println("yes");
                             throw x.syntaxError(String.format("Invalid char '%s' after '}'", c));
                         }
                         x.back();

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -19,37 +19,42 @@ import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
 /**
- * A JSONObject is an unordered collection of name/value pairs. Its external form is a string wrapped in curly braces
- * with colons between the names and values, and commas between the values and names. The internal form is an object
- * having <code>get</code> and <code>opt</code> methods for accessing the values by name, and <code>put</code> methods
- * for adding or replacing values by name. The values can be any of these types: <code>Boolean</code>,
+ * A JSONObject is an unordered collection of name/value pairs. Its external
+ * form is a string wrapped in curly braces with colons between the names and
+ * values, and commas between the values and names. The internal form is an
+ * object having <code>get</code> and <code>opt</code> methods for accessing
+ * the values by name, and <code>put</code> methods for adding or replacing
+ * values by name. The values can be any of these types: <code>Boolean</code>,
  * <code>JSONArray</code>, <code>JSONObject</code>, <code>Number</code>,
  * <code>String</code>, or the <code>JSONObject.NULL</code> object. A
- * JSONObject constructor can be used to convert an external form JSON text into an internal form whose values can be
- * retrieved with the
+ * JSONObject constructor can be used to convert an external form JSON text
+ * into an internal form whose values can be retrieved with the
  * <code>get</code> and <code>opt</code> methods, or to convert values into a
  * JSON text using the <code>put</code> and <code>toString</code> methods. A
  * <code>get</code> method returns a value if one can be found, and throws an
- * exception if one cannot be found. An <code>opt</code> method returns a default value instead of throwing an
- * exception, and so is useful for obtaining optional values.
+ * exception if one cannot be found. An <code>opt</code> method returns a
+ * default value instead of throwing an exception, and so is useful for
+ * obtaining optional values.
  * <p>
- * The generic <code>get()</code> and <code>opt()</code> methods return an object, which you can cast or query for type.
- * There are also typed
+ * The generic <code>get()</code> and <code>opt()</code> methods return an
+ * object, which you can cast or query for type. There are also typed
  * <code>get</code> and <code>opt</code> methods that do type checking and type
- * coercion for you. The opt methods differ from the get methods in that they do not throw. Instead, they return a
- * specified value, such as null.
+ * coercion for you. The opt methods differ from the get methods in that they
+ * do not throw. Instead, they return a specified value, such as null.
  * <p>
- * The <code>put</code> methods add or replace values in an object. For example,
+ * The <code>put</code> methods add or replace values in an object. For
+ * example,
  *
  * <pre>
  * myString = new JSONObject()
  *         .put(&quot;JSON&quot;, &quot;Hello, World!&quot;).toString();
  * </pre>
- * <p>
+ *
  * produces the string <code>{"JSON": "Hello, World"}</code>.
  * <p>
- * The texts produced by the <code>toString</code> methods strictly conform to the JSON syntax rules. The constructors
- * are more forgiving in the texts they will accept:
+ * The texts produced by the <code>toString</code> methods strictly conform to
+ * the JSON syntax rules. The constructors are more forgiving in the texts they
+ * will accept:
  * <ul>
  * <li>An extra <code>,</code>&nbsp;<small>(comma)</small> may appear just
  * before the closing brace.</li>
@@ -67,15 +72,16 @@ import java.util.regex.Pattern;
  * @version 2016-08-15
  */
 public class JSONObject {
-
     /**
-     * JSONObject.NULL is equivalent to the value that JavaScript calls null, whilst Java's null is equivalent to the
-     * value that JavaScript calls undefined.
+     * JSONObject.NULL is equivalent to the value that JavaScript calls null,
+     * whilst Java's null is equivalent to the value that JavaScript calls
+     * undefined.
      */
     private static final class Null {
 
         /**
-         * There is only intended to be a single instance of the NULL object, so the clone method returns itself.
+         * There is only intended to be a single instance of the NULL object,
+         * so the clone method returns itself.
          *
          * @return NULL.
          */
@@ -87,15 +93,16 @@ public class JSONObject {
         /**
          * A Null object is equal to the null value and to itself.
          *
-         * @param object An object to test for nullness.
-         * @return true if the object parameter is the JSONObject.NULL object or null.
+         * @param object
+         *            An object to test for nullness.
+         * @return true if the object parameter is the JSONObject.NULL object or
+         *         null.
          */
         @Override
         @SuppressWarnings("lgtm[java/unchecked-cast-in-equals]")
         public boolean equals(Object object) {
             return object == null || object == this;
         }
-
         /**
          * A Null object is equal to the null value and to itself.
          *
@@ -118,8 +125,8 @@ public class JSONObject {
     }
 
     /**
-     * Regular Expression Pattern that matches JSON Numbers. This is primarily used for output to guarantee that we are
-     * always writing valid JSON.
+     *  Regular Expression Pattern that matches JSON Numbers. This is primarily used for
+     *  output to guarantee that we are always writing valid JSON.
      */
     static final Pattern NUMBER_PATTERN = Pattern.compile("-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?");
 
@@ -159,13 +166,16 @@ public class JSONObject {
     }
 
     /**
-     * Construct a JSONObject from a subset of another JSONObject. An array of strings is used to identify the keys that
-     * should be copied. Missing keys are ignored.
+     * Construct a JSONObject from a subset of another JSONObject. An array of
+     * strings is used to identify the keys that should be copied. Missing keys
+     * are ignored.
      *
-     * @param jo    A JSONObject.
-     * @param names An array of strings.
+     * @param jo
+     *            A JSONObject.
+     * @param names
+     *            An array of strings.
      */
-    public JSONObject(JSONObject jo, String... names) {
+    public JSONObject(JSONObject jo, String ... names) {
         this(names.length);
         for (int i = 0; i < names.length; i += 1) {
             try {
@@ -178,8 +188,11 @@ public class JSONObject {
     /**
      * Construct a JSONObject from a JSONTokener.
      *
-     * @param x A JSONTokener object containing the source string.
-     * @throws JSONException If there is a syntax error in the source string or a duplicated key.
+     * @param x
+     *            A JSONTokener object containing the source string.
+     * @throws JSONException
+     *             If there is a syntax error in the source string or a
+     *             duplicated key.
      */
     public JSONObject(JSONTokener x) throws JSONException {
         this(x, new JSONParserConfiguration());
@@ -188,9 +201,13 @@ public class JSONObject {
     /**
      * Construct a JSONObject from a JSONTokener with custom json parse configurations.
      *
-     * @param x                       A JSONTokener object containing the source string.
-     * @param jsonParserConfiguration Variable to pass parser custom configuration for json parsing.
-     * @throws JSONException If there is a syntax error in the source string or a duplicated key.
+     * @param x
+     *            A JSONTokener object containing the source string.
+     * @param jsonParserConfiguration
+     *            Variable to pass parser custom configuration for json parsing.
+     * @throws JSONException
+     *             If there is a syntax error in the source string or a
+     *             duplicated key.
      */
     public JSONObject(JSONTokener x, JSONParserConfiguration jsonParserConfiguration) throws JSONException {
         this();
@@ -200,7 +217,6 @@ public class JSONObject {
         if (x.nextClean() != '{') {
             throw x.syntaxError("A JSONObject text must begin with '{'");
         }
-
         for (;;) {
             c = x.nextClean();
             switch (c) {
@@ -222,7 +238,6 @@ public class JSONObject {
             // The key is followed by ':'.
 
             c = x.nextClean();
-
             if (c != ':') {
                 throw x.syntaxError("Expected a ':' after a key");
             }
@@ -274,19 +289,26 @@ public class JSONObject {
     /**
      * Construct a JSONObject from a Map.
      *
-     * @param m A map object that can be used to initialize the contents of the JSONObject.
-     * @throws JSONException        If a value in the map is non-finite number.
-     * @throws NullPointerException If a key in the map is <code>null</code>
+     * @param m
+     *            A map object that can be used to initialize the contents of
+     *            the JSONObject.
+     * @throws JSONException
+     *            If a value in the map is non-finite number.
+     * @throws NullPointerException
+     *            If a key in the map is <code>null</code>
      */
     public JSONObject(Map<?, ?> m) {
-        this(m, 0, new JSONParserConfiguration());
+      this(m, 0, new JSONParserConfiguration());
     }
 
     /**
      * Construct a JSONObject from a Map with custom json parse configurations.
      *
-     * @param m                       A map object that can be used to initialize the contents of the JSONObject.
-     * @param jsonParserConfiguration Variable to pass parser custom configuration for json parsing.
+     * @param m
+     *            A map object that can be used to initialize the contents of
+     *            the JSONObject.
+     * @param jsonParserConfiguration
+     *            Variable to pass parser custom configuration for json parsing.
      */
     public JSONObject(Map<?, ?> m, JSONParserConfiguration jsonParserConfiguration) {
         this(m, 0, jsonParserConfiguration);
@@ -297,17 +319,16 @@ public class JSONObject {
      */
     private JSONObject(Map<?, ?> m, int recursionDepth, JSONParserConfiguration jsonParserConfiguration) {
         if (recursionDepth > jsonParserConfiguration.getMaxNestingDepth()) {
-            throw new JSONException(
-                "JSONObject has reached recursion depth limit of " + jsonParserConfiguration.getMaxNestingDepth());
+          throw new JSONException("JSONObject has reached recursion depth limit of " + jsonParserConfiguration.getMaxNestingDepth());
         }
         if (m == null) {
             this.map = new HashMap<String, Object>();
         } else {
             this.map = new HashMap<String, Object>(m.size());
-            for (final Entry<?, ?> e : m.entrySet()) {
-                if (e.getKey() == null) {
-                    throw new NullPointerException("Null key.");
-                }
+        	for (final Entry<?, ?> e : m.entrySet()) {
+        	    if(e.getKey() == null) {
+        	        throw new NullPointerException("Null key.");
+        	    }
                 final Object value = e.getValue();
                 if (value != null) {
                     testValidity(value);
@@ -318,24 +339,28 @@ public class JSONObject {
     }
 
     /**
-     * Construct a JSONObject from an Object using bean getters. It reflects on all of the public methods of the object.
-     * For each of the methods with no parameters and a name starting with <code>"get"</code> or
+     * Construct a JSONObject from an Object using bean getters. It reflects on
+     * all of the public methods of the object. For each of the methods with no
+     * parameters and a name starting with <code>"get"</code> or
      * <code>"is"</code> followed by an uppercase letter, the method is invoked,
-     * and a key and the value returned from the getter method are put into the new JSONObject.
+     * and a key and the value returned from the getter method are put into the
+     * new JSONObject.
      * <p>
-     * The key is formed by removing the <code>"get"</code> or <code>"is"</code> prefix. If the second remaining
-     * character is not upper case, then the first character is converted to lower case.
+     * The key is formed by removing the <code>"get"</code> or <code>"is"</code>
+     * prefix. If the second remaining character is not upper case, then the
+     * first character is converted to lower case.
      * <p>
-     * Methods that are <code>static</code>, return <code>void</code>, have parameters, or are "bridge" methods, are
-     * ignored.
+     * Methods that are <code>static</code>, return <code>void</code>,
+     * have parameters, or are "bridge" methods, are ignored.
      * <p>
-     * For example, if an object has a method named <code>"getName"</code>, and if the result of calling
-     * <code>object.getName()</code> is
+     * For example, if an object has a method named <code>"getName"</code>, and
+     * if the result of calling <code>object.getName()</code> is
      * <code>"Larry Fine"</code>, then the JSONObject will contain
      * <code>"name": "Larry Fine"</code>.
      * <p>
-     * The {@link JSONPropertyName} annotation can be used on a bean getter to override key name used in the JSONObject.
-     * For example, using the object above with the <code>getName</code> method, if we annotated it with:
+     * The {@link JSONPropertyName} annotation can be used on a bean getter to
+     * override key name used in the JSONObject. For example, using the object
+     * above with the <code>getName</code> method, if we annotated it with:
      * <pre>
      * &#64;JSONPropertyName("FullName")
      * public String getName() { return this.name; }
@@ -344,27 +369,33 @@ public class JSONObject {
      * <p>
      * Similarly, the {@link JSONPropertyName} annotation can be used on non-
      * <code>get</code> and <code>is</code> methods. We can also override key
-     * name used in the JSONObject as seen below even though the field would normally be ignored:
+     * name used in the JSONObject as seen below even though the field would normally
+     * be ignored:
      * <pre>
      * &#64;JSONPropertyName("FullName")
      * public String fullName() { return this.name; }
      * </pre>
      * The resulting JSON object would contain <code>"FullName": "Larry Fine"</code>
      * <p>
-     * The {@link JSONPropertyIgnore} annotation can be used to force the bean property to not be serialized into JSON.
-     * If both {@link JSONPropertyIgnore} and {@link JSONPropertyName} are defined on the same method, a depth
-     * comparison is performed and the one closest to the concrete class being serialized is used. If both annotations
-     * are at the same level, then the {@link JSONPropertyIgnore} annotation takes precedent and the field is not
-     * serialized. For example, the following declaration would prevent the <code>getName</code> method from being
-     * serialized:
+     * The {@link JSONPropertyIgnore} annotation can be used to force the bean property
+     * to not be serialized into JSON. If both {@link JSONPropertyIgnore} and
+     * {@link JSONPropertyName} are defined on the same method, a depth comparison is
+     * performed and the one closest to the concrete class being serialized is used.
+     * If both annotations are at the same level, then the {@link JSONPropertyIgnore}
+     * annotation takes precedent and the field is not serialized.
+     * For example, the following declaration would prevent the <code>getName</code>
+     * method from being serialized:
      * <pre>
      * &#64;JSONPropertyName("FullName")
      * &#64;JSONPropertyIgnore
      * public String getName() { return this.name; }
      * </pre>
      *
-     * @param bean An object that has getter methods that should be used to make a JSONObject.
-     * @throws JSONException If a getter returned a non-finite number.
+     * @param bean
+     *            An object that has getter methods that should be used to make
+     *            a JSONObject.
+     * @throws JSONException
+     *            If a getter returned a non-finite number.
      */
     public JSONObject(Object bean) {
         this();
@@ -377,14 +408,20 @@ public class JSONObject {
     }
 
     /**
-     * Construct a JSONObject from an Object, using reflection to find the public members. The resulting JSONObject's
-     * keys will be the strings from the names array, and the values will be the field values associated with those keys
-     * in the object. If a key is not found or not visible, then it will not be copied into the new JSONObject.
+     * Construct a JSONObject from an Object, using reflection to find the
+     * public members. The resulting JSONObject's keys will be the strings from
+     * the names array, and the values will be the field values associated with
+     * those keys in the object. If a key is not found or not visible, then it
+     * will not be copied into the new JSONObject.
      *
-     * @param object An object that has fields that should be used to make a JSONObject.
-     * @param names  An array of strings, the names of the fields to be obtained from the object.
+     * @param object
+     *            An object that has fields that should be used to make a
+     *            JSONObject.
+     * @param names
+     *            An array of strings, the names of the fields to be obtained
+     *            from the object.
      */
-    public JSONObject(Object object, String... names) {
+    public JSONObject(Object object, String ... names) {
         this(names.length);
         Class<?> c = object.getClass();
         for (int i = 0; i < names.length; i += 1) {
@@ -397,24 +434,34 @@ public class JSONObject {
     }
 
     /**
-     * Construct a JSONObject from a source JSON text string. This is the most commonly used JSONObject constructor.
+     * Construct a JSONObject from a source JSON text string. This is the most
+     * commonly used JSONObject constructor.
      *
-     * @param source A string beginning with <code>{</code>&nbsp;<small>(left brace)</small> and ending with
-     *               <code>}</code> &nbsp;<small>(right brace)</small>.
-     * @throws JSONException If there is a syntax error in the source string or a duplicated key.
+     * @param source
+     *            A string beginning with <code>{</code>&nbsp;<small>(left
+     *            brace)</small> and ending with <code>}</code>
+     *            &nbsp;<small>(right brace)</small>.
+     * @exception JSONException
+     *                If there is a syntax error in the source string or a
+     *                duplicated key.
      */
     public JSONObject(String source) throws JSONException {
         this(source, new JSONParserConfiguration());
     }
 
     /**
-     * Construct a JSONObject from a source JSON text string with custom json parse configurations. This is the most
-     * commonly used JSONObject constructor.
+     * Construct a JSONObject from a source JSON text string with custom json parse configurations.
+     * This is the most commonly used JSONObject constructor.
      *
-     * @param source                  A string beginning with <code>{</code>&nbsp;<small>(left brace)</small> and ending
-     *                                with <code>}</code> &nbsp;<small>(right brace)</small>.
-     * @param jsonParserConfiguration Variable to pass parser custom configuration for json parsing.
-     * @throws JSONException If there is a syntax error in the source string or a duplicated key.
+     * @param source
+     *            A string beginning with <code>{</code>&nbsp;<small>(left
+     *            brace)</small> and ending with <code>}</code>
+     *            &nbsp;<small>(right brace)</small>.
+     * @param jsonParserConfiguration
+     *            Variable to pass parser custom configuration for json parsing.
+     * @exception JSONException
+     *                If there is a syntax error in the source string or a
+     *                duplicated key.
      */
     public JSONObject(String source, JSONParserConfiguration jsonParserConfiguration) throws JSONException {
         this(new JSONTokener(source), jsonParserConfiguration);
@@ -423,14 +470,17 @@ public class JSONObject {
     /**
      * Construct a JSONObject from a ResourceBundle.
      *
-     * @param baseName The ResourceBundle base name.
-     * @param locale   The Locale to load the ResourceBundle for.
-     * @throws JSONException If any JSONExceptions are detected.
+     * @param baseName
+     *            The ResourceBundle base name.
+     * @param locale
+     *            The Locale to load the ResourceBundle for.
+     * @throws JSONException
+     *             If any JSONExceptions are detected.
      */
     public JSONObject(String baseName, Locale locale) throws JSONException {
         this();
         ResourceBundle bundle = ResourceBundle.getBundle(baseName, locale,
-            Thread.currentThread().getContextClassLoader());
+                Thread.currentThread().getContextClassLoader());
 
 // Iterate through the keys in the bundle.
 
@@ -461,36 +511,44 @@ public class JSONObject {
     }
 
     /**
-     * Constructor to specify an initial capacity of the internal map. Useful for library internal calls where we know,
-     * or at least can best guess, how big this JSONObject will be.
+     * Constructor to specify an initial capacity of the internal map. Useful for library
+     * internal calls where we know, or at least can best guess, how big this JSONObject
+     * will be.
      *
      * @param initialCapacity initial capacity of the internal map.
      */
-    protected JSONObject(int initialCapacity) {
+    protected JSONObject(int initialCapacity){
         this.map = new HashMap<String, Object>(initialCapacity);
     }
 
     /**
-     * Accumulate values under a key. It is similar to the put method except that if there is already an object stored
-     * under the key then a JSONArray is stored under the key to hold all of the accumulated values. If there is already
-     * a JSONArray, then the new value is appended to it. In contrast, the put method replaces the previous value.
-     * <p>
-     * If only one value is accumulated that is not a JSONArray, then the result will be the same as using put. But if
-     * multiple values are accumulated, then the result will be like append.
+     * Accumulate values under a key. It is similar to the put method except
+     * that if there is already an object stored under the key then a JSONArray
+     * is stored under the key to hold all of the accumulated values. If there
+     * is already a JSONArray, then the new value is appended to it. In
+     * contrast, the put method replaces the previous value.
      *
-     * @param key   A key string.
-     * @param value An object to be accumulated under the key.
+     * If only one value is accumulated that is not a JSONArray, then the result
+     * will be the same as using put. But if multiple values are accumulated,
+     * then the result will be like append.
+     *
+     * @param key
+     *            A key string.
+     * @param value
+     *            An object to be accumulated under the key.
      * @return this.
-     * @throws JSONException        If the value is non-finite number.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject accumulate(String key, Object value) throws JSONException {
         testValidity(value);
         Object object = this.opt(key);
         if (object == null) {
             this.put(key,
-                value instanceof JSONArray ? new JSONArray().put(value)
-                    : value);
+                    value instanceof JSONArray ? new JSONArray().put(value)
+                            : value);
         } else if (object instanceof JSONArray) {
             ((JSONArray) object).put(value);
         } else {
@@ -500,16 +558,21 @@ public class JSONObject {
     }
 
     /**
-     * Append values to the array under a key. If the key does not exist in the JSONObject, then the key is put in the
-     * JSONObject with its value being a JSONArray containing the value parameter. If the key was already associated
-     * with a JSONArray, then the value parameter is appended to it.
+     * Append values to the array under a key. If the key does not exist in the
+     * JSONObject, then the key is put in the JSONObject with its value being a
+     * JSONArray containing the value parameter. If the key was already
+     * associated with a JSONArray, then the value parameter is appended to it.
      *
-     * @param key   A key string.
-     * @param value An object to be accumulated under the key.
+     * @param key
+     *            A key string.
+     * @param value
+     *            An object to be accumulated under the key.
      * @return this.
-     * @throws JSONException        If the value is non-finite number or if the current value associated with the key is
-     *                              not a JSONArray.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number or if the current value associated with
+     *             the key is not a JSONArray.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject append(String key, Object value) throws JSONException {
         testValidity(value);
@@ -525,9 +588,11 @@ public class JSONObject {
     }
 
     /**
-     * Produce a string from a double. The string "null" will be returned if the number is not finite.
+     * Produce a string from a double. The string "null" will be returned if the
+     * number is not finite.
      *
-     * @param d A double.
+     * @param d
+     *            A double.
      * @return A String.
      */
     public static String doubleToString(double d) {
@@ -539,7 +604,7 @@ public class JSONObject {
 
         String string = Double.toString(d);
         if (string.indexOf('.') > 0 && string.indexOf('e') < 0
-            && string.indexOf('E') < 0) {
+                && string.indexOf('E') < 0) {
             while (string.endsWith("0")) {
                 string = string.substring(0, string.length() - 1);
             }
@@ -553,9 +618,11 @@ public class JSONObject {
     /**
      * Get the value object associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The object associated with the key.
-     * @throws JSONException if the key is not found.
+     * @throws JSONException
+     *             if the key is not found.
      */
     public Object get(String key) throws JSONException {
         if (key == null) {
@@ -571,15 +638,20 @@ public class JSONObject {
     /**
      * Get the enum value associated with a key.
      *
-     * @param <E>   Enum Type
-     * @param clazz The type of enum to retrieve.
-     * @param key   A key string.
+     * @param <E>
+     *            Enum Type
+     * @param clazz
+     *           The type of enum to retrieve.
+     * @param key
+     *           A key string.
      * @return The enum value associated with the key
-     * @throws JSONException if the key is not found or if the value cannot be converted to an enum.
+     * @throws JSONException
+     *             if the key is not found or if the value cannot be converted
+     *             to an enum.
      */
     public <E extends Enum<E>> E getEnum(Class<E> clazz, String key) throws JSONException {
         E val = optEnum(clazz, key);
-        if (val == null) {
+        if(val==null) {
             // JSONException should really take a throwable argument.
             // If it did, I would re-implement this with the Enum.valueOf
             // method and place any thrown exception in the JSONException
@@ -591,19 +663,22 @@ public class JSONObject {
     /**
      * Get the boolean value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The truth.
-     * @throws JSONException if the value is not a Boolean or the String "true" or "false".
+     * @throws JSONException
+     *             if the value is not a Boolean or the String "true" or
+     *             "false".
      */
     public boolean getBoolean(String key) throws JSONException {
         Object object = this.get(key);
         if (object.equals(Boolean.FALSE)
-            || (object instanceof String && ((String) object)
-            .equalsIgnoreCase("false"))) {
+                || (object instanceof String && ((String) object)
+                        .equalsIgnoreCase("false"))) {
             return false;
         } else if (object.equals(Boolean.TRUE)
-            || (object instanceof String && ((String) object)
-            .equalsIgnoreCase("true"))) {
+                || (object instanceof String && ((String) object)
+                        .equalsIgnoreCase("true"))) {
             return true;
         }
         throw wrongValueFormatException(key, "Boolean", object, null);
@@ -612,9 +687,12 @@ public class JSONObject {
     /**
      * Get the BigInteger value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The numeric value.
-     * @throws JSONException if the key is not found or if the value cannot be converted to BigInteger.
+     * @throws JSONException
+     *             if the key is not found or if the value cannot
+     *             be converted to BigInteger.
      */
     public BigInteger getBigInteger(String key) throws JSONException {
         Object object = this.get(key);
@@ -626,13 +704,17 @@ public class JSONObject {
     }
 
     /**
-     * Get the BigDecimal value associated with a key. If the value is float or double, the
-     * {@link BigDecimal#BigDecimal(double)} constructor will be used. See notes on the constructor for conversion
-     * issues that may arise.
+     * Get the BigDecimal value associated with a key. If the value is float or
+     * double, the {@link BigDecimal#BigDecimal(double)} constructor will
+     * be used. See notes on the constructor for conversion issues that may
+     * arise.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The numeric value.
-     * @throws JSONException if the key is not found or if the value cannot be converted to BigDecimal.
+     * @throws JSONException
+     *             if the key is not found or if the value
+     *             cannot be converted to BigDecimal.
      */
     public BigDecimal getBigDecimal(String key) throws JSONException {
         Object object = this.get(key);
@@ -646,15 +728,17 @@ public class JSONObject {
     /**
      * Get the double value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The numeric value.
-     * @throws JSONException if the key is not found or if the value is not a Number object and cannot be converted to a
-     *                       number.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a Number
+     *             object and cannot be converted to a number.
      */
     public double getDouble(String key) throws JSONException {
         final Object object = this.get(key);
-        if (object instanceof Number) {
-            return ((Number) object).doubleValue();
+        if(object instanceof Number) {
+            return ((Number)object).doubleValue();
         }
         try {
             return Double.parseDouble(object.toString());
@@ -666,15 +750,17 @@ public class JSONObject {
     /**
      * Get the float value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The numeric value.
-     * @throws JSONException if the key is not found or if the value is not a Number object and cannot be converted to a
-     *                       number.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a Number
+     *             object and cannot be converted to a number.
      */
     public float getFloat(String key) throws JSONException {
         final Object object = this.get(key);
-        if (object instanceof Number) {
-            return ((Number) object).floatValue();
+        if(object instanceof Number) {
+            return ((Number)object).floatValue();
         }
         try {
             return Float.parseFloat(object.toString());
@@ -686,16 +772,18 @@ public class JSONObject {
     /**
      * Get the Number value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The numeric value.
-     * @throws JSONException if the key is not found or if the value is not a Number object and cannot be converted to a
-     *                       number.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a Number
+     *             object and cannot be converted to a number.
      */
     public Number getNumber(String key) throws JSONException {
         Object object = this.get(key);
         try {
             if (object instanceof Number) {
-                return (Number) object;
+                return (Number)object;
             }
             return stringToNumber(object.toString());
         } catch (Exception e) {
@@ -706,14 +794,17 @@ public class JSONObject {
     /**
      * Get the int value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The integer value.
-     * @throws JSONException if the key is not found or if the value cannot be converted to an integer.
+     * @throws JSONException
+     *             if the key is not found or if the value cannot be converted
+     *             to an integer.
      */
     public int getInt(String key) throws JSONException {
         final Object object = this.get(key);
-        if (object instanceof Number) {
-            return ((Number) object).intValue();
+        if(object instanceof Number) {
+            return ((Number)object).intValue();
         }
         try {
             return Integer.parseInt(object.toString());
@@ -725,9 +816,11 @@ public class JSONObject {
     /**
      * Get the JSONArray value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return A JSONArray which is the value.
-     * @throws JSONException if the key is not found or if the value is not a JSONArray.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a JSONArray.
      */
     public JSONArray getJSONArray(String key) throws JSONException {
         Object object = this.get(key);
@@ -740,9 +833,11 @@ public class JSONObject {
     /**
      * Get the JSONObject value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return A JSONObject which is the value.
-     * @throws JSONException if the key is not found or if the value is not a JSONObject.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a JSONObject.
      */
     public JSONObject getJSONObject(String key) throws JSONException {
         Object object = this.get(key);
@@ -755,14 +850,17 @@ public class JSONObject {
     /**
      * Get the long value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The long value.
-     * @throws JSONException if the key is not found or if the value cannot be converted to a long.
+     * @throws JSONException
+     *             if the key is not found or if the value cannot be converted
+     *             to a long.
      */
     public long getLong(String key) throws JSONException {
         final Object object = this.get(key);
-        if (object instanceof Number) {
-            return ((Number) object).longValue();
+        if(object instanceof Number) {
+            return ((Number)object).longValue();
         }
         try {
             return Long.parseLong(object.toString());
@@ -774,7 +872,8 @@ public class JSONObject {
     /**
      * Get an array of field names from a JSONObject.
      *
-     * @param jo JSON object
+     * @param jo
+     *            JSON object
      * @return An array of field names, or null if there are no names.
      */
     public static String[] getNames(JSONObject jo) {
@@ -787,7 +886,8 @@ public class JSONObject {
     /**
      * Get an array of public field names from an Object.
      *
-     * @param object object to read
+     * @param object
+     *            object to read
      * @return An array of field names, or null if there are no names.
      */
     public static String[] getNames(Object object) {
@@ -810,9 +910,11 @@ public class JSONObject {
     /**
      * Get the string associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return A string which is the value.
-     * @throws JSONException if there is no string value for the key.
+     * @throws JSONException
+     *             if there is no string value for the key.
      */
     public String getString(String key) throws JSONException {
         Object object = this.get(key);
@@ -825,7 +927,8 @@ public class JSONObject {
     /**
      * Determine if the JSONObject contains a specific key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return true if the key exists in the JSONObject.
      */
     public boolean has(String key) {
@@ -833,15 +936,19 @@ public class JSONObject {
     }
 
     /**
-     * Increment a property of a JSONObject. If there is no such property, create one with a value of 1 (Integer). If
-     * there is such a property, and if it is an Integer, Long, Double, Float, BigInteger, or BigDecimal then add one to
-     * it. No overflow bounds checking is performed, so callers should initialize the key prior to this call with an
-     * appropriate type that can handle the maximum expected value.
+     * Increment a property of a JSONObject. If there is no such property,
+     * create one with a value of 1 (Integer). If there is such a property, and if it is
+     * an Integer, Long, Double, Float, BigInteger, or BigDecimal then add one to it.
+     * No overflow bounds checking is performed, so callers should initialize the key
+     * prior to this call with an appropriate type that can handle the maximum expected
+     * value.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return this.
-     * @throws JSONException If there is already a property with this name that is not an Integer, Long, Double, or
-     *                       Float.
+     * @throws JSONException
+     *             If there is already a property with this name that is not an
+     *             Integer, Long, Double, or Float.
      */
     public JSONObject increment(String key) throws JSONException {
         Object value = this.opt(key);
@@ -852,13 +959,13 @@ public class JSONObject {
         } else if (value instanceof Long) {
             this.put(key, ((Long) value).longValue() + 1L);
         } else if (value instanceof BigInteger) {
-            this.put(key, ((BigInteger) value).add(BigInteger.ONE));
+            this.put(key, ((BigInteger)value).add(BigInteger.ONE));
         } else if (value instanceof Float) {
             this.put(key, ((Float) value).floatValue() + 1.0f);
         } else if (value instanceof Double) {
             this.put(key, ((Double) value).doubleValue() + 1.0d);
         } else if (value instanceof BigDecimal) {
-            this.put(key, ((BigDecimal) value).add(BigDecimal.ONE));
+            this.put(key, ((BigDecimal)value).add(BigDecimal.ONE));
         } else {
             throw new JSONException("Unable to increment [" + quote(key) + "].");
         }
@@ -866,45 +973,53 @@ public class JSONObject {
     }
 
     /**
-     * Determine if the value associated with the key is <code>null</code> or if there is no value.
+     * Determine if the value associated with the key is <code>null</code> or if there is no
+     * value.
      *
-     * @param key A key string.
-     * @return true if there is no value associated with the key or if the value is the JSONObject.NULL object.
+     * @param key
+     *            A key string.
+     * @return true if there is no value associated with the key or if the value
+     *        is the JSONObject.NULL object.
      */
     public boolean isNull(String key) {
         return JSONObject.NULL.equals(this.opt(key));
     }
 
     /**
-     * Get an enumeration of the keys of the JSONObject. Modifying this key Set will also modify the JSONObject. Use
-     * with caution.
+     * Get an enumeration of the keys of the JSONObject. Modifying this key Set will also
+     * modify the JSONObject. Use with caution.
+     *
+     * @see Set#iterator()
      *
      * @return An iterator of the keys.
-     * @see Set#iterator()
      */
     public Iterator<String> keys() {
         return this.keySet().iterator();
     }
 
     /**
-     * Get a set of keys of the JSONObject. Modifying this key Set will also modify the JSONObject. Use with caution.
+     * Get a set of keys of the JSONObject. Modifying this key Set will also modify the
+     * JSONObject. Use with caution.
+     *
+     * @see Map#keySet()
      *
      * @return A keySet.
-     * @see Map#keySet()
      */
     public Set<String> keySet() {
         return this.map.keySet();
     }
 
     /**
-     * Get a set of entries of the JSONObject. These are raw values and may not match what is returned by the JSONObject
-     * get* and opt* functions. Modifying the returned EntrySet or the Entry objects contained therein will modify the
+     * Get a set of entries of the JSONObject. These are raw values and may not
+     * match what is returned by the JSONObject get* and opt* functions. Modifying
+     * the returned EntrySet or the Entry objects contained therein will modify the
      * backing JSONObject. This does not return a clone or a read-only view.
-     * <p>
+     *
      * Use with caution.
      *
-     * @return An Entry Set
      * @see Map#entrySet()
+     *
+     * @return An Entry Set
      */
     protected Set<Entry<String, Object>> entrySet() {
         return this.map.entrySet();
@@ -920,7 +1035,8 @@ public class JSONObject {
     }
 
     /**
-     * Removes all of the elements from this JSONObject. The JSONObject will be empty after this call returns.
+     * Removes all of the elements from this JSONObject.
+     * The JSONObject will be empty after this call returns.
      */
     public void clear() {
         this.map.clear();
@@ -936,23 +1052,27 @@ public class JSONObject {
     }
 
     /**
-     * Produce a JSONArray containing the names of the elements of this JSONObject.
+     * Produce a JSONArray containing the names of the elements of this
+     * JSONObject.
      *
-     * @return A JSONArray containing the key strings, or null if the JSONObject is empty.
+     * @return A JSONArray containing the key strings, or null if the JSONObject
+     *        is empty.
      */
     public JSONArray names() {
-        if (this.map.isEmpty()) {
-            return null;
-        }
+    	if(this.map.isEmpty()) {
+    		return null;
+    	}
         return new JSONArray(this.map.keySet());
     }
 
     /**
      * Produce a string from a Number.
      *
-     * @param number A Number
+     * @param number
+     *            A Number
      * @return A String.
-     * @throws JSONException If n is a non-finite number.
+     * @throws JSONException
+     *             If n is a non-finite number.
      */
     public static String numberToString(Number number) throws JSONException {
         if (number == null) {
@@ -964,7 +1084,7 @@ public class JSONObject {
 
         String string = number.toString();
         if (string.indexOf('.') > 0 && string.indexOf('e') < 0
-            && string.indexOf('E') < 0) {
+                && string.indexOf('E') < 0) {
             while (string.endsWith("0")) {
                 string = string.substring(0, string.length() - 1);
             }
@@ -978,7 +1098,8 @@ public class JSONObject {
     /**
      * Get an optional value associated with a key.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return An object which is the value, or null if there is no value.
      */
     public Object opt(String key) {
@@ -988,9 +1109,12 @@ public class JSONObject {
     /**
      * Get the enum value associated with a key.
      *
-     * @param <E>   Enum Type
-     * @param clazz The type of enum to retrieve.
-     * @param key   A key string.
+     * @param <E>
+     *            Enum Type
+     * @param clazz
+     *            The type of enum to retrieve.
+     * @param key
+     *            A key string.
      * @return The enum value associated with the key or null if not found
      */
     public <E extends Enum<E>> E optEnum(Class<E> clazz, String key) {
@@ -1000,12 +1124,16 @@ public class JSONObject {
     /**
      * Get the enum value associated with a key.
      *
-     * @param <E>          Enum Type
-     * @param clazz        The type of enum to retrieve.
-     * @param key          A key string.
-     * @param defaultValue The default in case the value is not found
-     * @return The enum value associated with the key or defaultValue if the value is not found or cannot be assigned to
-     * <code>clazz</code>
+     * @param <E>
+     *            Enum Type
+     * @param clazz
+     *            The type of enum to retrieve.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default in case the value is not found
+     * @return The enum value associated with the key or defaultValue
+     *            if the value is not found or cannot be assigned to <code>clazz</code>
      */
     public <E extends Enum<E>> E optEnum(Class<E> clazz, String key, E defaultValue) {
         try {
@@ -1028,10 +1156,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional boolean associated with a key. It returns false if there is no such key, or if the value is not
-     * Boolean.TRUE or the String "true".
+     * Get an optional boolean associated with a key. It returns false if there
+     * is no such key, or if the value is not Boolean.TRUE or the String "true".
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The truth.
      */
     public boolean optBoolean(String key) {
@@ -1039,11 +1168,14 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional boolean associated with a key. It returns the defaultValue if there is no such key, or if it is
-     * not a Boolean or the String "true" or "false" (case insensitive).
+     * Get an optional boolean associated with a key. It returns the
+     * defaultValue if there is no such key, or if it is not a Boolean or the
+     * String "true" or "false" (case insensitive).
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return The truth.
      */
     public boolean optBoolean(String key, boolean defaultValue) {
@@ -1051,7 +1183,7 @@ public class JSONObject {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof Boolean) {
+        if (val instanceof Boolean){
             return ((Boolean) val).booleanValue();
         }
         try {
@@ -1063,10 +1195,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional boolean object associated with a key. It returns false if there is no such key, or if the value
-     * is not Boolean.TRUE or the String "true".
+     * Get an optional boolean object associated with a key. It returns false if there
+     * is no such key, or if the value is not Boolean.TRUE or the String "true".
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The truth.
      */
     public Boolean optBooleanObject(String key) {
@@ -1074,11 +1207,14 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional boolean object associated with a key. It returns the defaultValue if there is no such key, or if
-     * it is not a Boolean or the String "true" or "false" (case insensitive).
+     * Get an optional boolean object associated with a key. It returns the
+     * defaultValue if there is no such key, or if it is not a Boolean or the
+     * String "true" or "false" (case insensitive).
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return The truth.
      */
     public Boolean optBooleanObject(String key, Boolean defaultValue) {
@@ -1086,7 +1222,7 @@ public class JSONObject {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof Boolean) {
+        if (val instanceof Boolean){
             return ((Boolean) val).booleanValue();
         }
         try {
@@ -1098,13 +1234,17 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional BigDecimal associated with a key, or the defaultValue if there is no such key or if its value is
-     * not a number. If the value is a string, an attempt will be made to evaluate it as a number. If the value is float
-     * or double, then the {@link BigDecimal#BigDecimal(double)} constructor will be used. See notes on the constructor
-     * for conversion issues that may arise.
+     * Get an optional BigDecimal associated with a key, or the defaultValue if
+     * there is no such key or if its value is not a number. If the value is a
+     * string, an attempt will be made to evaluate it as a number. If the value
+     * is float or double, then the {@link BigDecimal#BigDecimal(double)}
+     * constructor will be used. See notes on the constructor for conversion
+     * issues that may arise.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public BigDecimal optBigDecimal(String key, BigDecimal defaultValue) {
@@ -1113,38 +1253,39 @@ public class JSONObject {
     }
 
     /**
-     * @param val          value to convert
+     * @param val value to convert
      * @param defaultValue default value to return is the conversion doesn't work or is null.
-     * @return BigDecimal conversion of the original value, or the defaultValue if unable to convert.
+     * @return BigDecimal conversion of the original value, or the defaultValue if unable
+     *          to convert.
      */
     static BigDecimal objectToBigDecimal(Object val, BigDecimal defaultValue) {
         return objectToBigDecimal(val, defaultValue, true);
     }
 
     /**
-     * @param val          value to convert
+     * @param val value to convert
      * @param defaultValue default value to return is the conversion doesn't work or is null.
-     * @param exact        When <code>true</code>, then {@link Double} and {@link Float} values will be converted
-     *                     exactly. When <code>false</code>, they will be converted to {@link String} values before
-     *                     converting to {@link BigDecimal}.
-     * @return BigDecimal conversion of the original value, or the defaultValue if unable to convert.
+     * @param exact When <code>true</code>, then {@link Double} and {@link Float} values will be converted exactly.
+     *      When <code>false</code>, they will be converted to {@link String} values before converting to {@link BigDecimal}.
+     * @return BigDecimal conversion of the original value, or the defaultValue if unable
+     *          to convert.
      */
     static BigDecimal objectToBigDecimal(Object val, BigDecimal defaultValue, boolean exact) {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof BigDecimal) {
+        if (val instanceof BigDecimal){
             return (BigDecimal) val;
         }
-        if (val instanceof BigInteger) {
+        if (val instanceof BigInteger){
             return new BigDecimal((BigInteger) val);
         }
-        if (val instanceof Double || val instanceof Float) {
-            if (!numberIsFinite((Number) val)) {
+        if (val instanceof Double || val instanceof Float){
+            if (!numberIsFinite((Number)val)) {
                 return defaultValue;
             }
             if (exact) {
-                return new BigDecimal(((Number) val).doubleValue());
+                return new BigDecimal(((Number)val).doubleValue());
             }
             // use the string constructor so that we maintain "nice" values for doubles and floats
             // the double constructor will translate doubles to "exact" values instead of the likely
@@ -1152,7 +1293,7 @@ public class JSONObject {
             return new BigDecimal(val.toString());
         }
         if (val instanceof Long || val instanceof Integer
-            || val instanceof Short || val instanceof Byte) {
+                || val instanceof Short || val instanceof Byte){
             return new BigDecimal(((Number) val).longValue());
         }
         // don't check if it's a string in case of unchecked Number subclasses
@@ -1164,11 +1305,14 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional BigInteger associated with a key, or the defaultValue if there is no such key or if its value is
-     * not a number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional BigInteger associated with a key, or the defaultValue if
+     * there is no such key or if its value is not a number. If the value is a
+     * string, an attempt will be made to evaluate it as a number.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public BigInteger optBigInteger(String key, BigInteger defaultValue) {
@@ -1177,28 +1321,29 @@ public class JSONObject {
     }
 
     /**
-     * @param val          value to convert
+     * @param val value to convert
      * @param defaultValue default value to return is the conversion doesn't work or is null.
-     * @return BigInteger conversion of the original value, or the defaultValue if unable to convert.
+     * @return BigInteger conversion of the original value, or the defaultValue if unable
+     *          to convert.
      */
     static BigInteger objectToBigInteger(Object val, BigInteger defaultValue) {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof BigInteger) {
+        if (val instanceof BigInteger){
             return (BigInteger) val;
         }
-        if (val instanceof BigDecimal) {
+        if (val instanceof BigDecimal){
             return ((BigDecimal) val).toBigInteger();
         }
-        if (val instanceof Double || val instanceof Float) {
-            if (!numberIsFinite((Number) val)) {
+        if (val instanceof Double || val instanceof Float){
+            if (!numberIsFinite((Number)val)) {
                 return defaultValue;
             }
             return new BigDecimal(((Number) val).doubleValue()).toBigInteger();
         }
         if (val instanceof Long || val instanceof Integer
-            || val instanceof Short || val instanceof Byte) {
+                || val instanceof Short || val instanceof Byte){
             return BigInteger.valueOf(((Number) val).longValue());
         }
         // don't check if it's a string in case of unchecked Number subclasses
@@ -1209,7 +1354,7 @@ public class JSONObject {
             // this conversion to BigDecimal then to BigInteger is to maintain
             // that type cast support that may truncate the decimal.
             final String valStr = val.toString();
-            if (isDecimalNotation(valStr)) {
+            if(isDecimalNotation(valStr)) {
                 return new BigDecimal(valStr).toBigInteger();
             }
             return new BigInteger(valStr);
@@ -1219,10 +1364,12 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional double associated with a key, or NaN if there is no such key or if its value is not a number. If
-     * the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional double associated with a key, or NaN if there is no such
+     * key or if its value is not a number. If the value is a string, an attempt
+     * will be made to evaluate it as a number.
      *
-     * @param key A string which is the key.
+     * @param key
+     *            A string which is the key.
      * @return An object which is the value.
      */
     public double optDouble(String key) {
@@ -1230,11 +1377,14 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional double associated with a key, or the defaultValue if there is no such key or if its value is not
-     * a number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional double associated with a key, or the defaultValue if
+     * there is no such key or if its value is not a number. If the value is a
+     * string, an attempt will be made to evaluate it as a number.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public double optDouble(String key, double defaultValue) {
@@ -1246,10 +1396,12 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Double object associated with a key, or NaN if there is no such key or if its value is not a
-     * number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional Double object associated with a key, or NaN if there is no such
+     * key or if its value is not a number. If the value is a string, an attempt
+     * will be made to evaluate it as a number.
      *
-     * @param key A string which is the key.
+     * @param key
+     *            A string which is the key.
      * @return An object which is the value.
      */
     public Double optDoubleObject(String key) {
@@ -1257,11 +1409,14 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Double object associated with a key, or the defaultValue if there is no such key or if its value
-     * is not a number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional Double object associated with a key, or the defaultValue if
+     * there is no such key or if its value is not a number. If the value is a
+     * string, an attempt will be made to evaluate it as a number.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public Double optDoubleObject(String key, Double defaultValue) {
@@ -1273,10 +1428,12 @@ public class JSONObject {
     }
 
     /**
-     * Get the optional float value associated with an index. NaN is returned if there is no value for the index, or if
-     * the value is not a number and cannot be converted to a number.
+     * Get the optional float value associated with an index. NaN is returned
+     * if there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The value.
      */
     public float optFloat(String key) {
@@ -1284,11 +1441,14 @@ public class JSONObject {
     }
 
     /**
-     * Get the optional float value associated with an index. The defaultValue is returned if there is no value for the
-     * index, or if the value is not a number and cannot be converted to a number.
+     * Get the optional float value associated with an index. The defaultValue
+     * is returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
      *
-     * @param key          A key string.
-     * @param defaultValue The default value.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default value.
      * @return The value.
      */
     public float optFloat(String key, float defaultValue) {
@@ -1304,10 +1464,12 @@ public class JSONObject {
     }
 
     /**
-     * Get the optional Float object associated with an index. NaN is returned if there is no value for the index, or if
-     * the value is not a number and cannot be converted to a number.
+     * Get the optional Float object associated with an index. NaN is returned
+     * if there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return The object.
      */
     public Float optFloatObject(String key) {
@@ -1315,11 +1477,14 @@ public class JSONObject {
     }
 
     /**
-     * Get the optional Float object associated with an index. The defaultValue is returned if there is no value for the
-     * index, or if the value is not a number and cannot be converted to a number.
+     * Get the optional Float object associated with an index. The defaultValue
+     * is returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
      *
-     * @param key          A key string.
-     * @param defaultValue The default object.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default object.
      * @return The object.
      */
     public Float optFloatObject(String key, Float defaultValue) {
@@ -1335,10 +1500,12 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional int value associated with a key, or zero if there is no such key or if the value is not a number.
-     * If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional int value associated with a key, or zero if there is no
+     * such key or if the value is not a number. If the value is a string, an
+     * attempt will be made to evaluate it as a number.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return An object which is the value.
      */
     public int optInt(String key) {
@@ -1346,11 +1513,14 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional int value associated with a key, or the default if there is no such key or if the value is not a
-     * number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional int value associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public int optInt(String key, int defaultValue) {
@@ -1362,10 +1532,12 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Integer object associated with a key, or zero if there is no such key or if the value is not a
-     * number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional Integer object associated with a key, or zero if there is no
+     * such key or if the value is not a number. If the value is a string, an
+     * attempt will be made to evaluate it as a number.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return An object which is the value.
      */
     public Integer optIntegerObject(String key) {
@@ -1373,11 +1545,14 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Integer object associated with a key, or the default if there is no such key or if the value is
-     * not a number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional Integer object associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public Integer optIntegerObject(String key, Integer defaultValue) {
@@ -1389,10 +1564,11 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional JSONArray associated with a key. It returns null if there is no such key, or if its value is not
-     * a JSONArray.
+     * Get an optional JSONArray associated with a key. It returns null if there
+     * is no such key, or if its value is not a JSONArray.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return A JSONArray which is the value.
      */
     public JSONArray optJSONArray(String key) {
@@ -1400,11 +1576,13 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional JSONArray associated with a key, or the default if there is no such key, or if its value is not a
-     * JSONArray.
+     * Get an optional JSONArray associated with a key, or the default if there
+     * is no such key, or if its value is not a JSONArray.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return A JSONArray which is the value.
      */
     public JSONArray optJSONArray(String key, JSONArray defaultValue) {
@@ -1413,22 +1591,23 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional JSONObject associated with a key. It returns null if there is no such key, or if its value is not
-     * a JSONObject.
+     * Get an optional JSONObject associated with a key. It returns null if
+     * there is no such key, or if its value is not a JSONObject.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return A JSONObject which is the value.
      */
-    public JSONObject optJSONObject(String key) {
-        return this.optJSONObject(key, null);
-    }
+    public JSONObject optJSONObject(String key) { return this.optJSONObject(key, null); }
 
     /**
-     * Get an optional JSONObject associated with a key, or the default if there is no such key or if the value is not a
-     * JSONObject.
+     * Get an optional JSONObject associated with a key, or the default if there
+     * is no such key or if the value is not a JSONObject.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An JSONObject which is the value.
      */
     public JSONObject optJSONObject(String key, JSONObject defaultValue) {
@@ -1437,10 +1616,12 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional long value associated with a key, or zero if there is no such key or if the value is not a
-     * number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional long value associated with a key, or zero if there is no
+     * such key or if the value is not a number. If the value is a string, an
+     * attempt will be made to evaluate it as a number.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return An object which is the value.
      */
     public long optLong(String key) {
@@ -1448,11 +1629,14 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional long value associated with a key, or the default if there is no such key or if the value is not a
-     * number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional long value associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public long optLong(String key, long defaultValue) {
@@ -1465,10 +1649,12 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Long object associated with a key, or zero if there is no such key or if the value is not a
-     * number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional Long object associated with a key, or zero if there is no
+     * such key or if the value is not a number. If the value is a string, an
+     * attempt will be made to evaluate it as a number.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return An object which is the value.
      */
     public Long optLongObject(String key) {
@@ -1476,11 +1662,14 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional Long object associated with a key, or the default if there is no such key or if the value is not
-     * a number. If the value is a string, an attempt will be made to evaluate it as a number.
+     * Get an optional Long object associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public Long optLongObject(String key, Long defaultValue) {
@@ -1493,11 +1682,13 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional {@link Number} value associated with a key, or <code>null</code> if there is no such key or if
-     * the value is not a number. If the value is a string, an attempt will be made to evaluate it as a number
-     * ({@link BigDecimal}). This method would be used in cases where type coercion of the number value is unwanted.
+     * Get an optional {@link Number} value associated with a key, or <code>null</code>
+     * if there is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number ({@link BigDecimal}). This method
+     * would be used in cases where type coercion of the number value is unwanted.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return An object which is the value.
      */
     public Number optNumber(String key) {
@@ -1505,12 +1696,15 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional {@link Number} value associated with a key, or the default if there is no such key or if the
-     * value is not a number. If the value is a string, an attempt will be made to evaluate it as a number. This method
+     * Get an optional {@link Number} value associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number. This method
      * would be used in cases where type coercion of the number value is unwanted.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return An object which is the value.
      */
     public Number optNumber(String key, Number defaultValue) {
@@ -1518,7 +1712,7 @@ public class JSONObject {
         if (NULL.equals(val)) {
             return defaultValue;
         }
-        if (val instanceof Number) {
+        if (val instanceof Number){
             return (Number) val;
         }
 
@@ -1530,10 +1724,12 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional string associated with a key. It returns an empty string if there is no such key. If the value is
-     * not a string and is not null, then it is converted to a string.
+     * Get an optional string associated with a key. It returns an empty string
+     * if there is no such key. If the value is not a string and is not null,
+     * then it is converted to a string.
      *
-     * @param key A key string.
+     * @param key
+     *            A key string.
      * @return A string which is the value.
      */
     public String optString(String key) {
@@ -1541,10 +1737,13 @@ public class JSONObject {
     }
 
     /**
-     * Get an optional string associated with a key. It returns the defaultValue if there is no such key.
+     * Get an optional string associated with a key. It returns the defaultValue
+     * if there is no such key.
      *
-     * @param key          A key string.
-     * @param defaultValue The default.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
      * @return A string which is the value.
      */
     public String optString(String key, String defaultValue) {
@@ -1553,11 +1752,15 @@ public class JSONObject {
     }
 
     /**
-     * Populates the internal map of the JSONObject with the bean properties. The bean can not be recursive.
+     * Populates the internal map of the JSONObject with the bean properties. The
+     * bean can not be recursive.
      *
-     * @param bean the bean
-     * @throws JSONException If a getter returned a non-finite number.
      * @see JSONObject#JSONObject(Object)
+     *
+     * @param bean
+     *            the bean
+     * @throws JSONException
+     *            If a getter returned a non-finite number.
      */
     private void populateMap(Object bean) {
         populateMap(bean, Collections.newSetFromMap(new IdentityHashMap<Object, Boolean>()));
@@ -1574,11 +1777,11 @@ public class JSONObject {
         for (final Method method : methods) {
             final int modifiers = method.getModifiers();
             if (Modifier.isPublic(modifiers)
-                && !Modifier.isStatic(modifiers)
-                && method.getParameterTypes().length == 0
-                && !method.isBridge()
-                && method.getReturnType() != Void.TYPE
-                && isValidMethodName(method.getName())) {
+                    && !Modifier.isStatic(modifiers)
+                    && method.getParameterTypes().length == 0
+                    && !method.isBridge()
+                    && method.getReturnType() != Void.TYPE
+                    && isValidMethodName(method.getName())) {
                 final String key = getKeyNameFromMethod(method);
                 if (key != null && !key.isEmpty()) {
                     try {
@@ -1659,14 +1862,18 @@ public class JSONObject {
     }
 
     /**
-     * Searches the class hierarchy to see if the method or it's super implementations and interfaces has the
-     * annotation.
+     * Searches the class hierarchy to see if the method or it's super
+     * implementations and interfaces has the annotation.
      *
-     * @param <A>             type of the annotation
-     * @param m               method to check
-     * @param annotationClass annotation to look for
-     * @return the {@link Annotation} if the annotation exists on the current method or one of its super class
-     * definitions
+     * @param <A>
+     *            type of the annotation
+     *
+     * @param m
+     *            method to check
+     * @param annotationClass
+     *            annotation to look for
+     * @return the {@link Annotation} if the annotation exists on the current method
+     *         or one of its super class definitions
      */
     private static <A extends Annotation> A getAnnotation(final Method m, final Class<A> annotationClass) {
         // if we have invalid data the result is null
@@ -1697,14 +1904,13 @@ public class JSONObject {
         }
 
         //If the superclass is Object, no annotations will be found any more
-        if (c.getSuperclass().equals(Object.class)) {
+        if (c.getSuperclass().equals(Object.class))
             return null;
-        }
 
         try {
             return getAnnotation(
-                c.getSuperclass().getMethod(m.getName(), m.getParameterTypes()),
-                annotationClass);
+                    c.getSuperclass().getMethod(m.getName(), m.getParameterTypes()),
+                    annotationClass);
         } catch (final SecurityException ex) {
             return null;
         } catch (final NoSuchMethodException ex) {
@@ -1713,11 +1919,14 @@ public class JSONObject {
     }
 
     /**
-     * Searches the class hierarchy to see if the method or it's super implementations and interfaces has the
-     * annotation. Returns the depth of the annotation in the hierarchy.
+     * Searches the class hierarchy to see if the method or it's super
+     * implementations and interfaces has the annotation. Returns the depth of the
+     * annotation in the hierarchy.
      *
-     * @param m               method to check
-     * @param annotationClass annotation to look for
+     * @param m
+     *            method to check
+     * @param annotationClass
+     *            annotation to look for
      * @return Depth of the annotation or -1 if the annotation is not on the method.
      */
     private static int getAnnotationDepth(final Method m, final Class<? extends Annotation> annotationClass) {
@@ -1753,14 +1962,13 @@ public class JSONObject {
         }
 
         //If the superclass is Object, no annotations will be found any more
-        if (c.getSuperclass().equals(Object.class)) {
+        if (c.getSuperclass().equals(Object.class))
             return -1;
-        }
 
         try {
             int d = getAnnotationDepth(
-                c.getSuperclass().getMethod(m.getName(), m.getParameterTypes()),
-                annotationClass);
+                    c.getSuperclass().getMethod(m.getName(), m.getParameterTypes()),
+                    annotationClass);
             if (d > 0) {
                 // since the annotation was on the superclass, add 1
                 return d + 1;
@@ -1776,24 +1984,33 @@ public class JSONObject {
     /**
      * Put a key/boolean pair in the JSONObject.
      *
-     * @param key   A key string.
-     * @param value A boolean which is the value.
+     * @param key
+     *            A key string.
+     * @param value
+     *            A boolean which is the value.
      * @return this.
-     * @throws JSONException        If the value is non-finite number.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject put(String key, boolean value) throws JSONException {
         return this.put(key, value ? Boolean.TRUE : Boolean.FALSE);
     }
 
     /**
-     * Put a key/value pair in the JSONObject, where the value will be a JSONArray which is produced from a Collection.
+     * Put a key/value pair in the JSONObject, where the value will be a
+     * JSONArray which is produced from a Collection.
      *
-     * @param key   A key string.
-     * @param value A Collection value.
+     * @param key
+     *            A key string.
+     * @param value
+     *            A Collection value.
      * @return this.
-     * @throws JSONException        If the value is non-finite number.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject put(String key, Collection<?> value) throws JSONException {
         return this.put(key, new JSONArray(value));
@@ -1802,11 +2019,15 @@ public class JSONObject {
     /**
      * Put a key/double pair in the JSONObject.
      *
-     * @param key   A key string.
-     * @param value A double which is the value.
+     * @param key
+     *            A key string.
+     * @param value
+     *            A double which is the value.
      * @return this.
-     * @throws JSONException        If the value is non-finite number.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject put(String key, double value) throws JSONException {
         return this.put(key, Double.valueOf(value));
@@ -1815,11 +2036,15 @@ public class JSONObject {
     /**
      * Put a key/float pair in the JSONObject.
      *
-     * @param key   A key string.
-     * @param value A float which is the value.
+     * @param key
+     *            A key string.
+     * @param value
+     *            A float which is the value.
      * @return this.
-     * @throws JSONException        If the value is non-finite number.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject put(String key, float value) throws JSONException {
         return this.put(key, Float.valueOf(value));
@@ -1828,11 +2053,15 @@ public class JSONObject {
     /**
      * Put a key/int pair in the JSONObject.
      *
-     * @param key   A key string.
-     * @param value An int which is the value.
+     * @param key
+     *            A key string.
+     * @param value
+     *            An int which is the value.
      * @return this.
-     * @throws JSONException        If the value is non-finite number.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject put(String key, int value) throws JSONException {
         return this.put(key, Integer.valueOf(value));
@@ -1841,39 +2070,53 @@ public class JSONObject {
     /**
      * Put a key/long pair in the JSONObject.
      *
-     * @param key   A key string.
-     * @param value A long which is the value.
+     * @param key
+     *            A key string.
+     * @param value
+     *            A long which is the value.
      * @return this.
-     * @throws JSONException        If the value is non-finite number.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject put(String key, long value) throws JSONException {
         return this.put(key, Long.valueOf(value));
     }
 
     /**
-     * Put a key/value pair in the JSONObject, where the value will be a JSONObject which is produced from a Map.
+     * Put a key/value pair in the JSONObject, where the value will be a
+     * JSONObject which is produced from a Map.
      *
-     * @param key   A key string.
-     * @param value A Map value.
+     * @param key
+     *            A key string.
+     * @param value
+     *            A Map value.
      * @return this.
-     * @throws JSONException        If the value is non-finite number.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject put(String key, Map<?, ?> value) throws JSONException {
         return this.put(key, new JSONObject(value));
     }
 
     /**
-     * Put a key/value pair in the JSONObject. If the value is <code>null</code>, then the key will be removed from the
-     * JSONObject if it is present.
+     * Put a key/value pair in the JSONObject. If the value is <code>null</code>, then the
+     * key will be removed from the JSONObject if it is present.
      *
-     * @param key   A key string.
-     * @param value An object which is the value. It should be of one of these types: Boolean, Double, Integer,
-     *              JSONArray, JSONObject, Long, String, or the JSONObject.NULL object.
+     * @param key
+     *            A key string.
+     * @param value
+     *            An object which is the value. It should be of one of these
+     *            types: Boolean, Double, Integer, JSONArray, JSONObject, Long,
+     *            String, or the JSONObject.NULL object.
      * @return this.
-     * @throws JSONException        If the value is non-finite number.
-     * @throws NullPointerException If the key is <code>null</code>.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
      */
     public JSONObject put(String key, Object value) throws JSONException {
         if (key == null) {
@@ -1889,13 +2132,17 @@ public class JSONObject {
     }
 
     /**
-     * Put a key/value pair in the JSONObject, but only if the key and the value are both non-null, and only if there is
-     * not already a member with that name.
+     * Put a key/value pair in the JSONObject, but only if the key and the value
+     * are both non-null, and only if there is not already a member with that
+     * name.
      *
-     * @param key   key to insert into
-     * @param value value to insert
+     * @param key
+     *            key to insert into
+     * @param value
+     *            value to insert
      * @return this.
-     * @throws JSONException if the key is a duplicate
+     * @throws JSONException
+     *             if the key is a duplicate
      */
     public JSONObject putOnce(String key, Object value) throws JSONException {
         if (key != null && value != null) {
@@ -1908,13 +2155,18 @@ public class JSONObject {
     }
 
     /**
-     * Put a key/value pair in the JSONObject, but only if the key and the value are both non-null.
+     * Put a key/value pair in the JSONObject, but only if the key and the value
+     * are both non-null.
      *
-     * @param key   A key string.
-     * @param value An object which is the value. It should be of one of these types: Boolean, Double, Integer,
-     *              JSONArray, JSONObject, Long, String, or the JSONObject.NULL object.
+     * @param key
+     *            A key string.
+     * @param value
+     *            An object which is the value. It should be of one of these
+     *            types: Boolean, Double, Integer, JSONArray, JSONObject, Long,
+     *            String, or the JSONObject.NULL object.
      * @return this.
-     * @throws JSONException If the value is a non-finite number.
+     * @throws JSONException
+     *             If the value is a non-finite number.
      */
     public JSONObject putOpt(String key, Object value) throws JSONException {
         if (key != null && value != null) {
@@ -1924,8 +2176,9 @@ public class JSONObject {
     }
 
     /**
-     * Creates a JSONPointer using an initialization string and tries to match it to an item within this JSONObject. For
-     * example, given a JSONObject initialized with this document:
+     * Creates a JSONPointer using an initialization string and tries to
+     * match it to an item within this JSONObject. For example, given a
+     * JSONObject initialized with this document:
      * <pre>
      * {
      *     "a":{"b":"c"}
@@ -1935,8 +2188,8 @@ public class JSONObject {
      * <pre>
      * "/a/b"
      * </pre>
-     * Then this method will return the String "c". A JSONPointerException may be thrown from code called by this
-     * method.
+     * Then this method will return the String "c".
+     * A JSONPointerException may be thrown from code called by this method.
      *
      * @param jsonPointer string that can be used to create a JSONPointer
      * @return the item matched by the JSONPointer, otherwise null
@@ -1944,10 +2197,10 @@ public class JSONObject {
     public Object query(String jsonPointer) {
         return query(new JSONPointer(jsonPointer));
     }
-
     /**
-     * Uses a user initialized JSONPointer  and tries to match it to an item within this JSONObject. For example, given
-     * a JSONObject initialized with this document:
+     * Uses a user initialized JSONPointer  and tries to
+     * match it to an item within this JSONObject. For example, given a
+     * JSONObject initialized with this document:
      * <pre>
      * {
      *     "a":{"b":"c"}
@@ -1957,8 +2210,8 @@ public class JSONObject {
      * <pre>
      * "/a/b"
      * </pre>
-     * Then this method will return the String "c". A JSONPointerException may be thrown from code called by this
-     * method.
+     * Then this method will return the String "c".
+     * A JSONPointerException may be thrown from code called by this method.
      *
      * @param jsonPointer string that can be used to create a JSONPointer
      * @return the item matched by the JSONPointer, otherwise null
@@ -1968,20 +2221,20 @@ public class JSONObject {
     }
 
     /**
-     * Queries and returns a value from this object using {@code jsonPointer}, or returns null if the query fails due to
-     * a missing key.
+     * Queries and returns a value from this object using {@code jsonPointer}, or
+     * returns null if the query fails due to a missing key.
      *
      * @param jsonPointer the string representation of the JSON pointer
      * @return the queried value or {@code null}
      * @throws IllegalArgumentException if {@code jsonPointer} has invalid syntax
      */
     public Object optQuery(String jsonPointer) {
-        return optQuery(new JSONPointer(jsonPointer));
+    	return optQuery(new JSONPointer(jsonPointer));
     }
 
     /**
-     * Queries and returns a value from this object using {@code jsonPointer}, or returns null if the query fails due to
-     * a missing key.
+     * Queries and returns a value from this object using {@code jsonPointer}, or
+     * returns null if the query fails due to a missing key.
      *
      * @param jsonPointer The JSON pointer
      * @return the queried value or {@code null}
@@ -1996,11 +2249,14 @@ public class JSONObject {
     }
 
     /**
-     * Produce a string in double quotes with backslash sequences in all the right places. A backslash will be inserted
-     * within &lt;/, producing &lt;\/, allowing JSON text to be delivered in HTML. In JSON text, a string cannot contain
-     * a control character or an unescaped quote or backslash.
+     * Produce a string in double quotes with backslash sequences in all the
+     * right places. A backslash will be inserted within &lt;/, producing
+     * &lt;\/, allowing JSON text to be delivered in HTML. In JSON text, a
+     * string cannot contain a control character or an unescaped quote or
+     * backslash.
      *
-     * @param string A String
+     * @param string
+     *            A String
      * @return A String correctly formatted for insertion in a JSON text.
      */
     @SuppressWarnings("resource")
@@ -2042,42 +2298,42 @@ public class JSONObject {
             b = c;
             c = string.charAt(i);
             switch (c) {
-                case '\\':
-                case '"':
+            case '\\':
+            case '"':
+                w.write('\\');
+                w.write(c);
+                break;
+            case '/':
+                if (b == '<') {
                     w.write('\\');
-                    w.write(c);
-                    break;
-                case '/':
-                    if (b == '<') {
-                        w.write('\\');
-                    }
-                    w.write(c);
-                    break;
-                case '\b':
-                    w.write("\\b");
-                    break;
-                case '\t':
-                    w.write("\\t");
-                    break;
-                case '\n':
-                    w.write("\\n");
-                    break;
-                case '\f':
-                    w.write("\\f");
-                    break;
-                case '\r':
-                    w.write("\\r");
-                    break;
-                default:
-                    if (c < ' ' || (c >= '\u0080' && c < '\u00a0')
+                }
+                w.write(c);
+                break;
+            case '\b':
+                w.write("\\b");
+                break;
+            case '\t':
+                w.write("\\t");
+                break;
+            case '\n':
+                w.write("\\n");
+                break;
+            case '\f':
+                w.write("\\f");
+                break;
+            case '\r':
+                w.write("\\r");
+                break;
+            default:
+                if (c < ' ' || (c >= '\u0080' && c < '\u00a0')
                         || (c >= '\u2000' && c < '\u2100')) {
-                        w.write("\\u");
-                        hhhh = Integer.toHexString(c);
-                        w.write("0000", 0, 4 - hhhh.length());
-                        w.write(hhhh);
-                    } else {
-                        w.write(c);
-                    }
+                    w.write("\\u");
+                    hhhh = Integer.toHexString(c);
+                    w.write("0000", 0, 4 - hhhh.length());
+                    w.write(hhhh);
+                } else {
+                    w.write(c);
+                }
             }
         }
         w.write('"');
@@ -2087,15 +2343,18 @@ public class JSONObject {
     /**
      * Remove a name and its value, if present.
      *
-     * @param key The name to be removed.
-     * @return The value that was associated with the name, or null if there was no value.
+     * @param key
+     *            The name to be removed.
+     * @return The value that was associated with the name, or null if there was
+     *         no value.
      */
     public Object remove(String key) {
         return this.map.remove(key);
     }
 
     /**
-     * Determine if two JSONObjects are similar. They must contain the same set of names which must be associated with
+     * Determine if two JSONObjects are similar.
+     * They must contain the same set of names which must be associated with
      * similar values.
      *
      * @param other The other JSONObject
@@ -2106,34 +2365,34 @@ public class JSONObject {
             if (!(other instanceof JSONObject)) {
                 return false;
             }
-            if (!this.keySet().equals(((JSONObject) other).keySet())) {
+            if (!this.keySet().equals(((JSONObject)other).keySet())) {
                 return false;
             }
-            for (final Entry<String, ?> entry : this.entrySet()) {
+            for (final Entry<String,?> entry : this.entrySet()) {
                 String name = entry.getKey();
                 Object valueThis = entry.getValue();
-                Object valueOther = ((JSONObject) other).get(name);
-                if (valueThis == valueOther) {
-                    continue;
+                Object valueOther = ((JSONObject)other).get(name);
+                if(valueThis == valueOther) {
+                	continue;
                 }
-                if (valueThis == null) {
-                    return false;
+                if(valueThis == null) {
+                	return false;
                 }
                 if (valueThis instanceof JSONObject) {
-                    if (!((JSONObject) valueThis).similar(valueOther)) {
+                    if (!((JSONObject)valueThis).similar(valueOther)) {
                         return false;
                     }
                 } else if (valueThis instanceof JSONArray) {
-                    if (!((JSONArray) valueThis).similar(valueOther)) {
+                    if (!((JSONArray)valueThis).similar(valueOther)) {
                         return false;
                     }
                 } else if (valueThis instanceof Number && valueOther instanceof Number) {
-                    if (!isNumberSimilar((Number) valueThis, (Number) valueOther)) {
-                        return false;
+                    if (!isNumberSimilar((Number)valueThis, (Number)valueOther)) {
+                    	return false;
                     }
                 } else if (valueThis instanceof JSONString && valueOther instanceof JSONString) {
                     if (!((JSONString) valueThis).toJSONString().equals(((JSONString) valueOther).toJSONString())) {
-                        return false;
+                    	return false;
                     }
                 } else if (!valueThis.equals(valueOther)) {
                     return false;
@@ -2147,13 +2406,14 @@ public class JSONObject {
 
     /**
      * Compares two numbers to see if they are similar.
-     * <p>
-     * If either of the numbers are Double or Float instances, then they are checked to have a finite value. If either
-     * value is not finite (NaN or &#177;infinity), then this function will always return false. If both numbers are
-     * finite, they are first checked to be the same type and implement {@link Comparable}. If they do, then the actual
-     * {@link Comparable#compareTo(Object)} is called. If they are not the same type, or don't implement Comparable,
-     * then they are converted to {@link BigDecimal}s. Finally the BigDecimal values are compared using
-     * {@link BigDecimal#compareTo(BigDecimal)}.
+     *
+     * If either of the numbers are Double or Float instances, then they are checked to have
+     * a finite value. If either value is not finite (NaN or &#177;infinity), then this
+     * function will always return false. If both numbers are finite, they are first checked
+     * to be the same type and implement {@link Comparable}. If they do, then the actual
+     * {@link Comparable#compareTo(Object)} is called. If they are not the same type, or don't
+     * implement Comparable, then they are converted to {@link BigDecimal}s. Finally the
+     * BigDecimal values are compared using {@link BigDecimal#compareTo(BigDecimal)}.
      *
      * @param l the Left value to compare. Can not be <code>null</code>.
      * @param r the right value to compare. Can not be <code>null</code>.
@@ -2167,10 +2427,10 @@ public class JSONObject {
 
         // if the classes are the same and implement Comparable
         // then use the built in compare first.
-        if (l.getClass().equals(r.getClass()) && l instanceof Comparable) {
-            @SuppressWarnings({"rawtypes", "unchecked"})
-            int compareTo = ((Comparable) l).compareTo(r);
-            return compareTo == 0;
+        if(l.getClass().equals(r.getClass()) && l instanceof Comparable) {
+            @SuppressWarnings({ "rawtypes", "unchecked" })
+            int compareTo = ((Comparable)l).compareTo(r);
+            return compareTo==0;
         }
 
         // BigDecimal should be able to handle all of our number types that we support through
@@ -2201,15 +2461,18 @@ public class JSONObject {
      */
     protected static boolean isDecimalNotation(final String val) {
         return val.indexOf('.') > -1 || val.indexOf('e') > -1
-            || val.indexOf('E') > -1 || "-0".equals(val);
+                || val.indexOf('E') > -1 || "-0".equals(val);
     }
 
     /**
-     * Try to convert a string into a number, boolean, or null. If the string can't be converted, return the string.
+     * Try to convert a string into a number, boolean, or null. If the string
+     * can't be converted, return the string.
      *
-     * @param string A String. can not be null.
+     * @param string
+     *            A String. can not be null.
      * @return A simple JSON value.
-     * @throws NullPointerException Thrown if the string is null.
+     * @throws NullPointerException
+     *             Thrown if the string is null.
      */
     // Changes to this method must be copied to the corresponding method in
     // the XML class to keep full support for Android
@@ -2245,14 +2508,14 @@ public class JSONObject {
     }
 
     /**
-     * Converts a string to a number using the narrowest possible type. Possible returns for this function are
-     * BigDecimal, Double, BigInteger, Long, and Integer. When a Double is returned, it should always be a valid Double
-     * and not NaN or +-infinity.
+     * Converts a string to a number using the narrowest possible type. Possible
+     * returns for this function are BigDecimal, Double, BigInteger, Long, and Integer.
+     * When a Double is returned, it should always be a valid Double and not NaN or +-infinity.
      *
      * @param val value to convert
      * @return Number representation of the value.
-     * @throws NumberFormatException thrown if the value is not a valid number. A public caller should catch this and
-     *                               wrap it in a {@link JSONException} if applicable.
+     * @throws NumberFormatException thrown if the value is not a valid number. A public
+     *      caller should catch this and wrap it in a {@link JSONException} if applicable.
      */
     protected static Number stringToNumber(final String val) throws NumberFormatException {
         char initial = val.charAt(0);
@@ -2264,7 +2527,7 @@ public class JSONObject {
                 // keep that by forcing a decimal.
                 try {
                     BigDecimal bd = new BigDecimal(val);
-                    if (initial == '-' && BigDecimal.ZERO.compareTo(bd) == 0) {
+                    if(initial == '-' && BigDecimal.ZERO.compareTo(bd)==0) {
                         return Double.valueOf(-0.0);
                     }
                     return bd;
@@ -2272,26 +2535,26 @@ public class JSONObject {
                     // this is to support "Hex Floats" like this: 0x1.0P-1074
                     try {
                         Double d = Double.valueOf(val);
-                        if (d.isNaN() || d.isInfinite()) {
-                            throw new NumberFormatException("val [" + val + "] is not a valid number.");
+                        if(d.isNaN() || d.isInfinite()) {
+                            throw new NumberFormatException("val ["+val+"] is not a valid number.");
                         }
                         return d;
                     } catch (NumberFormatException ignore) {
-                        throw new NumberFormatException("val [" + val + "] is not a valid number.");
+                        throw new NumberFormatException("val ["+val+"] is not a valid number.");
                     }
                 }
             }
             // block items like 00 01 etc. Java number parsers treat these as Octal.
-            if (initial == '0' && val.length() > 1) {
+            if(initial == '0' && val.length() > 1) {
                 char at1 = val.charAt(1);
-                if (at1 >= '0' && at1 <= '9') {
-                    throw new NumberFormatException("val [" + val + "] is not a valid number.");
+                if(at1 >= '0' && at1 <= '9') {
+                    throw new NumberFormatException("val ["+val+"] is not a valid number.");
                 }
             } else if (initial == '-' && val.length() > 2) {
                 char at1 = val.charAt(1);
                 char at2 = val.charAt(2);
-                if (at1 == '0' && at2 >= '0' && at2 <= '9') {
-                    throw new NumberFormatException("val [" + val + "] is not a valid number.");
+                if(at1 == '0' && at2 >= '0' && at2 <= '9') {
+                    throw new NumberFormatException("val ["+val+"] is not a valid number.");
                 }
             }
             // integer representation.
@@ -2303,22 +2566,24 @@ public class JSONObject {
             // only what they need. i.e. Less runtime overhead if the value is
             // long lived.
             BigInteger bi = new BigInteger(val);
-            if (bi.bitLength() <= 31) {
+            if(bi.bitLength() <= 31){
                 return Integer.valueOf(bi.intValue());
             }
-            if (bi.bitLength() <= 63) {
+            if(bi.bitLength() <= 63){
                 return Long.valueOf(bi.longValue());
             }
             return bi;
         }
-        throw new NumberFormatException("val [" + val + "] is not a valid number.");
+        throw new NumberFormatException("val ["+val+"] is not a valid number.");
     }
 
     /**
      * Throw an exception if the object is a NaN or infinite number.
      *
-     * @param o The object to test.
-     * @throws JSONException If o is a non-finite number.
+     * @param o
+     *            The object to test.
+     * @throws JSONException
+     *             If o is a non-finite number.
      */
     public static void testValidity(Object o) throws JSONException {
         if (o instanceof Number && !numberIsFinite((Number) o)) {
@@ -2327,12 +2592,15 @@ public class JSONObject {
     }
 
     /**
-     * Produce a JSONArray containing the values of the members of this JSONObject.
+     * Produce a JSONArray containing the values of the members of this
+     * JSONObject.
      *
-     * @param names A JSONArray containing a list of key strings. This determines the sequence of the values in the
-     *              result.
+     * @param names
+     *            A JSONArray containing a list of key strings. This determines
+     *            the sequence of the values in the result.
      * @return A JSONArray of values.
-     * @throws JSONException If any of the values are non-finite numbers.
+     * @throws JSONException
+     *             If any of the values are non-finite numbers.
      */
     public JSONArray toJSONArray(JSONArray names) throws JSONException {
         if (names == null || names.isEmpty()) {
@@ -2346,15 +2614,17 @@ public class JSONObject {
     }
 
     /**
-     * Make a JSON text of this JSONObject. For compactness, no whitespace is added. If this would not result in a
-     * syntactically correct JSON text, then null will be returned instead.
+     * Make a JSON text of this JSONObject. For compactness, no whitespace is
+     * added. If this would not result in a syntactically correct JSON text,
+     * then null will be returned instead.
      * <p><b>
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
      *
-     * @return a printable, displayable, portable, transmittable representation of the object, beginning with
-     * <code>{</code>&nbsp;<small>(left brace)</small> and ending with <code>}</code>&nbsp;<small>(right
-     * brace)</small>.
+     * @return a printable, displayable, portable, transmittable representation
+     *         of the object, beginning with <code>{</code>&nbsp;<small>(left
+     *         brace)</small> and ending with <code>}</code>&nbsp;<small>(right
+     *         brace)</small>.
      */
     @Override
     public String toString() {
@@ -2382,11 +2652,14 @@ public class JSONObject {
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
      *
-     * @param indentFactor The number of spaces to add to each level of indentation.
-     * @return a printable, displayable, portable, transmittable representation of the object, beginning with
-     * <code>{</code>&nbsp;<small>(left brace)</small> and ending with <code>}</code>&nbsp;<small>(right
-     * brace)</small>.
-     * @throws JSONException If the object contains an invalid number.
+     * @param indentFactor
+     *            The number of spaces to add to each level of indentation.
+     * @return a printable, displayable, portable, transmittable representation
+     *         of the object, beginning with <code>{</code>&nbsp;<small>(left
+     *         brace)</small> and ending with <code>}</code>&nbsp;<small>(right
+     *         brace)</small>.
+     * @throws JSONException
+     *             If the object contains an invalid number.
      */
     @SuppressWarnings("resource")
     public String toString(int indentFactor) throws JSONException {
@@ -2398,37 +2671,47 @@ public class JSONObject {
     }
 
     /**
-     * Make a JSON text of an Object value. If the object has an value.toJSONString() method, then that method will be
-     * used to produce the JSON text. The method is required to produce a strictly conforming text. If the object does
-     * not contain a toJSONString method (which is the most common case), then a text will be produced by other means.
-     * If the value is an array or Collection, then a JSONArray will be made from it and its toJSONString method will be
-     * called. If the value is a MAP, then a JSONObject will be made from it and its toJSONString method will be called.
-     * Otherwise, the value's toString method will be called, and the result will be quoted.
+     * Make a JSON text of an Object value. If the object has an
+     * value.toJSONString() method, then that method will be used to produce the
+     * JSON text. The method is required to produce a strictly conforming text.
+     * If the object does not contain a toJSONString method (which is the most
+     * common case), then a text will be produced by other means. If the value
+     * is an array or Collection, then a JSONArray will be made from it and its
+     * toJSONString method will be called. If the value is a MAP, then a
+     * JSONObject will be made from it and its toJSONString method will be
+     * called. Otherwise, the value's toString method will be called, and the
+     * result will be quoted.
      *
      * <p>
      * Warning: This method assumes that the data structure is acyclical.
      *
-     * @param value The value to be serialized.
-     * @return a printable, displayable, transmittable representation of the object, beginning with
-     * <code>{</code>&nbsp;<small>(left brace)</small> and ending with <code>}</code>&nbsp;<small>(right
-     * brace)</small>.
-     * @throws JSONException If the value is or contains an invalid number.
+     * @param value
+     *            The value to be serialized.
+     * @return a printable, displayable, transmittable representation of the
+     *         object, beginning with <code>{</code>&nbsp;<small>(left
+     *         brace)</small> and ending with <code>}</code>&nbsp;<small>(right
+     *         brace)</small>.
+     * @throws JSONException
+     *             If the value is or contains an invalid number.
      */
     public static String valueToString(Object value) throws JSONException {
-        // moves the implementation to JSONWriter as:
-        // 1. It makes more sense to be part of the writer class
-        // 2. For Android support this method is not available. By implementing it in the Writer
-        //    Android users can use the writer with the built in Android JSONObject implementation.
+    	// moves the implementation to JSONWriter as:
+    	// 1. It makes more sense to be part of the writer class
+    	// 2. For Android support this method is not available. By implementing it in the Writer
+    	//    Android users can use the writer with the built in Android JSONObject implementation.
         return JSONWriter.valueToString(value);
     }
 
     /**
-     * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL object. If it is an array or
-     * collection, wrap it in a JSONArray. If it is a map, wrap it in a JSONObject. If it is a standard property
-     * (Double, String, et al) then it is already wrapped. Otherwise, if it comes from one of the java packages, turn it
-     * into a string. And if it doesn't, try to wrap it in a JSONObject. If the wrapping fails, then null is returned.
+     * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL
+     * object. If it is an array or collection, wrap it in a JSONArray. If it is
+     * a map, wrap it in a JSONObject. If it is a standard property (Double,
+     * String, et al) then it is already wrapped. Otherwise, if it comes from
+     * one of the java packages, turn it into a string. And if it doesn't, try
+     * to wrap it in a JSONObject. If the wrapping fails, then null is returned.
      *
-     * @param object The object to wrap
+     * @param object
+     *            The object to wrap
      * @return The wrapped value
      */
     public static Object wrap(Object object) {
@@ -2436,38 +2719,42 @@ public class JSONObject {
     }
 
     /**
-     * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL object. If it is an array or
-     * collection, wrap it in a JSONArray. If it is a map, wrap it in a JSONObject. If it is a standard property
-     * (Double, String, et al) then it is already wrapped. Otherwise, if it comes from one of the java packages, turn it
-     * into a string. And if it doesn't, try to wrap it in a JSONObject. If the wrapping fails, then null is returned.
+     * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL
+     * object. If it is an array or collection, wrap it in a JSONArray. If it is
+     * a map, wrap it in a JSONObject. If it is a standard property (Double,
+     * String, et al) then it is already wrapped. Otherwise, if it comes from
+     * one of the java packages, turn it into a string. And if it doesn't, try
+     * to wrap it in a JSONObject. If the wrapping fails, then null is returned.
      *
-     * @param object                  The object to wrap
-     * @param recursionDepth          Variable for tracking the count of nested object creations.
-     * @param jsonParserConfiguration Variable to pass parser custom configuration for json parsing.
+     * @param object
+     *            The object to wrap
+     * @param recursionDepth
+     *            Variable for tracking the count of nested object creations.
+     * @param jsonParserConfiguration
+     *            Variable to pass parser custom configuration for json parsing.
      * @return The wrapped value
      */
     static Object wrap(Object object, int recursionDepth, JSONParserConfiguration jsonParserConfiguration) {
-        return wrap(object, null, recursionDepth, jsonParserConfiguration);
+      return wrap(object, null, recursionDepth, jsonParserConfiguration);
     }
 
     private static Object wrap(Object object, Set<Object> objectsRecord) {
-        return wrap(object, objectsRecord, 0, new JSONParserConfiguration());
+      return wrap(object, objectsRecord, 0, new JSONParserConfiguration());
     }
 
-    private static Object wrap(Object object, Set<Object> objectsRecord, int recursionDepth,
-        JSONParserConfiguration jsonParserConfiguration) {
+    private static Object wrap(Object object, Set<Object> objectsRecord, int recursionDepth, JSONParserConfiguration jsonParserConfiguration) {
         try {
             if (NULL.equals(object)) {
                 return NULL;
             }
             if (object instanceof JSONObject || object instanceof JSONArray
-                || NULL.equals(object) || object instanceof JSONString
-                || object instanceof Byte || object instanceof Character
-                || object instanceof Short || object instanceof Integer
-                || object instanceof Long || object instanceof Boolean
-                || object instanceof Float || object instanceof Double
-                || object instanceof String || object instanceof BigInteger
-                || object instanceof BigDecimal || object instanceof Enum) {
+                    || NULL.equals(object) || object instanceof JSONString
+                    || object instanceof Byte || object instanceof Character
+                    || object instanceof Short || object instanceof Integer
+                    || object instanceof Long || object instanceof Boolean
+                    || object instanceof Float || object instanceof Double
+                    || object instanceof String || object instanceof BigInteger
+                    || object instanceof BigDecimal || object instanceof Enum) {
                 return object;
             }
 
@@ -2484,17 +2771,18 @@ public class JSONObject {
             }
             Package objectPackage = object.getClass().getPackage();
             String objectPackageName = objectPackage != null ? objectPackage
-                .getName() : "";
+                    .getName() : "";
             if (objectPackageName.startsWith("java.")
-                || objectPackageName.startsWith("javax.")
-                || object.getClass().getClassLoader() == null) {
+                    || objectPackageName.startsWith("javax.")
+                    || object.getClass().getClassLoader() == null) {
                 return object.toString();
             }
             if (objectsRecord != null) {
                 return new JSONObject(object, objectsRecord);
             }
             return new JSONObject(object);
-        } catch (JSONException exception) {
+        }
+        catch (JSONException exception) {
             throw exception;
         } catch (Exception exception) {
             return null;
@@ -2502,11 +2790,11 @@ public class JSONObject {
     }
 
     /**
-     * Write the contents of the JSONObject as JSON text to a writer. For compactness, no whitespace is added.
+     * Write the contents of the JSONObject as JSON text to a writer. For
+     * compactness, no whitespace is added.
      * <p><b>
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
-     *
      * @param writer the writer object
      * @return The writer.
      * @throws JSONException if a called function has an error
@@ -2517,7 +2805,7 @@ public class JSONObject {
 
     @SuppressWarnings("resource")
     static final Writer writeValue(Writer writer, Object value,
-        int indentFactor, int indent) throws JSONException, IOException {
+            int indentFactor, int indent) throws JSONException, IOException {
         if (value == null || value.equals(null)) {
             writer.write("null");
         } else if (value instanceof JSONString) {
@@ -2536,7 +2824,7 @@ public class JSONObject {
         } else if (value instanceof Number) {
             // not all Numbers may match actual JSON Numbers. i.e. fractions or Imaginary
             final String numberAsString = numberToString((Number) value);
-            if (NUMBER_PATTERN.matcher(numberAsString).matches()) {
+            if(NUMBER_PATTERN.matcher(numberAsString).matches()) {
                 writer.write(numberAsString);
             } else {
                 // The Number value is not a valid JSON number.
@@ -2546,7 +2834,7 @@ public class JSONObject {
         } else if (value instanceof Boolean) {
             writer.write(value.toString());
         } else if (value instanceof Enum<?>) {
-            writer.write(quote(((Enum<?>) value).name()));
+            writer.write(quote(((Enum<?>)value).name()));
         } else if (value instanceof JSONObject) {
             ((JSONObject) value).write(writer, indentFactor, indent);
         } else if (value instanceof JSONArray) {
@@ -2588,36 +2876,40 @@ public class JSONObject {
      * Warning: This method assumes that the data structure is acyclical.
      * </b>
      *
-     * @param writer       Writes the serialized JSON
-     * @param indentFactor The number of spaces to add to each level of indentation.
-     * @param indent       The indentation of the top level.
+     * @param writer
+     *            Writes the serialized JSON
+     * @param indentFactor
+     *            The number of spaces to add to each level of indentation.
+     * @param indent
+     *            The indentation of the top level.
      * @return The writer.
-     * @throws JSONException if a called function has an error or a write error occurs
+     * @throws JSONException if a called function has an error or a write error
+     * occurs
      */
     @SuppressWarnings("resource")
     public Writer write(Writer writer, int indentFactor, int indent)
-        throws JSONException {
+            throws JSONException {
         try {
             boolean needsComma = false;
             final int length = this.length();
             writer.write('{');
 
             if (length == 1) {
-                final Entry<String, ?> entry = this.entrySet().iterator().next();
+            	final Entry<String,?> entry = this.entrySet().iterator().next();
                 final String key = entry.getKey();
                 writer.write(quote(key));
                 writer.write(':');
                 if (indentFactor > 0) {
                     writer.write(' ');
                 }
-                try {
+                try{
                     writeValue(writer, entry.getValue(), indentFactor, indent);
                 } catch (Exception e) {
                     throw new JSONException("Unable to write JSONObject value for key: " + key, e);
                 }
             } else if (length != 0) {
                 final int newIndent = indent + indentFactor;
-                for (final Entry<String, ?> entry : this.entrySet()) {
+                for (final Entry<String,?> entry : this.entrySet()) {
                     if (needsComma) {
                         writer.write(',');
                     }
@@ -2651,8 +2943,9 @@ public class JSONObject {
     }
 
     /**
-     * Returns a java.util.Map containing all of the entries in this object. If an entry in the object is a JSONArray or
-     * JSONObject it will also be converted.
+     * Returns a java.util.Map containing all of the entries in this object.
+     * If an entry in the object is a JSONArray or JSONObject it will also
+     * be converted.
      * <p>
      * Warning: This method assumes that the data structure is acyclical.
      *
@@ -2678,37 +2971,35 @@ public class JSONObject {
 
     /**
      * Create a new JSONException in a common format for incorrect conversions.
-     *
-     * @param key       name of the key
+     * @param key name of the key
      * @param valueType the type of value being coerced to
-     * @param cause     optional cause of the coercion failure
+     * @param cause optional cause of the coercion failure
      * @return JSONException that can be thrown.
      */
     private static JSONException wrongValueFormatException(
-        String key,
-        String valueType,
-        Object value,
-        Throwable cause) {
-        if (value == null) {
+            String key,
+            String valueType,
+            Object value,
+            Throwable cause) {
+        if(value == null) {
 
             return new JSONException(
-                "JSONObject[" + quote(key) + "] is not a " + valueType + " (null)."
-                , cause);
+                    "JSONObject[" + quote(key) + "] is not a " + valueType + " (null)."
+                    , cause);
         }
         // don't try to toString collections or known object types that could be large.
-        if (value instanceof Map || value instanceof Iterable || value instanceof JSONObject) {
+        if(value instanceof Map || value instanceof Iterable || value instanceof JSONObject) {
             return new JSONException(
-                "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + ")."
-                , cause);
+                    "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + ")."
+                    , cause);
         }
         return new JSONException(
-            "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + " : " + value + ")."
-            , cause);
+                "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + " : " + value + ")."
+                , cause);
     }
 
     /**
      * Create a new JSONException in a common format for recursive object definition.
-     *
      * @param key name of the key
      * @return JSONException that can be thrown.
      */
@@ -2720,28 +3011,21 @@ public class JSONObject {
 
     /**
      * For a prospective number, remove the leading zeros
-     *
      * @param value prospective number
      * @return number without leading zeros
      */
-    private static String removeLeadingZerosOfNumber(String value) {
-        if (value.equals("-")) {
-            return value;
-        }
+    private static String removeLeadingZerosOfNumber(String value){
+        if (value.equals("-")){return value;}
         boolean negativeFirstChar = (value.charAt(0) == '-');
-        int counter = negativeFirstChar ? 1 : 0;
-        while (counter < value.length()) {
-            if (value.charAt(counter) != '0') {
-                if (negativeFirstChar) {
-                    return "-".concat(value.substring(counter));
-                }
+        int counter = negativeFirstChar ? 1:0;
+        while (counter < value.length()){
+            if (value.charAt(counter) != '0'){
+                if (negativeFirstChar) {return "-".concat(value.substring(counter));}
                 return value.substring(counter);
             }
             ++counter;
         }
-        if (negativeFirstChar) {
-            return "-0";
-        }
+        if (negativeFirstChar) {return "-0";}
         return "0";
     }
 }

--- a/src/main/java/org/json/JSONTokener.java
+++ b/src/main/java/org/json/JSONTokener.java
@@ -334,63 +334,71 @@ public class JSONTokener {
      * @return A String.
      * @throws JSONException Unterminated string or unbalanced quotes if strictMode == true.
      */
-    public String nextString(char quote) throws JSONException {
-        char c;
-        StringBuilder sb = new StringBuilder();
-        for (;;) {
-            c = this.next();
-            switch (c) {
-                case 0:
-                case '\n':
-                case '\r':
-                    throw this.syntaxError("Unterminated string. " +
-                        "Character with int code " + (int) c + " is not allowed within a quoted string.");
-                case '\\':
-                    c = this.next();
-                    switch (c) {
-                        case 'b':
-                            sb.append('\b');
-                            break;
-                        case 't':
-                            sb.append('\t');
-                            break;
-                        case 'n':
-                            sb.append('\n');
-                            break;
-                        case 'f':
-                            sb.append('\f');
-                            break;
-                        case 'r':
-                            sb.append('\r');
-                            break;
-                        case 'u':
-                            String next = this.next(4);
-                            try {
-                                sb.append((char) Integer.parseInt(next, 16));
-                            } catch (NumberFormatException e) {
-                                throw this.syntaxError("Illegal escape. " +
-                                        "\\u must be followed by a 4 digit hexadecimal number. \\" + next
-                                        + " is not valid.",
-                                    e);
-                            }
-                            break;
-                        case '"':
-                        case '\'':
-                        case '\\':
-                        case '/':
-                            sb.append(c);
-                            break;
-                        default:
-                            throw this.syntaxError("Illegal escape. Escape sequence  \\" + c + " is not valid.");
-                    }
-                    break;
-                default:
-                    if (c == quote) {
-                        return sb.toString();
-                    }
-                    sb.append(c);
+    public Object nextString(char quote, boolean strictMode) throws JSONException {
+        if (strictMode && quote == '\'') {
+            throw this.syntaxError("Single quote wrap not allowed in strict mode");
+        }
+
+        if (quote == '"' || quote == '\'') {
+            char c;
+            StringBuilder sb = new StringBuilder();
+            for (; ; ) {
+                c = this.next();
+                switch (c) {
+                    case 0:
+                    case '\n':
+                    case '\r':
+                        throw this.syntaxError("Unterminated string. " +
+                            "Character with int code " + (int) c + " is not allowed within a quoted string.");
+                    case '\\':
+                        c = this.next();
+                        switch (c) {
+                            case 'b':
+                                sb.append('\b');
+                                break;
+                            case 't':
+                                sb.append('\t');
+                                break;
+                            case 'n':
+                                sb.append('\n');
+                                break;
+                            case 'f':
+                                sb.append('\f');
+                                break;
+                            case 'r':
+                                sb.append('\r');
+                                break;
+                            case 'u':
+                                String next = this.next(4);
+                                try {
+                                    sb.append((char) Integer.parseInt(next, 16));
+                                } catch (NumberFormatException e) {
+                                    throw this.syntaxError("Illegal escape. " +
+                                            "\\u must be followed by a 4 digit hexadecimal number. \\" + next
+                                            + " is not valid.",
+                                        e);
+                                }
+                                break;
+                            case '"':
+                            case '\'':
+                            case '\\':
+                            case '/':
+                                sb.append(c);
+                                break;
+                            default:
+                                throw this.syntaxError("Illegal escape. Escape sequence  \\" + c + " is not valid.");
+                        }
+                        break;
+                    default:
+                        if (c == quote) {
+                            return sb.toString();
+                        }
+                        sb.append(c);
+                }
             }
         }
+
+        return parsedUnquotedText(quote, strictMode);
     }
 
     /**
@@ -528,15 +536,7 @@ public class JSONTokener {
     Object nextSimpleValue(char c, JSONParserConfiguration jsonParserConfiguration) {
         boolean strictMode = jsonParserConfiguration.isStrictMode();
 
-        if (strictMode && c == '\'') {
-            throw this.syntaxError("Single quote wrap not allowed in strict mode");
-        }
-
-        if (c == '"' || c == '\'') {
-            return this.nextString(c);
-        }
-
-        return parsedUnquotedText(c, strictMode);
+        return this.nextString(c, strictMode);
     }
 
     /**

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -47,6 +47,44 @@ public class JSONParserConfigurationTest {
     }
 
     @Test
+    public void givenInvalidJsonObjects_testStrictModeTrue_shouldThrowJsonException() throws IOException {
+        /*assertThrows(JSONException.class,
+            () -> new JSONObject("{}abc", new JSONParserConfiguration().withStrictMode(true)));*/
+
+        try (final Stream<String> lines = Files.lines(Paths.get("src/test/resources/Issue884-validJsonObj.json"))) {
+            final String resultJsonAsString = lines.collect(Collectors.joining());
+
+            final JSONObject jsonObject = new JSONObject(resultJsonAsString, new JSONParserConfiguration().withStrictMode(true));
+
+            System.out.println(jsonObject.toString(2));
+        } catch (Exception e){
+            e.printStackTrace();
+        }
+
+        //JSONObject jsonObject = new JSONObject("{\"test\": {\"key\": \"val\", \"key2\"}}", new JSONParserConfiguration().withStrictMode(true));
+        //JSONObject jsonObject2 = new JSONObject("{}}", new JSONParserConfiguration().withStrictMode(true));
+    }
+
+    @Test
+    public void givenValidJsonObject_testStrictModeTrue_shouldThrowJsonException() throws IOException {
+        /*assertThrows(JSONException.class,
+            () -> new JSONObject("{}abc", new JSONParserConfiguration().withStrictMode(true)));*/
+
+        try (final Stream<String> lines = Files.lines(Paths.get("src/test/resources/Issue884-validJsonObj.json"))) {
+            final String resultJsonAsString = lines.collect(Collectors.joining());
+
+            final JSONObject jsonObject = new JSONObject(resultJsonAsString, new JSONParserConfiguration().withStrictMode(true));
+
+            System.out.println(jsonObject.toString(2));
+        } catch (Exception e){
+            e.printStackTrace();
+        }
+
+        //JSONObject jsonObject = new JSONObject("{\"test\": {\"key\": \"val\", \"key2\"}}", new JSONParserConfiguration().withStrictMode(true));
+        //JSONObject jsonObject2 = new JSONObject("{}}", new JSONParserConfiguration().withStrictMode(true));
+    }
+
+    @Test
     public void givenEmptyArray_testStrictModeTrue_shouldNotThrowJsonException() {
         JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
             .withStrictMode(true);
@@ -76,7 +114,7 @@ public class JSONParserConfigurationTest {
     }
 
     @Test
-    public void givenValidEmptyArrayInsideArray_testStrictModeTrue_shouldNotThrowJsonException(){
+    public void givenValidEmptyArrayInsideArray_testStrictModeTrue_shouldNotThrowJsonException() {
         JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
             .withStrictMode(true);
 
@@ -88,7 +126,7 @@ public class JSONParserConfigurationTest {
     }
 
     @Test
-    public void givenValidEmptyArrayInsideArray_testStrictModeFalse_shouldNotThrowJsonException(){
+    public void givenValidEmptyArrayInsideArray_testStrictModeFalse_shouldNotThrowJsonException() {
         JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
             .withStrictMode(false);
 
@@ -242,8 +280,12 @@ public class JSONParserConfigurationTest {
         JSONException jeTwo = assertThrows(JSONException.class,
             () -> new JSONArray(testCaseTwo, jsonParserConfiguration));
 
-        assertEquals("Unterminated string. Character with int code 0 is not allowed within a quoted string. at 15 [character 16 line 1]", jeOne.getMessage());
-        assertEquals("Unterminated string. Character with int code 0 is not allowed within a quoted string. at 15 [character 16 line 1]", jeTwo.getMessage());
+        assertEquals(
+            "Unterminated string. Character with int code 0 is not allowed within a quoted string. at 15 [character 16 line 1]",
+            jeOne.getMessage());
+        assertEquals(
+            "Unterminated string. Character with int code 0 is not allowed within a quoted string. at 15 [character 16 line 1]",
+            jeTwo.getMessage());
     }
 
 

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -1,12 +1,8 @@
 package org.json.junit;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -118,7 +114,7 @@ public class JSONParserConfigurationTest {
     }
 
     @Test
-    public void givenValidEmptyArrayInsideArray_testStrictModeTrue_shouldNotThrowJsonException() {
+    public void givenValidEmptyArrayInsideArray_testStrictModeTrue_shouldNotThrowJsonException(){
         JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
             .withStrictMode(true);
 
@@ -130,7 +126,7 @@ public class JSONParserConfigurationTest {
     }
 
     @Test
-    public void givenValidEmptyArrayInsideArray_testStrictModeFalse_shouldNotThrowJsonException() {
+    public void givenValidEmptyArrayInsideArray_testStrictModeFalse_shouldNotThrowJsonException(){
         JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
             .withStrictMode(false);
 
@@ -282,12 +278,8 @@ public class JSONParserConfigurationTest {
         JSONException jeTwo = assertThrows(JSONException.class,
             () -> new JSONArray(testCaseTwo, jsonParserConfiguration));
 
-        assertEquals(
-            "Unterminated string. Character with int code 0 is not allowed within a quoted string. at 15 [character 16 line 1]",
-            jeOne.getMessage());
-        assertEquals(
-            "Unterminated string. Character with int code 0 is not allowed within a quoted string. at 15 [character 16 line 1]",
-            jeTwo.getMessage());
+        assertEquals("Unterminated string. Character with int code 0 is not allowed within a quoted string. at 15 [character 16 line 1]", jeOne.getMessage());
+        assertEquals("Unterminated string. Character with int code 0 is not allowed within a quoted string. at 15 [character 16 line 1]", jeTwo.getMessage());
     }
 
 

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -50,7 +50,8 @@ public class JSONParserConfigurationTest {
     public void givenInvalidJsonObjects_testStrictModeTrue_shouldThrowJsonException() {
         final List<String> jsonObjects = Arrays.asList(
             "{}}",
-            "{}abc"
+            "{}abc",
+            "{{}"
         );
 
         jsonObjects.forEach(jsonObject ->
@@ -59,7 +60,7 @@ public class JSONParserConfigurationTest {
     }
 
     @Test
-    public void givenValidArraysWithInvalidJsonObjects_testStrictMode_shouldThrowJsonException(){
+    public void givenValidArraysWithInvalidJsonObjects_testStrictMode_shouldThrowJsonException() {
         final List<String> jsonArrays = Arrays.asList(
             "[1, {}}]",
             "[1, 2, 3, \"value\", true]abc",
@@ -78,12 +79,12 @@ public class JSONParserConfigurationTest {
         );
 
         jsonPaths.forEach(path -> {
-                final String resultJsonAsString = Util.getJsonStringFromFilePath(Paths.get(path));
+            final String resultJsonAsString = Util.getJsonStringFromFilePath(Paths.get(path));
 
-                final JSONObject resultJsonObject = new JSONObject(resultJsonAsString,
-                    new JSONParserConfiguration().withStrictMode(true));
+            final JSONObject resultJsonObject = new JSONObject(resultJsonAsString,
+                new JSONParserConfiguration().withStrictMode(true));
 
-                assertEquals(resultJsonAsString.replaceAll("\\s", "").length(), resultJsonObject.toString().length());
+            assertEquals(resultJsonAsString.replaceAll("\\s", "").length(), resultJsonObject.toString().length());
         });
     }
 
@@ -167,15 +168,13 @@ public class JSONParserConfigurationTest {
     }
 
     @Test
-    public void givenCompliantJSONArrayFile_testStrictModeTrue_shouldNotThrowAnyException() throws IOException {
-        try (Stream<String> lines = Files.lines(Paths.get("src/test/resources/compliantJsonArray.json"))) {
-            String compliantJsonArrayAsString = lines.collect(Collectors.joining());
-            JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
-                .withStrictMode(true);
+    public void givenCompliantJSONArrayFile_testStrictModeTrue_shouldNotThrowAnyException() {
+        final String compliantJsonArrayAsString = Util.getJsonStringFromFilePath(
+            Paths.get("src/test/resources/compliantJsonArray.json"));
+        final JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
+            .withStrictMode(true);
 
-            new JSONArray(compliantJsonArrayAsString, jsonParserConfiguration);
-        }
-
+        new JSONArray(compliantJsonArrayAsString, jsonParserConfiguration);
     }
 
     @Test

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -59,6 +59,19 @@ public class JSONParserConfigurationTest {
     }
 
     @Test
+    public void givenValidArraysWithInvalidJsonObjects_testStrictMode_shouldThrowJsonException(){
+        final List<String> jsonArrays = Arrays.asList(
+            "[1, {}}]",
+            "[1, 2, 3, \"value\", true]abc",
+            "[{}, {\"key\":\"value\"}abc]"
+        );
+
+        jsonArrays.forEach(jsonArray ->
+            assertThrows(JSONException.class,
+                () -> new JSONArray(jsonArray, new JSONParserConfiguration().withStrictMode(true))));
+    }
+
+    @Test
     public void givenValidJsonObjects_testStrictModeTrue() {
         final List<String> jsonPaths = Arrays.asList(
             "src/test/resources/Issue884-validJsonObj.json"

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -47,41 +47,31 @@ public class JSONParserConfigurationTest {
     }
 
     @Test
-    public void givenInvalidJsonObjects_testStrictModeTrue_shouldThrowJsonException() throws IOException {
-        /*assertThrows(JSONException.class,
-            () -> new JSONObject("{}abc", new JSONParserConfiguration().withStrictMode(true)));*/
+    public void givenInvalidJsonObjects_testStrictModeTrue_shouldThrowJsonException() {
+        final List<String> jsonObjects = Arrays.asList(
+            "{}}",
+            "{}abc"
+        );
 
-        try (final Stream<String> lines = Files.lines(Paths.get("src/test/resources/Issue884-validJsonObj.json"))) {
-            final String resultJsonAsString = lines.collect(Collectors.joining());
-
-            final JSONObject jsonObject = new JSONObject(resultJsonAsString, new JSONParserConfiguration().withStrictMode(true));
-
-            System.out.println(jsonObject.toString(2));
-        } catch (Exception e){
-            e.printStackTrace();
-        }
-
-        //JSONObject jsonObject = new JSONObject("{\"test\": {\"key\": \"val\", \"key2\"}}", new JSONParserConfiguration().withStrictMode(true));
-        //JSONObject jsonObject2 = new JSONObject("{}}", new JSONParserConfiguration().withStrictMode(true));
+        jsonObjects.forEach(jsonObject ->
+            assertThrows(JSONException.class,
+                () -> new JSONObject(jsonObject, new JSONParserConfiguration().withStrictMode(true))));
     }
 
     @Test
-    public void givenValidJsonObject_testStrictModeTrue_shouldThrowJsonException() throws IOException {
-        /*assertThrows(JSONException.class,
-            () -> new JSONObject("{}abc", new JSONParserConfiguration().withStrictMode(true)));*/
+    public void givenValidJsonObjects_testStrictModeTrue() {
+        final List<String> jsonPaths = Arrays.asList(
+            "src/test/resources/Issue884-validJsonObj.json"
+        );
 
-        try (final Stream<String> lines = Files.lines(Paths.get("src/test/resources/Issue884-validJsonObj.json"))) {
-            final String resultJsonAsString = lines.collect(Collectors.joining());
+        jsonPaths.forEach(path -> {
+                final String resultJsonAsString = Util.getJsonStringFromFilePath(Paths.get(path));
 
-            final JSONObject jsonObject = new JSONObject(resultJsonAsString, new JSONParserConfiguration().withStrictMode(true));
+                final JSONObject resultJsonObject = new JSONObject(resultJsonAsString,
+                    new JSONParserConfiguration().withStrictMode(true));
 
-            System.out.println(jsonObject.toString(2));
-        } catch (Exception e){
-            e.printStackTrace();
-        }
-
-        //JSONObject jsonObject = new JSONObject("{\"test\": {\"key\": \"val\", \"key2\"}}", new JSONParserConfiguration().withStrictMode(true));
-        //JSONObject jsonObject2 = new JSONObject("{}}", new JSONParserConfiguration().withStrictMode(true));
+                assertEquals(resultJsonAsString.replaceAll("\\s", "").length(), resultJsonObject.toString().length());
+        });
     }
 
     @Test

--- a/src/test/java/org/json/junit/Util.java
+++ b/src/test/java/org/json/junit/Util.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.*;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 
 import java.util.stream.Collectors;
@@ -17,8 +16,9 @@ import java.util.stream.Stream;
 import org.json.*;
 
 /**
- * These are helpful utility methods that perform basic comparisons between various objects. In most cases, the
- * comparisons are not order-dependent, or else the order is known.
+ * These are helpful utility methods that perform basic comparisons
+ * between various objects. In most cases, the comparisons are not
+ * order-dependent, or else the order is known.
  */
 public class Util {
 
@@ -31,15 +31,15 @@ public class Util {
     }
 
     /**
-     * Compares two JSONArrays for equality. The arrays need not be in the same order.
-     *
-     * @param jsonArray         created by the code to be tested
+     * Compares two JSONArrays for equality.
+     * The arrays need not be in the same order.
+     * @param jsonArray created by the code to be tested
      * @param expectedJsonArray created specifically for comparing
      */
     public static void compareActualVsExpectedJsonArrays(JSONArray jsonArray,
-        JSONArray expectedJsonArray) {
+            JSONArray expectedJsonArray) {
         assertTrue("jsonArray lengths should be equal",
-            jsonArray.length() == expectedJsonArray.length());
+                jsonArray.length() == expectedJsonArray.length());
         for (int i = 0; i < jsonArray.length(); ++i) {
             Object value = jsonArray.get(i);
             Object expectedValue = expectedJsonArray.get(i);
@@ -48,15 +48,15 @@ public class Util {
     }
 
     /**
-     * Compares two JSONObjects for equality. The objects need not be in the same order
-     *
-     * @param jsonObject         created by the code to be tested
+     * Compares two JSONObjects for equality. The objects need not be
+     * in the same order
+     * @param jsonObject created by the code to be tested
      * @param expectedJsonObject created specifically for comparing
      */
     public static void compareActualVsExpectedJsonObjects(
-        JSONObject jsonObject, JSONObject expectedJsonObject) {
+            JSONObject jsonObject, JSONObject expectedJsonObject) {
         assertTrue("jsonObjects should have the same length",
-            jsonObject.length() == expectedJsonObject.length());
+                jsonObject.length() == expectedJsonObject.length());
         Iterator<String> keys = jsonObject.keys();
         while (keys.hasNext()) {
             String key = keys.next();
@@ -67,25 +67,25 @@ public class Util {
     }
 
     /**
-     * Compare two objects for equality. Might be JSONArray, JSONObject, or something else.
-     *
-     * @param value         created by the code to be tested
+     * Compare two objects for equality. Might be JSONArray, JSONObject,
+     * or something else.
+     * @param value created by the code to be tested
      * @param expectedValue created specifically for comparing
      */
     private static void compareActualVsExpectedObjects(Object value,
-        Object expectedValue) {
+            Object expectedValue) {
         if (value instanceof JSONObject && expectedValue instanceof JSONObject) {
             // Compare JSONObjects
-            JSONObject jsonObject = (JSONObject) value;
-            JSONObject expectedJsonObject = (JSONObject) expectedValue;
+            JSONObject jsonObject = (JSONObject)value;
+            JSONObject expectedJsonObject = (JSONObject)expectedValue;
             compareActualVsExpectedJsonObjects(
-                jsonObject, expectedJsonObject);
+                    jsonObject, expectedJsonObject);
         } else if (value instanceof JSONArray && expectedValue instanceof JSONArray) {
             // Compare JSONArrays
-            JSONArray jsonArray = (JSONArray) value;
-            JSONArray expectedJsonArray = (JSONArray) expectedValue;
+            JSONArray jsonArray = (JSONArray)value;
+            JSONArray expectedJsonArray = (JSONArray)expectedValue;
             compareActualVsExpectedJsonArrays(
-                jsonArray, expectedJsonArray);
+                    jsonArray, expectedJsonArray);
         } else {
             /**
              * Compare all other types using toString(). First, the types must
@@ -112,7 +112,6 @@ public class Util {
 
     /**
      * Asserts that all JSONObject maps are the same as the default ctor
-     *
      * @param jsonObjects list of objects to be tested
      */
     public static void checkJSONObjectsMaps(List<JSONObject> jsonObjects) {
@@ -130,7 +129,6 @@ public class Util {
 
     /**
      * Asserts that all JSONObject maps are the same as the default ctor
-     *
      * @param jsonObject the object to be tested
      */
     public static void checkJSONObjectMaps(JSONObject jsonObject) {
@@ -141,9 +139,8 @@ public class Util {
 
     /**
      * Asserts that all JSONObject maps are the same as mapType
-     *
      * @param jsonObject object to be tested
-     * @param mapType    mapType to test against
+     * @param mapType mapType to test against
      */
     public static void checkJSONObjectMaps(JSONObject jsonObject, Class<? extends Map> mapType) {
         if (mapType == null) {
@@ -182,9 +179,8 @@ public class Util {
 
     /**
      * Asserts that all JSONObject maps in the JSONArray object match mapType
-     *
      * @param jsonArray object to be tested
-     * @param mapType   map type to be tested against
+     * @param mapType map type to be tested against
      */
     public static void checkJSONArrayMaps(JSONArray jsonArray, Class<? extends Map> mapType) {
         if (jsonArray == null) {
@@ -197,18 +193,18 @@ public class Util {
         while (it.hasNext()) {
             Object val = it.next();
             if (val instanceof JSONObject) {
-                JSONObject jsonObjectVal = (JSONObject) val;
+                JSONObject jsonObjectVal = (JSONObject)val;
                 checkJSONObjectMaps(jsonObjectVal, mapType);
             } else if (val instanceof JSONArray) {
-                JSONArray jsonArrayVal = (JSONArray) val;
+                JSONArray jsonArrayVal = (JSONArray)val;
                 checkJSONArrayMaps(jsonArrayVal, mapType);
             }
         }
     }
 
     /**
-     * Asserts that all JSONObject maps nested in the JSONArray match the default mapType
-     *
+     * Asserts that all JSONObject maps nested in the JSONArray match
+     * the default mapType
      * @param jsonArray the object to be tested
      */
     public static void checkJSONArrayMaps(JSONArray jsonArray) {

--- a/src/test/java/org/json/junit/Util.java
+++ b/src/test/java/org/json/junit/Util.java
@@ -6,27 +6,40 @@ Public Domain.
 
 import static org.junit.Assert.*;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.json.*;
 
 /**
- * These are helpful utility methods that perform basic comparisons
- * between various objects. In most cases, the comparisons are not
- * order-dependent, or else the order is known.
+ * These are helpful utility methods that perform basic comparisons between various objects. In most cases, the
+ * comparisons are not order-dependent, or else the order is known.
  */
 public class Util {
 
+    public static String getJsonStringFromFilePath(final Path path) {
+        try (final Stream<String> lines = Files.lines(path)) {
+            return lines.collect(Collectors.joining());
+        } catch (final IOException ioe) {
+            throw new IllegalStateException(String.format("Unable to retrieve path: %s", path));
+        }
+    }
+
     /**
-     * Compares two JSONArrays for equality.
-     * The arrays need not be in the same order.
-     * @param jsonArray created by the code to be tested
+     * Compares two JSONArrays for equality. The arrays need not be in the same order.
+     *
+     * @param jsonArray         created by the code to be tested
      * @param expectedJsonArray created specifically for comparing
      */
     public static void compareActualVsExpectedJsonArrays(JSONArray jsonArray,
-            JSONArray expectedJsonArray) {
+        JSONArray expectedJsonArray) {
         assertTrue("jsonArray lengths should be equal",
-                jsonArray.length() == expectedJsonArray.length());
+            jsonArray.length() == expectedJsonArray.length());
         for (int i = 0; i < jsonArray.length(); ++i) {
             Object value = jsonArray.get(i);
             Object expectedValue = expectedJsonArray.get(i);
@@ -35,15 +48,15 @@ public class Util {
     }
 
     /**
-     * Compares two JSONObjects for equality. The objects need not be
-     * in the same order 
-     * @param jsonObject created by the code to be tested
+     * Compares two JSONObjects for equality. The objects need not be in the same order
+     *
+     * @param jsonObject         created by the code to be tested
      * @param expectedJsonObject created specifically for comparing
      */
     public static void compareActualVsExpectedJsonObjects(
-            JSONObject jsonObject, JSONObject expectedJsonObject) {
+        JSONObject jsonObject, JSONObject expectedJsonObject) {
         assertTrue("jsonObjects should have the same length",
-                jsonObject.length() == expectedJsonObject.length());
+            jsonObject.length() == expectedJsonObject.length());
         Iterator<String> keys = jsonObject.keys();
         while (keys.hasNext()) {
             String key = keys.next();
@@ -54,25 +67,25 @@ public class Util {
     }
 
     /**
-     * Compare two objects for equality. Might be JSONArray, JSONObject,
-     * or something else.
-     * @param value created by the code to be tested
+     * Compare two objects for equality. Might be JSONArray, JSONObject, or something else.
+     *
+     * @param value         created by the code to be tested
      * @param expectedValue created specifically for comparing
      */
     private static void compareActualVsExpectedObjects(Object value,
-            Object expectedValue) {
+        Object expectedValue) {
         if (value instanceof JSONObject && expectedValue instanceof JSONObject) {
             // Compare JSONObjects
-            JSONObject jsonObject = (JSONObject)value;
-            JSONObject expectedJsonObject = (JSONObject)expectedValue;
+            JSONObject jsonObject = (JSONObject) value;
+            JSONObject expectedJsonObject = (JSONObject) expectedValue;
             compareActualVsExpectedJsonObjects(
-                    jsonObject, expectedJsonObject);
+                jsonObject, expectedJsonObject);
         } else if (value instanceof JSONArray && expectedValue instanceof JSONArray) {
             // Compare JSONArrays
-            JSONArray jsonArray = (JSONArray)value;
-            JSONArray expectedJsonArray = (JSONArray)expectedValue;
+            JSONArray jsonArray = (JSONArray) value;
+            JSONArray expectedJsonArray = (JSONArray) expectedValue;
             compareActualVsExpectedJsonArrays(
-                    jsonArray, expectedJsonArray);
+                jsonArray, expectedJsonArray);
         } else {
             /**
              * Compare all other types using toString(). First, the types must
@@ -99,6 +112,7 @@ public class Util {
 
     /**
      * Asserts that all JSONObject maps are the same as the default ctor
+     *
      * @param jsonObjects list of objects to be tested
      */
     public static void checkJSONObjectsMaps(List<JSONObject> jsonObjects) {
@@ -116,6 +130,7 @@ public class Util {
 
     /**
      * Asserts that all JSONObject maps are the same as the default ctor
+     *
      * @param jsonObject the object to be tested
      */
     public static void checkJSONObjectMaps(JSONObject jsonObject) {
@@ -126,8 +141,9 @@ public class Util {
 
     /**
      * Asserts that all JSONObject maps are the same as mapType
+     *
      * @param jsonObject object to be tested
-     * @param mapType mapType to test against
+     * @param mapType    mapType to test against
      */
     public static void checkJSONObjectMaps(JSONObject jsonObject, Class<? extends Map> mapType) {
         if (mapType == null) {
@@ -141,7 +157,7 @@ public class Util {
                 assertTrue(mapType == ((JSONObject) val).getMapType());
                 checkJSONObjectMaps(jsonObjectVal, mapType);
             } else if (val instanceof JSONArray) {
-                JSONArray jsonArrayVal = (JSONArray)val;
+                JSONArray jsonArrayVal = (JSONArray) val;
                 checkJSONArrayMaps(jsonArrayVal, mapType);
             }
         }
@@ -149,6 +165,7 @@ public class Util {
 
     /**
      * Asserts that all JSONObject maps in the JSONArray object match the default map
+     *
      * @param jsonArrays list of JSONArray objects to be tested
      */
     public static void checkJSONArraysMaps(List<JSONArray> jsonArrays) {
@@ -165,8 +182,9 @@ public class Util {
 
     /**
      * Asserts that all JSONObject maps in the JSONArray object match mapType
+     *
      * @param jsonArray object to be tested
-     * @param mapType map type to be tested against
+     * @param mapType   map type to be tested against
      */
     public static void checkJSONArrayMaps(JSONArray jsonArray, Class<? extends Map> mapType) {
         if (jsonArray == null) {
@@ -179,18 +197,18 @@ public class Util {
         while (it.hasNext()) {
             Object val = it.next();
             if (val instanceof JSONObject) {
-                JSONObject jsonObjectVal = (JSONObject)val;
+                JSONObject jsonObjectVal = (JSONObject) val;
                 checkJSONObjectMaps(jsonObjectVal, mapType);
             } else if (val instanceof JSONArray) {
-                JSONArray jsonArrayVal = (JSONArray)val;
+                JSONArray jsonArrayVal = (JSONArray) val;
                 checkJSONArrayMaps(jsonArrayVal, mapType);
             }
         }
     }
 
     /**
-     * Asserts that all JSONObject maps nested in the JSONArray match
-     * the default mapType
+     * Asserts that all JSONObject maps nested in the JSONArray match the default mapType
+     *
      * @param jsonArray the object to be tested
      */
     public static void checkJSONArrayMaps(JSONArray jsonArray) {

--- a/src/test/resources/Issue884-validJsonObj.json
+++ b/src/test/resources/Issue884-validJsonObj.json
@@ -1,0 +1,14 @@
+{
+    "test": {
+        "key": "value",
+        "key2": "value",
+        "key3": {
+            "anotherNested": "obj",
+            "anArray": [
+                "val1",
+                1,
+                3
+            ]
+        }
+    }
+}


### PR DESCRIPTION
# Issue description https://github.com/stleary/JSON-java/issues/884:


> Strict mode now works for JSONArray (see #877), but not for JSONObject or for JSONArrays embedded in JSONObjects. For example, the following code parses without error:
> 
> ```
>         String str = "{\"a\": [b]}";
>         JSONObject jsonObject = new JSONObject(str, new JSONParserConfiguration().withStrictMode(true));
> ```
> 
> Several additional changes should be included with the PR:
> 
>     * The indentation in nextString(char, boolean) is incorrect.
> 
>     * ~There is a compiler warning in JSONTokener that should be fixed:~ (fixed in [add javadoc for strictmode #886](https://github.com/stleary/JSON-java/pull/886))
> 
> 
> ```
> Warning:  Javadoc Warnings
> Warning:  /home/runner/work/JSON-java/JSON-java/src/main/java/org/json/JSONTokener.java:294: warning: no @param for strictMode
> Warning:  public String nextString(char quote, boolean strictMode) throws JSONException {
> Warning:  ^
> Warning: [WARNING] 1 warning
> ```

# Analysis and Implementation

> Strict mode now works for JSONArray (see #877), but not for JSONObject or for JSONArrays embedded in JSONObjects

Fixed.

>     * The indentation in nextString(char, boolean) is incorrect.

- Could not find the nextString(char, boolean) signature in JSONTokener.
- No indentation issue found. Please specify exactly which nextString we're mentioning.