### PR TITLE
add badge to external hosted javadoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ JSON in Java [package org.json]
 [![Maven Central](https://img.shields.io/maven-central/v/org.json/json.svg)](https://mvnrepository.com/artifact/org.json/json)
 [![Java CI with Maven](https://github.com/stleary/JSON-java/actions/workflows/pipeline.yml/badge.svg)](https://github.com/stleary/JSON-java/actions/workflows/pipeline.yml)
 [![CodeQL](https://github.com/stleary/JSON-java/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/stleary/JSON-java/actions/workflows/codeql-analysis.yml)
+[![javadoc](https://javadoc.io/badge2/org.json/json/javadoc.svg)](https://javadoc.io/doc/org.json/json)
 
 **[Click here if you just want the latest release jar file.](https://search.maven.org/remotecontent?filepath=org/json/json/20250517/json-20250517.jar)**
 


### PR DESCRIPTION
In case you are interested to link to an automatically updating external hosted javadoc.

This site automatically updates (one per week) when there is a new version published to maven central to update the Javadoc to the latest version, taking the javadoc.jar published on maven central.

This relates to https://github.com/stleary/JSON-java/issues/873