### PR TITLE
Fixed: <t>null</t> used to be {"t":"null"} but now its {"t":null} with useStrings

### DIFF
--- a/src/main/java/org/json/XML.java
+++ b/src/main/java/org/json/XML.java
@@ -428,6 +428,9 @@ public class XML {
                                                 config.isKeepNumberAsString()
                                                         ? ((String) token)
                                                         : obj);
+                                    } else if (obj == JSONObject.NULL) {
+                                        jsonObject.accumulate(config.getcDataTagName(),
+                                                config.isKeepStrings() ? ((String) token) : obj);
                                     } else {
                                         jsonObject.accumulate(config.getcDataTagName(), stringToValue((String) token));
                                     }

--- a/src/test/java/org/json/junit/XMLConfigurationTest.java
+++ b/src/test/java/org/json/junit/XMLConfigurationTest.java
@@ -795,6 +795,18 @@ public class XMLConfigurationTest {
     }
 
     /**
+     * null is "null" when keepStrings == true
+     */
+    @Test
+    public void testToJSONArray_jsonOutput_null_withKeepString() {
+        final String originalXml = "<root><id>01</id><id>1</id><id>00</id><id>0</id><item id=\"01\"/><title>null</title></root>";
+        final JSONObject expected = new JSONObject("{\"root\":{\"item\":{\"id\":\"01\"},\"id\":[\"01\",\"1\",\"00\",\"0\"],\"title\":\"null\"}}");
+        final JSONObject actualJsonOutput = XML.toJSONObject(originalXml,
+                new XMLParserConfiguration().withKeepStrings(true));
+        Util.compareActualVsExpectedJsonObjects(actualJsonOutput,expected);
+    }
+
+    /**
      * Test keepStrings behavior when setting keepBooleanAsString, keepNumberAsString
      */
     @Test

--- a/src/test/java/org/json/junit/XMLConfigurationTest.java
+++ b/src/test/java/org/json/junit/XMLConfigurationTest.java
@@ -775,8 +775,8 @@ public class XMLConfigurationTest {
      */
     @Test
     public void testToJSONArray_jsonOutput_withKeepNumberAsString() {
-        final String originalXml = "<root><id>01</id><id>1</id><id>00</id><id>0</id><item id=\"01\"/><title>True</title></root>";
-        final JSONObject expected = new JSONObject("{\"root\":{\"item\":{\"id\":\"01\"},\"id\":[\"01\",\"1\",\"00\",\"0\"],\"title\":true}}");
+        final String originalXml = "<root><id>01</id><id>1</id><id>00</id><id>0</id><id>null</id><item id=\"01\"/><title>True</title></root>";
+        final JSONObject expected = new JSONObject("{\"root\":{\"item\":{\"id\":\"01\"},\"id\":[\"01\",\"1\",\"00\",\"0\",null],\"title\":true}}");
         final JSONObject actualJsonOutput = XML.toJSONObject(originalXml,
                 new XMLParserConfiguration().withKeepNumberAsString(true));
         Util.compareActualVsExpectedJsonObjects(actualJsonOutput,expected);
@@ -787,8 +787,8 @@ public class XMLConfigurationTest {
      */
     @Test
     public void testToJSONArray_jsonOutput_withKeepBooleanAsString() {
-        final String originalXml = "<root><id>01</id><id>1</id><id>00</id><id>0</id><item id=\"01\"/><title>True</title></root>";
-        final JSONObject expected = new JSONObject("{\"root\":{\"item\":{\"id\":\"01\"},\"id\":[\"01\",1,\"00\",0],\"title\":\"True\"}}");
+        final String originalXml = "<root><id>01</id><id>1</id><id>00</id><id>0</id><id>null</id><item id=\"01\"/><title>True</title></root>";
+        final JSONObject expected = new JSONObject("{\"root\":{\"item\":{\"id\":\"01\"},\"id\":[\"01\",1,\"00\",0,null],\"title\":\"True\"}}");
         final JSONObject actualJsonOutput = XML.toJSONObject(originalXml,
                 new XMLParserConfiguration().withKeepBooleanAsString(true));
         Util.compareActualVsExpectedJsonObjects(actualJsonOutput,expected);


### PR DESCRIPTION
Fixes #986 

Made keepStrings account for null in XML; fixing regression from previous commit.
Refactored two XML tests to include null.
Unit tests ran with gradlew.