### PR TITLE
New unit tests for Strict mode using JSONTokener and JSONParserConfiguration

### DIFF
--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -1,6 +1,9 @@
 package org.json.junit;
 
-import org.json.*;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONParserConfiguration;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -4,6 +4,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONParserConfiguration;
+import org.json.JSONTokener;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -1,9 +1,6 @@
 package org.json.junit;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.json.JSONParserConfiguration;
+import org.json.*;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -488,6 +485,40 @@ public class JSONParserConfigurationTest {
 
         assertEquals("Strict mode error: Value 'test' is not surrounded by quotes at 5 [character 6 line 1]",
                 je.getMessage());
+    }
+
+    @Test
+    public void givenInvalidInputObject_testStrictModeTrue_JSONObjectUsingJSONTokener_shouldThrowJSONException() {
+        JSONException exception = assertThrows(JSONException.class, () -> {
+            new JSONObject(new JSONTokener("{\"key\":\"value\"} invalid trailing text"), new JSONParserConfiguration().withStrictMode(true));
+        });
+
+        assertEquals("Strict mode error: Unparsed characters found at end of input text", exception.getMessage());
+    }
+
+    @Test
+    public void givenInvalidInputObject_testStrictModeTrue_JSONObjectUsingString_shouldThrowJSONException() {
+        JSONException exception = assertThrows(JSONException.class, () -> {
+            new JSONObject("{\"key\":\"value\"} invalid trailing text", new JSONParserConfiguration().withStrictMode(true));
+        });
+        assertEquals("Strict mode error: Unparsed characters found at end of input text", exception.getMessage());
+    }
+
+    @Test
+    public void givenInvalidInputObject_testStrictModeTrue_JSONArrayUsingJSONTokener_shouldThrowJSONException() {
+        JSONException exception = assertThrows(JSONException.class, () -> {
+            new JSONArray(new JSONTokener("[\"value\"] invalid trailing text"), new JSONParserConfiguration().withStrictMode(true));
+        });
+
+        assertEquals("Strict mode error: Unparsed characters found at end of input text at 11 [character 12 line 1]", exception.getMessage());
+    }
+
+    @Test
+    public void givenInvalidInputObject_testStrictModeTrue_JSONArrayUsingString_shouldThrowJSONException() {
+        JSONException exception = assertThrows(JSONException.class, () -> {
+            new JSONArray("[\"value\"] invalid trailing text", new JSONParserConfiguration().withStrictMode(true));
+        });
+        assertEquals("Strict mode error: Unparsed characters found at end of input text at 11 [character 12 line 1]", exception.getMessage());
     }
 
     /**


### PR DESCRIPTION
Adding new test cases with invalid characters at th end of the input to validate that the strict mode is enforced by the constructors of JSONObject and JSONArray. Turns out, that the constructor with JSONTokener instead of String input does not enforce the strict mode at the end of the object creation.

demonstrating, but not fixing, the bug behavior described in https://github.com/stleary/JSON-java/issues/935