### PR TITLE
deprecated unnecessary setter method

### DIFF
--- a/src/main/java/org/json/JSONTokener.java
+++ b/src/main/java/org/json/JSONTokener.java
@@ -112,7 +112,10 @@ public class JSONTokener {
     /**
      * Setter
      * @param jsonParserConfiguration new value for jsonParserConfiguration
+     *
+     * @deprecated method should not be used
      */
+    @Deprecated
     public void setJsonParserConfiguration(JSONParserConfiguration jsonParserConfiguration) {
         this.jsonParserConfiguration = jsonParserConfiguration;
     }


### PR DESCRIPTION
Deprecated setJSONParserConfiguration in JSONTokener.

No unit tests added as setter is not utilized.