### PR TITLE
Strict mode unit tests

### DIFF
--- a/src/main/java/org/json/JSONParserConfiguration.java
+++ b/src/main/java/org/json/JSONParserConfiguration.java
@@ -104,6 +104,9 @@ public class JSONParserConfiguration extends ParserConfiguration {
     }
 
     /**
+     * The parser throws an Exception when strict mode is true and tries to parse invalid JSON characters.
+     * Otherwise, the parser is more relaxed and might tolerate some invalid characters.
+     *
      * @return the current strict mode setting.
      */
     public boolean isStrictMode() {

--- a/src/main/java/org/json/JSONParserConfiguration.java
+++ b/src/main/java/org/json/JSONParserConfiguration.java
@@ -104,9 +104,6 @@ public class JSONParserConfiguration extends ParserConfiguration {
     }
 
     /**
-     * The parser throws an Exception when strict mode is true and tries to parse invalid JSON characters.
-     * Otherwise, the parser is more relaxed and might tolerate some invalid characters.
-     *
      * @return the current strict mode setting.
      */
     public boolean isStrictMode() {

--- a/src/main/java/org/json/JSONTokener.java
+++ b/src/main/java/org/json/JSONTokener.java
@@ -38,7 +38,18 @@ public class JSONTokener {
     /**
      * Construct a JSONTokener from a Reader. The caller must close the Reader.
      *
-     * @param reader     A reader.
+     * @param reader the source.
+     */
+    public JSONTokener(Reader reader) {
+        this(reader, new JSONParserConfiguration());
+    }
+
+    /**
+     * Construct a JSONTokener from a Reader with a given JSONParserConfiguration. The caller must close the Reader.
+     *
+     * @param reader the source.
+     * @param jsonParserConfiguration A JSONParserConfiguration instance that controls the behavior of the parser.
+     *
      */
     public JSONTokener(Reader reader, JSONParserConfiguration jsonParserConfiguration) {
         this.jsonParserConfiguration = jsonParserConfiguration;
@@ -54,10 +65,6 @@ public class JSONTokener {
         this.line = 1;
     }
 
-    public JSONTokener(Reader reader) {
-        this(reader, new JSONParserConfiguration());
-    }
-
     /**
      * Construct a JSONTokener from an InputStream. The caller must close the input stream.
      * @param inputStream The source.
@@ -69,23 +76,29 @@ public class JSONTokener {
     /**
      * Construct a JSONTokener from an InputStream. The caller must close the input stream.
      * @param inputStream The source.
+     * @param jsonParserConfiguration A JSONParserConfiguration instance that controls the behavior of the parser.
      */
     public JSONTokener(InputStream inputStream, JSONParserConfiguration jsonParserConfiguration) {
-        this(new InputStreamReader(inputStream, Charset.forName("UTF-8")),jsonParserConfiguration);
+        this(new InputStreamReader(inputStream, Charset.forName("UTF-8")), jsonParserConfiguration);
     }
 
 
     /**
      * Construct a JSONTokener from a string.
      *
-     * @param s     A source string.
+     * @param source A source string.
      */
-    public JSONTokener(String s) {
-        this(new StringReader(s));
+    public JSONTokener(String source) {
+        this(new StringReader(source));
     }
 
-    public JSONTokener(String s, JSONParserConfiguration jsonParserConfiguration) {
-        this(new StringReader(s), jsonParserConfiguration);
+    /**
+     * Construct a JSONTokener from an InputStream. The caller must close the input stream.
+     * @param source The source.
+     * @param jsonParserConfiguration A JSONParserConfiguration instance that controls the behavior of the parser.
+     */
+    public JSONTokener(String source, JSONParserConfiguration jsonParserConfiguration) {
+        this(new StringReader(source), jsonParserConfiguration);
     }
 
     /**

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -4,6 +4,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONParserConfiguration;
+import org.json.JSONTokener;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -488,6 +489,40 @@ public class JSONParserConfigurationTest {
 
         assertEquals("Strict mode error: Value 'test' is not surrounded by quotes at 5 [character 6 line 1]",
                 je.getMessage());
+    }
+
+    @Test
+    public void givenInvalidInputObject_testStrictModeTrue_JSONObjectUsingJSONTokener_shouldThrowJSONException() {
+        JSONException exception = assertThrows(JSONException.class, () -> {
+            new JSONObject(new JSONTokener("{\"key\":\"value\"} invalid trailing text"), new JSONParserConfiguration().withStrictMode(true));
+        });
+
+        assertEquals("Strict mode error: Unparsed characters found at end of input text at 17 [character 18 line 1]", exception.getMessage());
+    }
+
+    @Test
+    public void givenInvalidInputObject_testStrictModeTrue_JSONObjectUsingString_shouldThrowJSONException() {
+        JSONException exception = assertThrows(JSONException.class, () -> {
+            new JSONObject("{\"key\":\"value\"} invalid trailing text", new JSONParserConfiguration().withStrictMode(true));
+        });
+        assertEquals("Strict mode error: Unparsed characters found at end of input text at 17 [character 18 line 1]", exception.getMessage());
+    }
+
+    @Test
+    public void givenInvalidInputObject_testStrictModeTrue_JSONArrayUsingJSONTokener_shouldThrowJSONException() {
+        JSONException exception = assertThrows(JSONException.class, () -> {
+            new JSONArray(new JSONTokener("[\"value\"] invalid trailing text"), new JSONParserConfiguration().withStrictMode(true));
+        });
+
+        assertEquals("Strict mode error: Unparsed characters found at end of input text at 11 [character 12 line 1]", exception.getMessage());
+    }
+
+    @Test
+    public void givenInvalidInputObject_testStrictModeTrue_JSONArrayUsingString_shouldThrowJSONException() {
+        JSONException exception = assertThrows(JSONException.class, () -> {
+            new JSONArray("[\"value\"] invalid trailing text", new JSONParserConfiguration().withStrictMode(true));
+        });
+        assertEquals("Strict mode error: Unparsed characters found at end of input text at 11 [character 12 line 1]", exception.getMessage());
     }
 
     /**

--- a/src/test/java/org/json/junit/JSONTokenerTest.java
+++ b/src/test/java/org/json/junit/JSONTokenerTest.java
@@ -325,4 +325,21 @@ public class JSONTokenerTest {
            assertEquals("Stream closed", exception.getMessage());
        }
    }
+
+    @Test
+    public void testInvalidInput_JSONObject_withoutStrictModel_shouldParseInput() {
+        String input = "{\"invalidInput\": [],}";
+        JSONTokener tokener = new JSONTokener(input);
+        Object value = tokener.nextValue();
+        assertEquals(new JSONObject(input).toString(), value.toString());
+    }
+
+    @Test
+    public void testInvalidInput_JSONArray_withoutStrictModel_shouldParseInput() {
+        String input = "[\"invalidInput\",]";
+        JSONTokener tokener = new JSONTokener(input);
+        Object value = tokener.nextValue();
+        assertEquals(new JSONArray(input).toString(), value.toString());
+    }
+
 }


### PR DESCRIPTION
Taken the changes from https://github.com/stleary/JSON-java/pull/937 preserving an attribution history of the authors commits:

> fixes https://github.com/stleary/JSON-java/issues/935
> fixes https://github.com/stleary/JSON-java/issues/933
> resolves https://github.com/stleary/JSON-java/issues/927

In addition:
- Added missing Java doc
- Adopted tests from 
  https://github.com/stleary/JSON-java/pull/934 
  https://github.com/stleary/JSON-java/pull/936

this can be taken as a discussion baseline, or merged instead or after https://github.com/stleary/JSON-java/pull/937 and makes https://github.com/stleary/JSON-java/pull/934 and https://github.com/stleary/JSON-java/pull/936 obsolete