### PR TITLE
Refactor: Check equality with literal on lhs

### DIFF
--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -334,13 +334,11 @@ public class JSONArray implements Iterable<Object> {
      */
     public boolean getBoolean(int index) throws JSONException {
         Object object = this.get(index);
-        if (object.equals(Boolean.FALSE)
-                || (object instanceof String && ((String) object)
-                        .equalsIgnoreCase("false"))) {
+        if (Boolean.FALSE.equals(object)
+                || (object instanceof String && "false".equalsIgnoreCase((String) object))) {
             return false;
-        } else if (object.equals(Boolean.TRUE)
-                || (object instanceof String && ((String) object)
-                        .equalsIgnoreCase("true"))) {
+        } else if (Boolean.TRUE.equals(object)
+                || (object instanceof String && "true".equalsIgnoreCase((String) object))) {
             return true;
         }
         throw wrongValueFormatException(index, "boolean", object, null);

--- a/src/main/java/org/json/JSONML.java
+++ b/src/main/java/org/json/JSONML.java
@@ -111,7 +111,7 @@ public class JSONML {
                             }
                         } else if (c == '[') {
                             token = x.nextToken();
-                            if (token.equals("CDATA") && x.next() == '[') {
+                            if ("CDATA".equals(token) && x.next() == '[') {
                                 if (ja != null) {
                                     ja.put(x.nextCDATA());
                                 }

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -679,13 +679,11 @@ public class JSONObject {
      */
     public boolean getBoolean(String key) throws JSONException {
         Object object = this.get(key);
-        if (object.equals(Boolean.FALSE)
-                || (object instanceof String && ((String) object)
-                        .equalsIgnoreCase("false"))) {
+        if (Boolean.FALSE.equals(object)
+                || (object instanceof String && "false".equalsIgnoreCase((String) object))) {
             return false;
-        } else if (object.equals(Boolean.TRUE)
-                || (object instanceof String && ((String) object)
-                        .equalsIgnoreCase("true"))) {
+        } else if (Boolean.TRUE.equals(object)
+                || (object instanceof String && "true".equalsIgnoreCase((String) object))) {
             return true;
         }
         throw wrongValueFormatException(key, "Boolean", object, null);
@@ -1911,7 +1909,7 @@ public class JSONObject {
         }
 
         //If the superclass is Object, no annotations will be found any more
-        if (c.getSuperclass().equals(Object.class))
+        if (Object.class.equals(c.getSuperclass()))
             return null;
 
         try {
@@ -1969,7 +1967,7 @@ public class JSONObject {
         }
 
         //If the superclass is Object, no annotations will be found any more
-        if (c.getSuperclass().equals(Object.class))
+        if (Object.class.equals(c.getSuperclass()))
             return -1;
 
         try {
@@ -3022,7 +3020,7 @@ public class JSONObject {
      * @return number without leading zeros
      */
     private static String removeLeadingZerosOfNumber(String value){
-        if (value.equals("-")){return value;}
+        if ("-".equals(value)){return value;}
         boolean negativeFirstChar = (value.charAt(0) == '-');
         int counter = negativeFirstChar ? 1:0;
         while (counter < value.length()){

--- a/src/main/java/org/json/JSONPointer.java
+++ b/src/main/java/org/json/JSONPointer.java
@@ -127,7 +127,7 @@ public class JSONPointer {
         if (pointer == null) {
             throw new NullPointerException("pointer cannot be null");
         }
-        if (pointer.isEmpty() || pointer.equals("#")) {
+        if (pointer.isEmpty() || "#".equals(pointer)) {
             this.refTokens = Collections.emptyList();
             return;
         }


### PR DESCRIPTION
There are some equals() that are not `constant.equals(variable)`, but `variable.equals(constant)`.
I suggested to always use `constant.equals(variable)`, since it can avoid vary unintentionally bug, such as `NullPointerException`.