### PR TITLE
update minimum supported version in readme to Java 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Project goals include:
 * No external dependencies
 * Fast execution and low memory footprint
 * Maintain backward compatibility
-* Designed and tested to use on Java versions 1.6 - 21
+* Designed and tested to use on Java versions 8 - 21
+  * The last release to support Java 6 is [20230618](https://mvnrepository.com/artifact/org.json/json/20230618)
+
 
 
 The files in this package implement JSON encoders and decoders. The package can also convert between JSON and XML, HTTP headers, Cookies, and CDL.


### PR DESCRIPTION
As of the FAQs and the build settings, Java 8 is the minimum required version. The readme is still stating that the minimum supported version is Java 1.6. Also added the link to the latest Java 6 supporting version copied from the FAQ.