### PR TITLE
Fix a bug when calling JSONArray.addAll() with Collection as Object

### DIFF
--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -2001,7 +2001,7 @@ public class JSONArray implements Iterable<Object> {
             // JSONArray
             this.myArrayList.addAll(((JSONArray)array).myArrayList);
         } else if (array instanceof Collection) {
-            this.addAll((Collection<?>)array, wrap, recursionDepth);
+            this.addAll((Collection<?>)array, wrap, recursionDepth, jsonParserConfiguration);
         } else if (array instanceof Iterable) {
             this.addAll((Iterable<?>)array, wrap);
         } else {

--- a/src/test/java/org/json/junit/JSONArrayTest.java
+++ b/src/test/java/org/json/junit/JSONArrayTest.java
@@ -259,6 +259,11 @@ public class JSONArrayTest {
                      jsonArray.length(),
                      len);
 
+	// collection as object
+        @SuppressWarnings("RedundantCast")
+        Object myListAsObject = (Object) myList;
+        jsonArray.putAll(myListAsObject);
+	    
         for (int i = 0; i < myList.size(); i++) {
             assertEquals("collection elements should be equal",
                          myList.get(i),


### PR DESCRIPTION
That fix the #901 that was introduced in #823

I commented the details of why we need that fix on https://github.com/stleary/JSON-java/issues/901#issuecomment-2395078117