### PR TITLE
Bugfix: NullPointerException thrown for invalid input on JSONTokener without strict mode

### DIFF
--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -141,14 +141,14 @@ public class JSONArray implements Iterable<Object> {
                     }
                     if (nextChar == ']') {
                         // trailing commas are not allowed in strict mode
-                        if (jsonParserConfiguration.isStrictMode()) {
+                        if (jsonParserConfiguration != null && jsonParserConfiguration.isStrictMode()) {
                             throw x.syntaxError("Strict mode error: Expected another array element");
                         }
                         return;
                     }
                     if (nextChar == ',') {
                         // consecutive commas are not allowed in strict mode
-                        if (jsonParserConfiguration.isStrictMode()) {
+                        if (jsonParserConfiguration != null && jsonParserConfiguration.isStrictMode()) {
                             throw x.syntaxError("Strict mode error: Expected a valid array element");
                         }
                         return;

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -255,7 +255,7 @@ public class JSONObject {
             if (key != null) {
                 // Check if key exists
                 boolean keyExists = this.opt(key) != null;
-                if (keyExists && !jsonParserConfiguration.isOverwriteDuplicateKey()) {
+                if (keyExists && jsonParserConfiguration != null && !jsonParserConfiguration.isOverwriteDuplicateKey()) {
                     throw x.syntaxError("Duplicate key \"" + key + "\"");
                 }
 
@@ -271,13 +271,13 @@ public class JSONObject {
             switch (x.nextClean()) {
             case ';':
                 // In strict mode semicolon is not a valid separator
-                if (jsonParserConfiguration.isStrictMode()) {
+                if (jsonParserConfiguration != null && jsonParserConfiguration.isStrictMode()) {
                     throw x.syntaxError("Strict mode error: Invalid character ';' found");
                 }
             case ',':
                 if (x.nextClean() == '}') {
                     // trailing commas are not allowed in strict mode
-                    if (jsonParserConfiguration.isStrictMode()) {
+                    if (jsonParserConfiguration != null && jsonParserConfiguration.isStrictMode()) {
                         throw x.syntaxError("Strict mode error: Expected another object element");
                     }
                     return;

--- a/src/test/java/org/json/junit/JSONTokenerTest.java
+++ b/src/test/java/org/json/junit/JSONTokenerTest.java
@@ -325,4 +325,11 @@ public class JSONTokenerTest {
            assertEquals("Stream closed", exception.getMessage());
        }
    }
+
+   @Test
+   public void testInvalidInput_shouldThrowJSONException() {
+       String input = "{\"invalidInput\": [],}";
+       JSONTokener tokener = new JSONTokener(input);
+       assertThrows(JSONException.class, () -> tokener.nextValue());
+   }
 }

--- a/src/test/java/org/json/junit/JSONTokenerTest.java
+++ b/src/test/java/org/json/junit/JSONTokenerTest.java
@@ -6,6 +6,7 @@ Public Domain.
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/src/test/java/org/json/junit/JSONTokenerTest.java
+++ b/src/test/java/org/json/junit/JSONTokenerTest.java
@@ -6,7 +6,6 @@ Public Domain.
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -328,10 +327,18 @@ public class JSONTokenerTest {
    }
 
    @Test
-   public void testInvalidInput_shouldThrowJSONException() {
+   public void testInvalidInput_JSONObject_withoutStrictModel_shouldParseInput() {
        String input = "{\"invalidInput\": [],}";
        JSONTokener tokener = new JSONTokener(input);
        Object value = tokener.nextValue();
        assertEquals(new JSONObject(input).toString(), value.toString());
    }
+
+    @Test
+    public void testInvalidInput_JSONArray_withoutStrictModel_shouldParseInput() {
+        String input = "[\"invalidInput\",]";
+        JSONTokener tokener = new JSONTokener(input);
+        Object value = tokener.nextValue();
+        assertEquals(new JSONArray(input).toString(), value.toString());
+    }
 }

--- a/src/test/java/org/json/junit/JSONTokenerTest.java
+++ b/src/test/java/org/json/junit/JSONTokenerTest.java
@@ -6,7 +6,7 @@ Public Domain.
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -331,6 +331,7 @@ public class JSONTokenerTest {
    public void testInvalidInput_shouldThrowJSONException() {
        String input = "{\"invalidInput\": [],}";
        JSONTokener tokener = new JSONTokener(input);
-       assertThrows(JSONException.class, () -> tokener.nextValue());
+       Object value = tokener.nextValue();
+       assertEquals(new JSONObject(input).toString(), value.toString());
    }
 }


### PR DESCRIPTION
expect input to be parsed as the invalid characters are at the end after a valid object, but got a NullPointerException instead, providing a fix with null checks.

fixing https://github.com/stleary/JSON-java/issues/933