### PR TITLE
Option to store null value in JSONObject when parsing a map

### DIFF
--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -332,7 +332,7 @@ public class JSONObject {
         	        throw new NullPointerException("Null key.");
         	    }
                 final Object value = e.getValue();
-                if (value != null || jsonParserConfiguration.isJavaNullAsJsonNull()) {
+                if (value != null || jsonParserConfiguration.isUseNativeNulls()) {
                     testValidity(value);
                     this.map.put(String.valueOf(e.getKey()), wrap(value, recursionDepth + 1, jsonParserConfiguration));
                 }

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -332,7 +332,7 @@ public class JSONObject {
         	        throw new NullPointerException("Null key.");
         	    }
                 final Object value = e.getValue();
-                if (value != null) {
+                if (value != null || jsonParserConfiguration.isJavaNullAsJsonNull()) {
                     testValidity(value);
                     this.map.put(String.valueOf(e.getKey()), wrap(value, recursionDepth + 1, jsonParserConfiguration));
                 }

--- a/src/main/java/org/json/JSONParserConfiguration.java
+++ b/src/main/java/org/json/JSONParserConfiguration.java
@@ -37,6 +37,7 @@ public class JSONParserConfiguration extends ParserConfiguration {
         clone.strictMode = strictMode;
         clone.maxNestingDepth = maxNestingDepth;
         clone.keepStrings = keepStrings;
+        clone.useNativeNulls = useNativeNulls;
         return clone;
     }
 

--- a/src/main/java/org/json/JSONParserConfiguration.java
+++ b/src/main/java/org/json/JSONParserConfiguration.java
@@ -8,6 +8,11 @@ public class JSONParserConfiguration extends ParserConfiguration {
      * Used to indicate whether to overwrite duplicate key or not.
      */
     private boolean overwriteDuplicateKey;
+    
+    /**
+     * Used to indicate whether ignore null values when converting java maps to JSONObject or not.
+     */
+    private boolean javaNullAsJsonNull;
 
     /**
      * Configuration with the default values.
@@ -67,6 +72,21 @@ public class JSONParserConfiguration extends ParserConfiguration {
 
         return clone;
     }
+    
+    /**
+     * Controls the parser's behavior when meeting duplicate keys.
+     * If set to false, the parser will throw a JSONException when meeting a duplicate key.
+     * Or the duplicate key's value will be overwritten.
+     *
+     * @param javaNullAsJsonNull define, if the parser should ignore null values in Java maps
+     * @return The existing configuration will not be modified. A new configuration is returned.
+     */
+    public JSONParserConfiguration withJavaNullAsJsonNull(final boolean javaNullAsJsonNull) {
+        JSONParserConfiguration clone = this.clone();
+        clone.javaNullAsJsonNull = javaNullAsJsonNull;
+
+        return clone;
+    }
 
     /**
      * Sets the strict mode configuration for the JSON parser with default true value
@@ -106,6 +126,17 @@ public class JSONParserConfiguration extends ParserConfiguration {
     public boolean isOverwriteDuplicateKey() {
         return this.overwriteDuplicateKey;
     }
+    
+    /**
+     * The parser's behavior when meeting a null value in a java map, controls whether the parser should ignore 
+     * that map entry or write a JSON entry with a null value.
+     *
+     * @return The <code>javaNullAsJsonNull</code> configuration value.
+     */
+    public boolean isJavaNullAsJsonNull() {
+        return this.javaNullAsJsonNull;
+    }
+    
 
     /**
      * The parser throws an Exception when strict mode is true and tries to parse invalid JSON characters.

--- a/src/main/java/org/json/JSONParserConfiguration.java
+++ b/src/main/java/org/json/JSONParserConfiguration.java
@@ -10,9 +10,9 @@ public class JSONParserConfiguration extends ParserConfiguration {
     private boolean overwriteDuplicateKey;
     
     /**
-     * Used to indicate whether ignore null values when converting java maps to JSONObject or not.
+     * Used to indicate whether to convert java null values to JSONObject.NULL or ignoring the entry when converting java maps.
      */
-    private boolean javaNullAsJsonNull;
+    private boolean useNativeNulls;
 
     /**
      * Configuration with the default values.
@@ -74,16 +74,16 @@ public class JSONParserConfiguration extends ParserConfiguration {
     }
     
     /**
-     * Controls the parser's behavior when meeting duplicate keys.
-     * If set to false, the parser will throw a JSONException when meeting a duplicate key.
-     * Or the duplicate key's value will be overwritten.
+     * Controls the parser's behavior when meeting Java null values while converting maps.
+     * If set to true, the parser will put a JSONObject.NULL into the resulting JSONObject.
+     * Or the map entry will be ignored.
      *
-     * @param javaNullAsJsonNull define, if the parser should ignore null values in Java maps
+     * @param useNativeNulls defines if the parser should convert null values in Java maps
      * @return The existing configuration will not be modified. A new configuration is returned.
      */
-    public JSONParserConfiguration withJavaNullAsJsonNull(final boolean javaNullAsJsonNull) {
+    public JSONParserConfiguration withUseNativeNulls(final boolean useNativeNulls) {
         JSONParserConfiguration clone = this.clone();
-        clone.javaNullAsJsonNull = javaNullAsJsonNull;
+        clone.useNativeNulls = useNativeNulls;
 
         return clone;
     }
@@ -128,13 +128,14 @@ public class JSONParserConfiguration extends ParserConfiguration {
     }
     
     /**
-     * The parser's behavior when meeting a null value in a java map, controls whether the parser should ignore 
-     * that map entry or write a JSON entry with a null value.
+     * The parser's behavior when meeting a null value in a java map, controls whether the parser should 
+     * write a JSON entry with a null value (<code>isUseNativeNulls() == true</code>) 
+     * or ignore that map entry (<code>isUseNativeNulls() == false</code>).
      *
-     * @return The <code>javaNullAsJsonNull</code> configuration value.
+     * @return The <code>useNativeNulls</code> configuration value.
      */
-    public boolean isJavaNullAsJsonNull() {
-        return this.javaNullAsJsonNull;
+    public boolean isUseNativeNulls() {
+        return this.useNativeNulls;
     }
     
 

--- a/src/test/java/org/json/junit/JSONArrayTest.java
+++ b/src/test/java/org/json/junit/JSONArrayTest.java
@@ -235,7 +235,7 @@ public class JSONArrayTest {
         Map<String, Object> sub = new HashMap<String, Object>();
         sub.put("nullKey", null);	
         list.add(sub);
-        JSONParserConfiguration parserConfiguration = new JSONParserConfiguration().withJavaNullAsJsonNull(true);
+        JSONParserConfiguration parserConfiguration = new JSONParserConfiguration().withUseNativeNulls(true);
         JSONArray jsonArray = new JSONArray(list, parserConfiguration);
         JSONObject subObject = jsonArray.getJSONObject(0);
         assertTrue(subObject.has("nullKey"));

--- a/src/test/java/org/json/junit/JSONArrayTest.java
+++ b/src/test/java/org/json/junit/JSONArrayTest.java
@@ -228,6 +228,19 @@ public class JSONArrayTest {
         Util.checkJSONArrayMaps(jaRaw);
         Util.checkJSONArrayMaps(jaInt);
     }
+    
+    @Test
+    public void jsonArrayByListWithNestedNullValue() {
+        List<Map<String, Object>> list = new ArrayList<Map<String, Object>>();
+        Map<String, Object> sub = new HashMap<String, Object>();
+        sub.put("nullKey", null);	
+        list.add(sub);
+        JSONParserConfiguration parserConfiguration = new JSONParserConfiguration().withJavaNullAsJsonNull(true);
+        JSONArray jsonArray = new JSONArray(list, parserConfiguration);
+        JSONObject subObject = jsonArray.getJSONObject(0);
+        assertTrue(subObject.has("nullKey"));
+        assertEquals(JSONObject.NULL, subObject.get("nullKey"));
+    }
 
     /**
      * Tests consecutive calls to putAll with array and collection.

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -627,7 +627,7 @@ public class JSONObjectTest {
         assertTrue("expected null value to be ignored by default", obj1.isEmpty());
 
         // if configured, null values are written as such into the JSONObject.
-        JSONParserConfiguration parserConfiguration = new JSONParserConfiguration().withJavaNullAsJsonNull(true);
+        JSONParserConfiguration parserConfiguration = new JSONParserConfiguration().withUseNativeNulls(true);
         JSONObject obj2 = new JSONObject(map, parserConfiguration);
         assertFalse("expected null value to accepted when configured", obj2.isEmpty());
         assertTrue(obj2.has("nullKey"));
@@ -644,7 +644,7 @@ public class JSONObjectTest {
         nestedList.add(nestedMap);        
         map.put("nestedList", nestedList);
         
-        JSONParserConfiguration parserConfiguration = new JSONParserConfiguration().withJavaNullAsJsonNull(true);
+        JSONParserConfiguration parserConfiguration = new JSONParserConfiguration().withUseNativeNulls(true);
         JSONObject jsonObject = new JSONObject(map, parserConfiguration);
 
         JSONObject nestedObject = jsonObject.getJSONObject("nestedMap");

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -616,6 +616,46 @@ public class JSONObjectTest {
         assertTrue("expected \"doubleKey\":-23.45e67", Double.valueOf("-23.45e67").equals(jsonObject.query("/doubleKey")));
         Util.checkJSONObjectMaps(jsonObject);
     }
+    
+    @Test
+    public void jsonObjectByMapWithNullValueAndParserConfiguration() {
+        Map<String, Object> map = new HashMap<String, Object>();
+        map.put("nullKey", null);
+        
+        // by default, null values are ignored
+        JSONObject obj1 = new JSONObject(map);
+        assertTrue("expected null value to be ignored by default", obj1.isEmpty());
+
+        // if configured, null values are written as such into the JSONObject.
+        JSONParserConfiguration parserConfiguration = new JSONParserConfiguration().withJavaNullAsJsonNull(true);
+        JSONObject obj2 = new JSONObject(map, parserConfiguration);
+        assertFalse("expected null value to accepted when configured", obj2.isEmpty());
+        assertTrue(obj2.has("nullKey"));
+        assertEquals(JSONObject.NULL, obj2.get("nullKey"));
+    }
+    
+    @Test
+    public void jsonObjectByMapWithNestedNullValueAndParserConfiguration() {
+        Map<String, Object> map = new HashMap<String, Object>();
+        Map<String, Object> nestedMap = new HashMap<String, Object>();
+        nestedMap.put("nullKey", null);
+        map.put("nestedMap", nestedMap);
+        List<Map<String, Object>> nestedList = new ArrayList<Map<String,Object>>();
+        nestedList.add(nestedMap);        
+        map.put("nestedList", nestedList);
+        
+        JSONParserConfiguration parserConfiguration = new JSONParserConfiguration().withJavaNullAsJsonNull(true);
+        JSONObject jsonObject = new JSONObject(map, parserConfiguration);
+
+        JSONObject nestedObject = jsonObject.getJSONObject("nestedMap");
+        assertTrue(nestedObject.has("nullKey"));
+        assertEquals(JSONObject.NULL, nestedObject.get("nullKey"));
+        
+        JSONArray nestedArray = jsonObject.getJSONArray("nestedList");
+        assertEquals(1, nestedArray.length());
+        assertTrue(nestedArray.getJSONObject(0).has("nullKey"));
+        assertEquals(JSONObject.NULL, nestedArray.getJSONObject(0).get("nullKey"));
+    }
 
     /**
      * JSONObject built from a bean. In this case all but one of the 

--- a/src/test/java/org/json/junit/JSONParserConfigurationTest.java
+++ b/src/test/java/org/json/junit/JSONParserConfigurationTest.java
@@ -53,6 +53,14 @@ public class JSONParserConfigurationTest {
 
         assertTrue(jsonParserConfiguration.isKeepStrings());
     }
+    
+    @Test
+    public void useNativeNullsIsCloned() {
+        JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration()
+                .withUseNativeNulls(true)
+                .withStrictMode(true);
+        assertTrue(jsonParserConfiguration.isUseNativeNulls());
+    }
 
     @Test
     public void verifyDuplicateKeyThenMaxDepth() {


### PR DESCRIPTION
This PR provides a new JSONParserConfiguration option to allow a Java `Map.of("foo", null)` to be converted into `{"foo": null}` instead of `{}`.

See also Issue #296 and PR #338, which was rejected due to API concerns. Since now we have a proper configuration object these concerns are addressed.
