### PR TITLE
Validate XML numeric character references before string construction

### DIFF
--- a/src/main/java/org/json/XML.java
+++ b/src/main/java/org/json/XML.java
@@ -158,7 +158,7 @@ public class XML {
      * @param cp code point to test
      * @return true if the code point is not valid for an XML
      */
-    private static boolean mustEscape(int cp) {
+    static boolean mustEscape(int cp) {
         /* Valid range from https://www.w3.org/TR/REC-xml/#charsets
          *
          * #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]

--- a/src/main/java/org/json/XMLTokener.java
+++ b/src/main/java/org/json/XMLTokener.java
@@ -167,6 +167,9 @@ public class XMLTokener extends JSONTokener {
             int cp = (e.charAt(1) == 'x' || e.charAt(1) == 'X')
                 ? parseHexEntity(e)
                 : parseDecimalEntity(e);
+            if (XML.mustEscape(cp)) {
+                throw new JSONException("Invalid numeric character reference: &#" + e.substring(1) + ";");
+            }
             return new String(new int[] {cp}, 0, 1);
         }
         Character knownEntity = entity.get(e);

--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -1469,6 +1469,42 @@ public class XMLTest {
     }
 
     /**
+     * Tests that out-of-range hex entities throw JSONException rather than an uncaught runtime exception.
+     */
+    @Test(expected = JSONException.class)
+    public void testOutOfRangeHexEntityThrowsJSONException() {
+        String xmlStr = "<a>&#x110000;</a>";
+        XML.toJSONObject(xmlStr);
+    }
+
+    /**
+     * Tests that out-of-range decimal entities throw JSONException rather than an uncaught runtime exception.
+     */
+    @Test(expected = JSONException.class)
+    public void testOutOfRangeDecimalEntityThrowsJSONException() {
+        String xmlStr = "<a>&#1114112;</a>";
+        XML.toJSONObject(xmlStr);
+    }
+
+    /**
+     * Tests that surrogate code point entities throw JSONException.
+     */
+    @Test(expected = JSONException.class)
+    public void testSurrogateHexEntityThrowsJSONException() {
+        String xmlStr = "<a>&#xD800;</a>";
+        XML.toJSONObject(xmlStr);
+    }
+
+    /**
+     * Tests that out-of-range numeric entities in attribute values throw JSONException.
+     */
+    @Test(expected = JSONException.class)
+    public void testOutOfRangeHexEntityInAttributeThrowsJSONException() {
+        String xmlStr = "<a b=\"&#x110000;\"/>";
+        XML.toJSONObject(xmlStr);
+    }
+
+    /**
      * Tests that valid decimal numeric entity &#65; works correctly.
      * Should decode to character 'A'.
      */


### PR DESCRIPTION
Fixes #1045

This PR validates XML numeric character references before string construction.

Changes in this PR:
- reject XML-invalid numeric character references with `JSONException`
- add regression tests for out-of-range hex and decimal values
- add regression coverage for surrogate values and attribute values

#### Note

#1045 focused on out-of-range values such as `&#x110000;`, which raised an uncaught runtime exception before this fix. Surrogate values such as `&#xD800;` did not reproduce the same exception in my testing, but they are still invalid XML character references and are rejected by the same validation.