### PR TITLE
Restore lenient jsonarray allow consecutive commas and insert null 

### DIFF
--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -131,9 +131,9 @@ public class JSONArray implements Iterable<Object> {
      * @param x                       A JSONTokener instance from which the JSONArray is constructed.
      * @param jsonParserConfiguration A JSONParserConfiguration instance that controls the behavior of the parser.
      * @param isInitial               Boolean indicating position of char
-     * @return
+     * @return                        true if a syntax error has occurred, otherwise false
      */
-    private static boolean checkForSyntaxError(JSONTokener x, JSONParserConfiguration jsonParserConfiguration, boolean isInitial) {
+    private boolean checkForSyntaxError(JSONTokener x, JSONParserConfiguration jsonParserConfiguration, boolean isInitial) {
         char nextChar;
         switch (x.nextClean()) {
         case 0:
@@ -153,11 +153,11 @@ public class JSONArray implements Iterable<Object> {
                 return true;
             }
             if (nextChar == ',') {
-                // consecutive commas are not allowed in strict mode
+                // Consecutive commas are not allowed in strict mode.
+                // Otherwise, the tokener is backed up, and a null object is inserted by the calling code.
                 if (jsonParserConfiguration.isStrictMode()) {
                     throw x.syntaxError("Strict mode error: Expected a valid array element");
                 }
-                return true;
             }
             x.back();
             break;

--- a/src/test/java/org/json/junit/JSONArrayTest.java
+++ b/src/test/java/org/json/junit/JSONArrayTest.java
@@ -1557,9 +1557,9 @@ public class JSONArrayTest {
         JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration();
         if (jsonParserConfiguration.isStrictMode()) {
             try {
-                JSONArray jsonArray = new JSONArray(str);
+                new JSONArray(str);
                 fail("Expected to throw exception due to invalid string");
-            } catch (JSONException e) { }
+            } catch (JSONException e) { /* no action is needed here */ }
         } else {
             JSONArray jsonArray = new JSONArray(str);
             assertEquals("JSONArray in non-strictMode should contain a null entry",

--- a/src/test/java/org/json/junit/JSONArrayTest.java
+++ b/src/test/java/org/json/junit/JSONArrayTest.java
@@ -1548,4 +1548,22 @@ public class JSONArrayTest {
         nestedArray.add(buildNestedArray(maxDepth - 1));
         return nestedArray;
     }
+
+    @Test
+    public void TestLenientCommas() {
+        String str = "[1,,3]";
+
+        // Test should fail if default strictMode is true, pass with an extra null entry if false
+        JSONParserConfiguration jsonParserConfiguration = new JSONParserConfiguration();
+        if (jsonParserConfiguration.isStrictMode()) {
+            try {
+                JSONArray jsonArray = new JSONArray(str);
+                fail("Expected to throw exception due to invalid string");
+            } catch (JSONException e) { }
+        } else {
+            JSONArray jsonArray = new JSONArray(str);
+            assertEquals("JSONArray in non-strictMode should contain a null entry",
+                    "[1,null,3]", jsonArray.toString());
+        }
+    }
 }


### PR DESCRIPTION
**What problem does this code solve?**
Fixes a regression: lenient parsing should allow consecutive array commas, and insert a null.
The regression was that non-strictmode was resulting in the array being truncated.
Fixes #1033 
 
**Does the code still compile with Java6?**
Yes

**Risks**
Low

**Changes to the API?**
No

**Will this require a new release?**
No

**Should the documentation be updated?**
No

**Does it break the unit tests?**
No, a new unit test was added. Tested in both regular and strict mode

**Was any code refactored in this commit?**
No

**Review status**
**APPROVED** - By myself

Starting 3-day comment window
