### PR TITLE
Ignore static fields in JSONObject.fromJson()

### DIFF
--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -3349,7 +3349,7 @@ public class JSONObject {
      * of the given class. It supports basic data types including {@code int}, {@code double},
      * {@code float}, {@code long}, and {@code boolean}, as well as their boxed counterparts.
      * The target class must have a no-argument constructor, and its field names must match
-     * the keys in the JSON string.
+     * the keys in the JSON string. Static fields are ignored.
      *
      * <p><strong>Note:</strong> Only classes that are explicitly supported and registered within
      * the {@code JSONObject} context can be deserialized. If the provided class is not among those,
@@ -3366,6 +3366,9 @@ public class JSONObject {
         try {
             T obj = clazz.getDeclaredConstructor().newInstance();
             for (Field field : clazz.getDeclaredFields()) {
+                if (Modifier.isStatic(field.getModifiers())) {
+                    continue;
+                }
                 field.setAccessible(true);
                 String fieldName = field.getName();
                 if (has(fieldName)) {

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -66,6 +66,7 @@ import org.json.junit.data.CustomClassF;
 import org.json.junit.data.CustomClassG;
 import org.json.junit.data.CustomClassH;
 import org.json.junit.data.CustomClassI;
+import org.json.junit.data.CustomClassJ;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Ignore;
@@ -4231,5 +4232,22 @@ public class JSONObjectTest {
         CustomClassI customClassI = object.fromJson(CustomClassI.class);
         CustomClassI compareClassI = new CustomClassI(dataList);
         assertEquals(customClassI.integerMap.toString(), compareClassI.integerMap.toString());
+    }
+
+    @Test
+    public void jsonObjectParseFromJson_9() {
+        JSONObject object = new JSONObject();
+        object.put("number", 12);
+        object.put("classState", "mutated");
+
+        String initialClassState = CustomClassJ.classState;
+        CustomClassJ.classState = "original";
+        try {
+            CustomClassJ customClassJ = object.fromJson(CustomClassJ.class);
+            assertEquals(12, customClassJ.number);
+            assertEquals("original", CustomClassJ.classState);
+        } finally {
+            CustomClassJ.classState = initialClassState;
+        }
     }
 }

--- a/src/test/java/org/json/junit/data/CustomClassJ.java
+++ b/src/test/java/org/json/junit/data/CustomClassJ.java
@@ -1,0 +1,8 @@
+package org.json.junit.data;
+
+public class CustomClassJ {
+  public static String classState = "original";
+  public int number;
+
+  public CustomClassJ() {}
+}

--- a/src/test/java/org/json/junit/data/CustomClassJ.java
+++ b/src/test/java/org/json/junit/data/CustomClassJ.java
@@ -4,5 +4,7 @@ public class CustomClassJ {
   public static String classState = "original";
   public int number;
 
-  public CustomClassJ() {}
+  public CustomClassJ() {
+    // Required for JSONObject#fromJson(Class<T>) tests.
+  }
 }


### PR DESCRIPTION
Fixes #1043

This PR updates `JSONObject#fromJson(Class<T>)` to bind only instance fields.

Changes in this PR:
- skip static fields
- add a regression test
- update the Javadoc
